### PR TITLE
feat(F2a-07): isBlocked() con DELEGATION_TIMEOUT_MS

### DIFF
--- a/packages/hierarchy/src/hierarchy-orchestrator.ts
+++ b/packages/hierarchy/src/hierarchy-orchestrator.ts
@@ -170,6 +170,32 @@ export interface SpecialistMatch {
   allScores:  CapabilityScore[]
 }
 
+/**
+ * Resultado de isBlocked().
+ * Siempre se devuelve — nunca null, nunca lanza.
+ */
+export interface BlockedStatus {
+  /** true si el step/run está bloqueado */
+  blocked:     boolean
+
+  /** ID del RunStep bloqueado (si blocked = true) */
+  stepId?:     string
+
+  /** ID del Run al que pertenece el step bloqueado */
+  runId?:      string
+
+  /** nodeId del step bloqueado */
+  nodeId?:     string
+
+  /** Milisegundos transcurridos desde startedAt (si disponible) */
+  elapsedMs?:  number
+
+  /** El timeout que se superó */
+  timeoutMs?:  number
+
+  /** Razón textual para logging/alertas */
+  reason?:     string
+}
 
 // ── Opciones de configuración ────────────────────────────────────────────────────────────────
 
@@ -185,6 +211,21 @@ export interface OrchestratorOptions {
   /** Ejecutar subtareas en paralelo (true) o secuencial (false) */
   parallel?: boolean
 }
+
+/**
+ * Tiempo máximo que un RunStep de delegación puede estar
+ * en estado 'running' o 'queued' antes de considerarse bloqueado.
+ *
+ * No es un OrchestratorOptions — es un contrato de arquitectura.
+ * Si la delegación tarda más de esto, hay un problema estructural.
+ *
+ * Valor: 10 minutos. Racional:
+ *   - subtaskTimeoutMs default: 2 min (ejecución LLM)
+ *   - approvalTimeoutMs default: 15 min (espera humana)
+ *   - delegación: orquesta N subtasks de 2 min → 5 pasos
+ *     holgados = 10 min tope razonable
+ */
+export const DELEGATION_TIMEOUT_MS = 10 * 60 * 1000  // 10 minutos
 
 const DEFAULT_OPTIONS: Required<OrchestratorOptions> = {
   maxRetries:        2,
@@ -361,6 +402,136 @@ export class HierarchyOrchestrator {
     }
   }
 
