### PR TITLE
feat(F2a-05a): rename decomposeWithSupervisor → decomposeTask

### DIFF
--- a/packages/hierarchy/src/hierarchy-orchestrator.ts
+++ b/packages/hierarchy/src/hierarchy-orchestrator.ts
@@ -347,8 +347,10 @@ export class HierarchyOrchestrator {
 
   /**
    * Descompone un task en subtareas usando el supervisor LLM.
-   * Formato de salida del LLM: bloques ---DELEGATE--- (ver F2a-05c).
-   * TODO F2a-05b: migrar prompt a formato DELEGATE.
+   * Formato de salida actual del LLM: JSON array con objetos
+   *   { agentId: string, task: string }
+   *
+   * TODO F2a-05b: migrar prompt a formato ---DELEGATE---.
    * TODO F2a-05c: reemplazar parser JSON por parseDelegateBlocks().
    *
    * El prompt pide al supervisor que devuelva un JSON array con objetos:

--- a/packages/hierarchy/src/hierarchy-orchestrator.ts
+++ b/packages/hierarchy/src/hierarchy-orchestrator.ts
@@ -347,16 +347,26 @@ export class HierarchyOrchestrator {
 
   /**
    * Descompone un task en subtareas usando el supervisor LLM.
-   * Formato de salida actual del LLM: JSON array con objetos
+   *
+   * Formato objetivo de salida del LLM (target): el supervisor debe emitir bloques
+   *   ---DELEGATE---
+   *   agentId: <id>
+   *   task: <descripción>
+   *   ---END---
+   * que serán parseados por parseDelegateBlocks() una vez integrada (ver F2a-05c).
+   *
+   * Estado actual: el prompt pide al supervisor un JSON array con objetos
    *   { agentId: string, task: string }
+   * El parser JSON permanece en uso hasta que parseDelegateBlocks() esté integrado.
+   *
+   * Parseo robusto: extrae el primer bloque JSON del texto aunque haya prose.
+   *
+   * TODO: Eliminar el parseo JSON y reemplazarlo con parseDelegateBlocks() una vez
+   *       que dicha función esté disponible. Ver el símbolo parseDelegateBlocks()
+   *       para localizar el punto exacto de migración en este archivo.
    *
    * TODO F2a-05b: migrar prompt a formato ---DELEGATE---.
    * TODO F2a-05c: reemplazar parser JSON por parseDelegateBlocks().
-   *
-   * El prompt pide al supervisor que devuelva un JSON array con objetos:
-   *   { agentId: string, task: string }
-   *
-   * Parseo robusto: extrae el primer bloque JSON del texto aunque haya prose.
    */
   private async decomposeTask(
     rootTask: string,

--- a/packages/hierarchy/src/hierarchy-orchestrator.ts
+++ b/packages/hierarchy/src/hierarchy-orchestrator.ts
@@ -329,7 +329,7 @@ export class HierarchyOrchestrator {
     // Intentar descomposición vía supervisor LLM
     if (this.supervisorFn) {
       try {
-        return await this.decomposeWithSupervisor(rootTask, agents, input)
+        return await this.decomposeTask(rootTask, agents, input)
       } catch {
         // fallback silencioso a round-robin
       }
@@ -346,14 +346,17 @@ export class HierarchyOrchestrator {
   }
 
   /**
-   * Descomposición vía supervisor LLM.
+   * Descompone un task en subtareas usando el supervisor LLM.
+   * Formato de salida del LLM: bloques ---DELEGATE--- (ver F2a-05c).
+   * TODO F2a-05b: migrar prompt a formato DELEGATE.
+   * TODO F2a-05c: reemplazar parser JSON por parseDelegateBlocks().
    *
    * El prompt pide al supervisor que devuelva un JSON array con objetos:
    *   { agentId: string, task: string }
    *
    * Parseo robusto: extrae el primer bloque JSON del texto aunque haya prose.
    */
-  private async decomposeWithSupervisor(
+  private async decomposeTask(
     rootTask: string,
     agents:   HierarchyNode[],
     input?:   Record<string, unknown>,


### PR DESCRIPTION
- Renombrar declaración del método (línea ~359)
- Actualizar caller en decomposeTasks() (línea ~332)
- Actualizar JSDoc con TODOs F2a-05b y F2a-05c

Closes #F2a-05

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal task decomposition organization and naming for clarity.

* **Documentation**
  * Updated docs to clarify current output format and to describe planned future handling for delegated block-based tasks and parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->