+  /**
+   * Detecta si un RunStep de delegación está bloqueado.
+   *
+   * Un step está bloqueado cuando:
+   *   - status es 'running' o 'queued'
+   *   - startedAt + DELEGATION_TIMEOUT_MS < Date.now()
+   *
+   * NUNCA lanza — en caso de error de BD devuelve blocked: false
+   * (principio de fail-open: preferimos no fallar a falsos positivos).
+   *
+   * @param stepId  ID del RunStep a verificar
+   * @returns       BlockedStatus con diagnóstico completo
+   */
+  async isBlocked(stepId: string): Promise<BlockedStatus> {
+    try {
+      const step = await this.repo.findStep(stepId)
+
+      // Step no encontrado → no bloqueado (fail-open)
+      if (!step) {
+        return {
+          blocked: false,
+          reason:  `Step ${stepId} not found`,
+        }
+      }
+
+      // Solo steps de delegación en estado activo pueden bloquearse
+      if (step.nodeType !== 'delegation') {
+        return {
+          blocked: false,
+          stepId:  step.id,
+          runId:   step.runId,
+          reason:  `Step ${stepId} is not a delegation step (nodeType: ${step.nodeType})`,
+        }
+      }
+
+      // Step ya finalizado → no bloqueado
+      const activeStatuses = ['running', 'queued']
+      if (!activeStatuses.includes(step.status)) {
+        return {
+          blocked: false,
+          stepId:  step.id,
+          runId:   step.runId,
+          reason:  `Step ${stepId} has terminal status: ${step.status}`,
+        }
+      }
+
+      // Calcular tiempo transcurrido
+      // startedAt puede ser null si el step está 'queued' pero nunca llegó a 'running'.
+      // En ese caso usamos createdAt — un step queued durante 10 min también es un bloqueo.
+      const referenceTime = step.startedAt ?? step.createdAt
+      const elapsedMs     = Date.now() - referenceTime.getTime()
+
+      if (elapsedMs < DELEGATION_TIMEOUT_MS) {
+        return {
+          blocked:   false,
+          stepId:    step.id,
+          runId:     step.runId,
+          nodeId:    step.nodeId,
+          elapsedMs,
+          timeoutMs: DELEGATION_TIMEOUT_MS,
+          reason:    `Step running for ${elapsedMs}ms — within timeout (${DELEGATION_TIMEOUT_MS}ms)`,
+        }
+      }
+
+      // ── BLOQUEADO ──────────────────────────────────────────────
+      return {
+        blocked:   true,
+        stepId:    step.id,
+        runId:     step.runId,
+        nodeId:    step.nodeId,
+        elapsedMs,
+        timeoutMs: DELEGATION_TIMEOUT_MS,
+        reason:    `Delegation step ${stepId} blocked: running for ${elapsedMs}ms > ${DELEGATION_TIMEOUT_MS}ms timeout`,
+      }
+    } catch {
+      // Error de BD → fail-open
+      return {
+        blocked: false,
+        reason:  `isBlocked check failed for step ${stepId} — BD error`,
+      }
+    }
+  }
+
+  /**
+   * Verifica si algún RunStep de delegación en un Run está bloqueado.
+   * Útil para polls periódicos del gateway o n8n.
+   *
+   * NUNCA lanza.
+   *
+   * @param runId  ID del Run a verificar
+   * @returns      BlockedStatus del primer step bloqueado encontrado,
+   *               o { blocked: false } si ninguno lo está
+   */
+  async isRunBlocked(runId: string): Promise<BlockedStatus> {
+    try {
+      const steps = await this.repo.findDelegationStepsByRun(runId)
+
+      for (const step of steps) {
+        const activeStatuses = ['running', 'queued']
+        if (!activeStatuses.includes(step.status)) continue
+
+        const referenceTime = step.startedAt ?? step.createdAt
+        const elapsedMs     = Date.now() - referenceTime.getTime()
+
+        if (elapsedMs >= DELEGATION_TIMEOUT_MS) {
+          return {
+            blocked:   true,
+            stepId:    step.id,
+            runId:     step.runId,
+            nodeId:    step.nodeId,
+            elapsedMs,
+            timeoutMs: DELEGATION_TIMEOUT_MS,
+            reason:    `Run ${runId} blocked: delegation step ${step.id} running for ${elapsedMs}ms`,
+          }
+        }
+      }
+
+      return {
+        blocked: false,
+        runId,
+        reason:  `No blocked delegation steps in run ${runId}`,
+      }
+    } catch {
+      return {
+        blocked: false,
+        reason:  `isRunBlocked check failed for run ${runId} — BD error`,
+      }
+    }
+  }
+
   // ── Descomposición de tareas ─────────────────────────────────────────────────────────
 
   /**
@@ -398,8 +569,6 @@ export class HierarchyOrchestrator {
     }
 
     // [F2a-04] Fallback: asignar al especialista con mayor afinidad semántica
-    // Reemplaza el round-robin ciego anterior — si necesitas fan-out explícito,
-    // pásalo como opción al caller.
     const match = await this.findSpecialistWithCapability(rootTask, agents)
     return [{
       id:             `subtask-${match.node.id}-0`,
@@ -901,8 +1070,6 @@ export class HierarchyOrchestrator {
     }
 
     // Nodo intermedio → delegar al nivel inferior
-    // Los children son los nodos directos — no bajar más aquí;
-    // la recursión ocurre en el siguiente ciclo de orchestrate()
     return {
       type:     'delegate',
       node,

--- a/packages/hierarchy/src/index.ts
+++ b/packages/hierarchy/src/index.ts
@@ -11,6 +11,12 @@ export type {
   RouteDecision,
   CapabilityScore,
   SpecialistMatch,
+  BlockedStatus,
 } from './hierarchy-orchestrator.js'
 
-export { HierarchyOrchestrator, tokenize, jaccardScore } from './hierarchy-orchestrator.js'
+export {
+  HierarchyOrchestrator,
+  tokenize,
+  jaccardScore,
+  DELEGATION_TIMEOUT_MS,
+} from './hierarchy-orchestrator.js'

--- a/packages/run-engine/src/run-repository.ts
+++ b/packages/run-engine/src/run-repository.ts
@@ -250,6 +250,32 @@ export class RunRepository {
   }
 
   /**
+   * Devuelve todos los RunSteps de tipo 'delegation' de un Run.
+   * Usado por HierarchyOrchestrator.isRunBlocked().
+   *
+   * Solo selecciona los campos necesarios para la verificación de bloqueo —
+   * no toda la fila. Importante para queries frecuentes (polling del gateway).
+   */
+  async findDelegationStepsByRun(runId: string) {
+    return this.prisma.runStep.findMany({
+      where: {
+        runId,
+        nodeType: 'delegation',
+      },
+      select: {
+        id:        true,
+        runId:     true,
+        nodeId:    true,
+        nodeType:  true,
+        status:    true,
+        startedAt: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'asc' },
+    })
+  }
+
+  /**
    * Exposes the PrismaClient for sub-orchestrators created by delegateTask().
    * Required by F2a-03: HierarchyOrchestrator needs to pass the same client
    * to child orchestrators without breaking the repository abstraction.


### PR DESCRIPTION
## Descripción

Implementa detección de RunSteps de delegación bloqueados en `HierarchyOrchestrator`.

## Cambios

### `packages/hierarchy/src/hierarchy-orchestrator.ts`
- `DELEGATION_TIMEOUT_MS = 600_000` — constante de módulo exportada (10 min)
- `BlockedStatus` — tipo público con diagnóstico completo
- `isBlocked(stepId)` — detecta si un step de delegación superó el timeout
- `isRunBlocked(runId)` — escanea todos los steps de delegación de un Run
- Ambos métodos son **fail-open**: nunca lanzan, devuelven `{ blocked: false }` ante errores de BD

### `packages/run-engine/src/run-repository.ts`
- `findDelegationStepsByRun(runId)` — query optimizada (solo campos necesarios) para polling frecuente del gateway

### `packages/hierarchy/src/index.ts`
- Exporta `DELEGATION_TIMEOUT_MS` y `BlockedStatus`

## Criterio de cierre

- [x] `DELEGATION_TIMEOUT_MS = 600_000` exportada
- [x] `BlockedStatus` exportado con todos sus campos
- [x] `isBlocked(stepId)` implementado — fail-open
- [x] `isRunBlocked(runId)` implementado — fail-open
- [x] `findDelegationStepsByRun()` en RunRepository
- [x] Exports en `index.ts`

Closes #117