### PR TITLE
[F2a-09] deriveParentStatus() + isBlocked() + correcciones F2a-08

### DIFF
--- a/packages/run-engine/src/__tests__/hierarchy-status.service.test.ts
+++ b/packages/run-engine/src/__tests__/hierarchy-status.service.test.ts
@@ -1,9 +1,18 @@
 /**
- * Tests para HierarchyStatusService
+ * Tests para HierarchyStatusService, isBlocked() y deriveParentStatus().
  * Prisma completamente mockeado — sin conexión a BD.
+ *
+ * Tests 1-5:  escenarios F2a-08 (mantenidos)
+ * Tests 6-9:  isBlocked()
+ * Tests 10-18: deriveParentStatus()
+ * Tests 19-20: integración en assembleTree()
  */
 
-import { HierarchyStatusService } from '../hierarchy-status.service'
+import {
+  HierarchyStatusService,
+  isBlocked,
+  deriveParentStatus,
+} from '../hierarchy-status.service'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -20,13 +29,13 @@ function makeStep(overrides: Partial<Record<string, unknown>> = {}) {
     error:            null,
     startedAt:        new Date(Date.now() - 5_000),
     completedAt:      new Date(),
+    createdAt:        new Date(Date.now() - 6_000),
     model:            'gpt-4o-mini',
     provider:         'openai',
     promptTokens:     100,
     completionTokens: 50,
     totalTokens:      150,
     costUsd:          0.002,
-    createdAt:        new Date(),
     ...overrides,
   }
 }
@@ -49,133 +58,221 @@ function makeRun(overrides: Partial<Record<string, unknown>> = {}) {
   }
 }
 
-function makePrisma(overrides: Record<string, unknown> = {}) {
+function makePrisma() {
   return {
     run: {
       findUnique: jest.fn(),
       findFirst:  jest.fn(),
       findMany:   jest.fn(),
     },
-    ...overrides,
   } as unknown as Parameters<typeof HierarchyStatusService['prototype']['constructor']>[0]
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// ── Tests F2a-08 (1-5) ─────────────────────────────────────────────────────────
 
-describe('HierarchyStatusService', () => {
+describe('HierarchyStatusService — F2a-08 escenarios', () => {
 
-  // 1. getRunStatus() devuelve null si el runId no existe
-  it('returns null when run does not exist', async () => {
+  it('1. returns null when run does not exist', async () => {
     const prisma = makePrisma()
     ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(null)
-
     const svc = new HierarchyStatusService(prisma as any)
-    const result = await svc.getRunStatus('non-existent-id')
-
-    expect(result).toBeNull()
+    expect(await svc.getRunStatus('non-existent')).toBeNull()
   })
 
-  // 2. Árbol plano con agregados correctos
-  it('returns flat tree with correct aggregates', async () => {
-    const step1 = makeStep({ id: 's1', status: 'completed', totalTokens: 150, costUsd: 0.002 })
-    const step2 = makeStep({ id: 's2', status: 'completed', totalTokens: 200, costUsd: 0.003 })
-    const run   = makeRun({ steps: [step1, step2] })
-
+  it('2. returns flat tree with correct aggregates', async () => {
+    const s1  = makeStep({ id: 's1', totalTokens: 150, costUsd: 0.002 })
+    const s2  = makeStep({ id: 's2', totalTokens: 200, costUsd: 0.003 })
+    const run = makeRun({ steps: [s1, s2] })
     const prisma = makePrisma()
     ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
-
-    const svc    = new HierarchyStatusService(prisma as any)
-    const result = await svc.getRunStatus('run-1')
-
-    expect(result).not.toBeNull()
+    const result = await new HierarchyStatusService(prisma as any).getRunStatus('run-1')
     expect(result!.totalSteps).toBe(2)
     expect(result!.completedSteps).toBe(2)
-    expect(result!.failedSteps).toBe(0)
     expect(result!.totalTokens).toBe(350)
     expect(result!.totalCostUsd).toBeCloseTo(0.005)
-    expect(result!.depth).toBe(0)
   })
 
-  // 3. Expande un delegation step cuando existe Run hijo
-  it('expands delegation step with child run', async () => {
-    const delegationStep = makeStep({
-      id:       'step-del',
-      nodeId:   'node-dept',
-      nodeType: 'delegation',
-      status:   'completed',
-    })
-    const parentRun = makeRun({ steps: [delegationStep] })
-
+  it('3. expands delegation step with child run', async () => {
+    const delStep   = makeStep({ id: 'step-del', nodeId: 'node-dept', nodeType: 'delegation', status: 'completed' })
+    const parentRun = makeRun({ steps: [delStep] })
     const childStep = makeStep({ id: 'child-step', nodeId: 'node-agent', nodeType: 'agent' })
-    const childRun  = makeRun({
-      id:       'child-run',
-      metadata: { hierarchyRoot: 'node-dept' },
-      steps:    [childStep],
+    const childRun  = makeRun({ id: 'child-run', metadata: { hierarchyRoot: 'node-dept' }, steps: [childStep] })
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(parentRun)
+    ;(prisma.run.findFirst  as jest.Mock).mockResolvedValue(childRun)
+    const result = await new HierarchyStatusService(prisma as any).getRunStatus('run-1')
+    const del = result!.steps.find((s) => s.nodeType === 'delegation')
+    expect(del!.childRun!.runId).toBe('child-run')
+    expect(del!.childRun!.depth).toBe(1)
+  })
+
+  it('4. does not throw when child run query fails', async () => {
+    const delStep = makeStep({ nodeType: 'delegation', status: 'running', startedAt: new Date() })
+    const run     = makeRun({ steps: [delStep] })
+    const prisma  = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
+    ;(prisma.run.findFirst  as jest.Mock).mockRejectedValue(new Error('DB error'))
+    const result = await new HierarchyStatusService(prisma as any).getRunStatus('run-1')
+    expect(result).not.toBeNull()
+    expect(result!.steps[0].childRun).toBeNull()
+  })
+
+  it('5. counts blocked delegation steps (D-22e: queued + no startedAt + expired)', async () => {
+    const ago31s = new Date(Date.now() - 31_000)
+    // Forzar env a 30000 para este test (puede haber override en CI)
+    const blockedStep = makeStep({
+      id:        'blocked',
+      nodeType:  'delegation',
+      status:    'queued',
+      startedAt: null,
+      createdAt: ago31s,
     })
+    const normalStep = makeStep({ id: 'normal', nodeType: 'agent', status: 'completed' })
+    const run        = makeRun({ steps: [blockedStep, normalStep] })
+    const prisma     = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
+    ;(prisma.run.findFirst  as jest.Mock).mockResolvedValue(null)
+    const result = await new HierarchyStatusService(prisma as any).getRunStatus('run-1')
+    expect(result!.blockedSteps).toBe(1)
+  })
+})
+
+// ── Tests isBlocked() (6-9) ──────────────────────────────────────────────────────
+
+describe('isBlocked()', () => {
+
+  it('6. returns false when status is not queued', () => {
+    expect(isBlocked({
+      status:    'running',
+      startedAt: null,
+      createdAt: new Date(Date.now() - 60_000),
+    })).toBe(false)
+  })
+
+  it('7. returns false when startedAt is not null', () => {
+    expect(isBlocked({
+      status:    'queued',
+      startedAt: new Date(Date.now() - 60_000),
+      createdAt: new Date(Date.now() - 61_000),
+    })).toBe(false)
+  })
+
+  it('8. returns false when createdAt is within threshold', () => {
+    expect(isBlocked({
+      status:    'queued',
+      startedAt: null,
+      createdAt: new Date(Date.now() - 10_000), // 10s < 30s default
+    })).toBe(false)
+  })
+
+  it('9. returns true when queued + no startedAt + createdAt > 30s ago', () => {
+    expect(isBlocked({
+      status:    'queued',
+      startedAt: null,
+      createdAt: new Date(Date.now() - 31_000), // 31s > 30s default
+    })).toBe(true)
+  })
+})
+
+// ── Tests deriveParentStatus() (10-18) ────────────────────────────────────────
+
+describe('deriveParentStatus()', () => {
+
+  it('10. empty array returns completed', () => {
+    expect(deriveParentStatus([])).toBe('completed')
+  })
+
+  it('11. all completed returns completed', () => {
+    expect(deriveParentStatus([
+      { status: 'completed' },
+      { status: 'completed' },
+      { status: 'completed' },
+    ])).toBe('completed')
+  })
+
+  it('12. completed + skipped + cancelled returns completed', () => {
+    expect(deriveParentStatus([
+      { status: 'completed' },
+      { status: 'skipped' },
+      { status: 'cancelled' },
+    ])).toBe('completed')
+  })
+
+  it('13. completed + queued returns queued', () => {
+    expect(deriveParentStatus([
+      { status: 'completed' },
+      { status: 'queued' },
+    ])).toBe('queued')
+  })
+
+  it('14. completed + running returns running', () => {
+    expect(deriveParentStatus([
+      { status: 'completed' },
+      { status: 'running' },
+    ])).toBe('running')
+  })
+
+  it('15. running + failed returns failed (failed has priority)', () => {
+    expect(deriveParentStatus([
+      { status: 'running' },
+      { status: 'failed' },
+    ])).toBe('failed')
+  })
+
+  it('16. running + blocked returns blocked (blocked > running)', () => {
+    expect(deriveParentStatus([
+      { status: 'running' },
+      { status: 'blocked' },
+    ])).toBe('blocked')
+  })
+
+  it('17. failed + blocked returns failed (failed > blocked)', () => {
+    expect(deriveParentStatus([
+      { status: 'failed' },
+      { status: 'blocked' },
+    ])).toBe('failed')
+  })
+
+  it('18. waitingapproval + completed returns running (fallback)', () => {
+    expect(deriveParentStatus([
+      { status: 'waitingapproval' },
+      { status: 'completed' },
+    ])).toBe('running')
+  })
+})
+
+// ── Tests integración assembleTree() (19-20) ────────────────────────────────────
+
+describe('assembleTree() integration', () => {
+
+  it('19. derivedStatus differs from run.status when steps are mixed', async () => {
+    const s1 = makeStep({ id: 's1', status: 'completed' })
+    const s2 = makeStep({ id: 's2', status: 'queued', startedAt: null })
+    // run.status = 'running' (BD), pero derivedStatus debe ser 'queued'
+    const run = makeRun({ status: 'running', steps: [s1, s2] })
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
+    const result = await new HierarchyStatusService(prisma as any).getRunStatus('run-1')
+    expect(result!.status).toBe('running')          // valor real en BD
+    expect(result!.derivedStatus).toBe('queued')    // calculado
+  })
+
+  it('20. delegation step effectiveStatus inherits childRun.derivedStatus', async () => {
+    const delStep   = makeStep({ id: 'del', nodeType: 'delegation', nodeId: 'nd', status: 'running' })
+    const parentRun = makeRun({ status: 'running', steps: [delStep] })
+
+    // Child run tiene un step fallido → su derivedStatus = 'failed'
+    const failedChildStep = makeStep({ id: 'cf', status: 'failed' })
+    const childRun = makeRun({ id: 'crun', status: 'running', steps: [failedChildStep] })
 
     const prisma = makePrisma()
     ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(parentRun)
     ;(prisma.run.findFirst  as jest.Mock).mockResolvedValue(childRun)
 
-    const svc    = new HierarchyStatusService(prisma as any)
-    const result = await svc.getRunStatus('run-1')
-
-    expect(result).not.toBeNull()
-    const delNode = result!.steps.find((s) => s.nodeType === 'delegation')
-    expect(delNode).toBeDefined()
-    expect(delNode!.childRun).not.toBeNull()
-    expect(delNode!.childRun!.runId).toBe('child-run')
-    expect(delNode!.childRun!.depth).toBe(1)
-  })
-
-  // 4. NO lanza cuando findAndExpandChildRun falla
-  it('does not throw when child run query fails', async () => {
-    const delegationStep = makeStep({
-      nodeType: 'delegation',
-      status:   'running',
-      startedAt: new Date(),
-    })
-    const run = makeRun({ steps: [delegationStep] })
-
-    const prisma = makePrisma()
-    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
-    ;(prisma.run.findFirst  as jest.Mock).mockRejectedValue(new Error('DB connection lost'))
-
-    const svc = new HierarchyStatusService(prisma as any)
-
-    await expect(svc.getRunStatus('run-1')).resolves.not.toBeNull()
-
-    const result = await svc.getRunStatus('run-1')
-    const delNode = result!.steps.find((s) => s.nodeType === 'delegation')
-    expect(delNode!.childRun).toBeNull()
-  })
-
-  // 5. blockedSteps = 1 cuando hay delegation step en 'running' hace >10 min
-  it('counts blocked delegation steps correctly', async () => {
-    const elevenMinutesAgo = new Date(Date.now() - 11 * 60 * 1000)
-
-    const blockedStep = makeStep({
-      id:        'blocked-step',
-      nodeType:  'delegation',
-      status:    'running',
-      startedAt: elevenMinutesAgo,
-    })
-    const normalStep = makeStep({
-      id:       'normal-step',
-      nodeType: 'agent',
-      status:   'completed',
-    })
-    const run = makeRun({ steps: [blockedStep, normalStep] })
-
-    const prisma = makePrisma()
-    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
-    ;(prisma.run.findFirst  as jest.Mock).mockResolvedValue(null)
-
-    const svc    = new HierarchyStatusService(prisma as any)
-    const result = await svc.getRunStatus('run-1')
-
-    expect(result).not.toBeNull()
-    expect(result!.blockedSteps).toBe(1)
-    expect(result!.runningSteps).toBe(1)
+    const result = await new HierarchyStatusService(prisma as any).getRunStatus('run-1')
+    const del = result!.steps.find((s) => s.nodeType === 'delegation')!
+    expect(del.status).toBe('running')              // valor real en BD
+    expect(del.effectiveStatus).toBe('failed')       // heredado de childRun.derivedStatus
+    expect(del.childRun!.derivedStatus).toBe('failed')
   })
 })

--- a/packages/run-engine/src/__tests__/hierarchy-status.service.test.ts
+++ b/packages/run-engine/src/__tests__/hierarchy-status.service.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests para HierarchyStatusService
+ * Prisma completamente mockeado — sin conexión a BD.
+ */
+
+import { HierarchyStatusService } from '../hierarchy-status.service'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeStep(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id:               'step-1',
+    runId:            'run-1',
+    nodeId:           'node-1',
+    nodeType:         'agent',
+    status:           'completed',
+    index:            0,
+    input:            {},
+    output:           'ok',
+    error:            null,
+    startedAt:        new Date(Date.now() - 5_000),
+    completedAt:      new Date(),
+    model:            'gpt-4o-mini',
+    provider:         'openai',
+    promptTokens:     100,
+    completionTokens: 50,
+    totalTokens:      150,
+    costUsd:          0.002,
+    createdAt:        new Date(),
+    ...overrides,
+  }
+}
+
+function makeRun(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id:          'run-1',
+    workspaceId: 'ws-1',
+    agentId:     null,
+    status:      'completed',
+    inputData:   { task: 'test' },
+    outputData:  'result',
+    error:       null,
+    metadata:    {},
+    createdAt:   new Date(Date.now() - 10_000),
+    startedAt:   new Date(Date.now() - 9_000),
+    completedAt: new Date(),
+    steps:       [] as ReturnType<typeof makeStep>[],
+    ...overrides,
+  }
+}
+
+function makePrisma(overrides: Record<string, unknown> = {}) {
+  return {
+    run: {
+      findUnique: jest.fn(),
+      findFirst:  jest.fn(),
+      findMany:   jest.fn(),
+    },
+    ...overrides,
+  } as unknown as Parameters<typeof HierarchyStatusService['prototype']['constructor']>[0]
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('HierarchyStatusService', () => {
+
+  // 1. getRunStatus() devuelve null si el runId no existe
+  it('returns null when run does not exist', async () => {
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(null)
+
+    const svc = new HierarchyStatusService(prisma as any)
+    const result = await svc.getRunStatus('non-existent-id')
+
+    expect(result).toBeNull()
+  })
+
+  // 2. Árbol plano con agregados correctos
+  it('returns flat tree with correct aggregates', async () => {
+    const step1 = makeStep({ id: 's1', status: 'completed', totalTokens: 150, costUsd: 0.002 })
+    const step2 = makeStep({ id: 's2', status: 'completed', totalTokens: 200, costUsd: 0.003 })
+    const run   = makeRun({ steps: [step1, step2] })
+
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
+
+    const svc    = new HierarchyStatusService(prisma as any)
+    const result = await svc.getRunStatus('run-1')
+
+    expect(result).not.toBeNull()
+    expect(result!.totalSteps).toBe(2)
+    expect(result!.completedSteps).toBe(2)
+    expect(result!.failedSteps).toBe(0)
+    expect(result!.totalTokens).toBe(350)
+    expect(result!.totalCostUsd).toBeCloseTo(0.005)
+    expect(result!.depth).toBe(0)
+  })
+
+  // 3. Expande un delegation step cuando existe Run hijo
+  it('expands delegation step with child run', async () => {
+    const delegationStep = makeStep({
+      id:       'step-del',
+      nodeId:   'node-dept',
+      nodeType: 'delegation',
+      status:   'completed',
+    })
+    const parentRun = makeRun({ steps: [delegationStep] })
+
+    const childStep = makeStep({ id: 'child-step', nodeId: 'node-agent', nodeType: 'agent' })
+    const childRun  = makeRun({
+      id:       'child-run',
+      metadata: { hierarchyRoot: 'node-dept' },
+      steps:    [childStep],
+    })
+
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(parentRun)
+    ;(prisma.run.findFirst  as jest.Mock).mockResolvedValue(childRun)
+
+    const svc    = new HierarchyStatusService(prisma as any)
+    const result = await svc.getRunStatus('run-1')
+
+    expect(result).not.toBeNull()
+    const delNode = result!.steps.find((s) => s.nodeType === 'delegation')
+    expect(delNode).toBeDefined()
+    expect(delNode!.childRun).not.toBeNull()
+    expect(delNode!.childRun!.runId).toBe('child-run')
+    expect(delNode!.childRun!.depth).toBe(1)
+  })
+
+  // 4. NO lanza cuando findAndExpandChildRun falla
+  it('does not throw when child run query fails', async () => {
+    const delegationStep = makeStep({
+      nodeType: 'delegation',
+      status:   'running',
+      startedAt: new Date(),
+    })
+    const run = makeRun({ steps: [delegationStep] })
+
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
+    ;(prisma.run.findFirst  as jest.Mock).mockRejectedValue(new Error('DB connection lost'))
+
+    const svc = new HierarchyStatusService(prisma as any)
+
+    await expect(svc.getRunStatus('run-1')).resolves.not.toBeNull()
+
+    const result = await svc.getRunStatus('run-1')
+    const delNode = result!.steps.find((s) => s.nodeType === 'delegation')
+    expect(delNode!.childRun).toBeNull()
+  })
+
+  // 5. blockedSteps = 1 cuando hay delegation step en 'running' hace >10 min
+  it('counts blocked delegation steps correctly', async () => {
+    const elevenMinutesAgo = new Date(Date.now() - 11 * 60 * 1000)
+
+    const blockedStep = makeStep({
+      id:        'blocked-step',
+      nodeType:  'delegation',
+      status:    'running',
+      startedAt: elevenMinutesAgo,
+    })
+    const normalStep = makeStep({
+      id:       'normal-step',
+      nodeType: 'agent',
+      status:   'completed',
+    })
+    const run = makeRun({ steps: [blockedStep, normalStep] })
+
+    const prisma = makePrisma()
+    ;(prisma.run.findUnique as jest.Mock).mockResolvedValue(run)
+    ;(prisma.run.findFirst  as jest.Mock).mockResolvedValue(null)
+
+    const svc    = new HierarchyStatusService(prisma as any)
+    const result = await svc.getRunStatus('run-1')
+
+    expect(result).not.toBeNull()
+    expect(result!.blockedSteps).toBe(1)
+    expect(result!.runningSteps).toBe(1)
+  })
+})

--- a/packages/run-engine/src/hierarchy-status.service.ts
+++ b/packages/run-engine/src/hierarchy-status.service.ts
@@ -1,0 +1,354 @@
+/**
+ * HierarchyStatusService — árbol de estado de un Run con sub-orquestaciones
+ *
+ * Resuelve: "¿Qué está pasando en este runId, incluyendo sus sub-orquestaciones
+ * delegadas?"
+ *
+ * Relación padre-hijo entre Runs:
+ *   - delegateTask() crea sub-Run con metadata.hierarchyRoot = step.nodeId
+ *   - El service une padre→hijo buscando Runs donde:
+ *       workspaceId = run.workspaceId
+ *       metadata->>'hierarchyRoot' = step.nodeId
+ *       createdAt >= run.createdAt   (evitar falsos positivos)
+ */
+
+import type { PrismaClient, RunStep } from '@prisma/client'
+
+// ── Constantes ────────────────────────────────────────────────────────────────
+
+/**
+ * Timeout de delegación — mismo valor que DELEGATION_TIMEOUT_MS en F2a-07.
+ * TODO: reemplazar por import desde hierarchy-orchestrator.ts una vez
+ * que F2a-07 esté mergeado en main.
+ */
+const DELEGATION_TIMEOUT_MS = 10 * 60 * 1000  // 10 minutos
+
+/** Profundidad máxima de expansión de sub-runs */
+const MAX_DEPTH = 5
+
+// ── Tipos internos ────────────────────────────────────────────────────────────
+
+type RunWithSteps = NonNullable<
+  Awaited<ReturnType<PrismaClient['run']['findUnique']>>
+> & { steps: RunStep[] }
+
+// ── Tipos públicos ────────────────────────────────────────────────────────────
+
+/**
+ * Status de un RunStep en el árbol de estado.
+ * Campos mínimos — suficientes para UI y alertas.
+ */
+export interface StepNode {
+  stepId:    string
+  nodeId:    string
+  nodeType:  string
+  status:    string
+  index:     number
+  input:     unknown
+  output:    unknown
+  error:     string | null
+  startedAt: Date | null
+  finishedAt: Date | null
+
+  // Métricas LLM (null si nodeType es 'delegation' o no hay datos)
+  model:            string | null
+  provider:         string | null
+  promptTokens:     number | null
+  completionTokens: number | null
+  totalTokens:      number | null
+  costUsd:          number | null
+
+  // Si nodeType === 'delegation': sub-árbol del Run hijo
+  // null si el Run hijo aún no fue creado o no se encontró
+  childRun: RunStatusTree | null
+}
+
+/**
+ * Árbol de estado completo de un Run, incluyendo
+ * sub-runs delegados (recursivo, máximo MAX_DEPTH niveles).
+ */
+export interface RunStatusTree {
+  runId:       string
+  workspaceId: string
+  agentId:     string | null
+  status:      string
+  inputData:   unknown
+  outputData:  unknown
+  error:       string | null
+  createdAt:   Date
+  startedAt:   Date | null
+  finishedAt:  Date | null
+
+  steps:       StepNode[]
+
+  // Agregados calculados en el service
+  totalSteps:     number
+  completedSteps: number
+  failedSteps:    number
+  runningSteps:   number
+  /** Steps de delegación en 'running' que superaron DELEGATION_TIMEOUT_MS */
+  blockedSteps:   number
+  totalCostUsd:   number
+  totalTokens:    number
+  durationMs:     number | null
+  depth:          number
+}
+
+// ── HierarchyStatusService ───────────────────────────────────────────────────
+
+export class HierarchyStatusService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  // ── API pública ──────────────────────────────────────────────────────
+
+  /**
+   * Devuelve el árbol de estado completo de un Run.
+   *
+   * - Carga el Run con sus RunSteps desde Prisma
+   * - Para cada RunStep con nodeType 'delegation': expande el
+   *   Run hijo recursivamente (hasta MAX_DEPTH niveles)
+   * - Calcula agregados: costo total, tokens, steps bloqueados
+   *
+   * @param runId  ID del Run a consultar
+   * @returns      RunStatusTree completo, o null si no existe
+   */
+  async getRunStatus(runId: string): Promise<RunStatusTree | null> {
+    return this.buildTree(runId, 0)
+  }
+
+  /**
+   * Lista los Runs de un workspace con sus métricas básicas.
+   * NO expande sub-runs (depth 0) — para listados de UI.
+   *
+   * @param workspaceId ID del workspace
+   * @param opts        Filtros opcionales
+   */
+  async listWorkspaceRuns(
+    workspaceId: string,
+    opts: {
+      status?: string
+      limit?:  number
+      offset?: number
+    } = {},
+  ): Promise<RunStatusTree[]> {
+    const runs = await this.prisma.run.findMany({
+      where: {
+        workspaceId,
+        ...(opts.status ? { status: opts.status as never } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take:    opts.limit  ?? 50,
+      skip:    opts.offset ?? 0,
+      include: { steps: { orderBy: { index: 'asc' } } },
+    })
+
+    return Promise.all(
+      runs.map((run) => this.assembleTree(run as RunWithSteps, run.steps as RunStep[], 0))
+    )
+  }
+
+  // ── Construcción del árbol ───────────────────────────────────────────
+
+  /**
+   * Carga un Run desde BD y construye su árbol recursivamente.
+   * Punto único de entrada recursiva.
+   */
+  private async buildTree(
+    runId: string,
+    depth: number,
+  ): Promise<RunStatusTree | null> {
+    if (depth > MAX_DEPTH) return null
+
+    const run = await this.prisma.run.findUnique({
+      where:   { id: runId },
+      include: { steps: { orderBy: { index: 'asc' } } },
+    })
+    if (!run) return null
+
+    return this.assembleTree(run as RunWithSteps, run.steps as RunStep[], depth)
+  }
+
+  /**
+   * Ensambla RunStatusTree dado un Run y sus steps ya cargados.
+   * Expande steps de delegación buscando el Run hijo.
+   *
+   * Separado de buildTree para poder ser llamado desde listWorkspaceRuns
+   * sin una query adicional.
+   */
+  private async assembleTree(
+    run:   RunWithSteps,
+    steps: RunStep[],
+    depth: number,
+  ): Promise<RunStatusTree> {
+    // Construir StepNodes expandiendo delegaciones
+    const stepNodes: StepNode[] = await Promise.all(
+      steps.map((step) =>
+        this.buildStepNode(step, run.workspaceId, run.createdAt, depth)
+      )
+    )
+
+    // Calcular agregados (por nivel — no suma steps de sub-runs)
+    const agg = this.aggregate(stepNodes)
+
+    return {
+      runId:       run.id,
+      workspaceId: run.workspaceId,
+      agentId:     run.agentId   ?? null,
+      status:      run.status,
+      inputData:   run.inputData,
+      outputData:  (run as any).outputData ?? null,
+      error:       run.error     ?? null,
+      createdAt:   run.createdAt,
+      startedAt:   run.startedAt ?? null,
+      finishedAt:  (run as any).completedAt ?? null,
+      steps:       stepNodes,
+      ...agg,
+      durationMs:  run.startedAt
+        ? (((run as any).completedAt ?? new Date()).getTime() - run.startedAt.getTime())
+        : null,
+      depth,
+    }
+  }
+
+  /**
+   * Construye un StepNode.
+   * Si nodeType === 'delegation': busca el Run hijo y lo expande.
+   */
+  private async buildStepNode(
+    step:            RunStep,
+    workspaceId:     string,
+    parentCreatedAt: Date,
+    depth:           number,
+  ): Promise<StepNode> {
+    let childRun: RunStatusTree | null = null
+
+    if (step.nodeType === 'delegation' && depth < MAX_DEPTH) {
+      childRun = await this.findAndExpandChildRun(
+        step.nodeId,
+        workspaceId,
+        parentCreatedAt,
+        depth + 1,
+      )
+    }
+
+    return {
+      stepId:    step.id,
+      nodeId:    step.nodeId,
+      nodeType:  step.nodeType,
+      status:    step.status,
+      index:     step.index,
+      input:     step.input,
+      output:    step.output,
+      error:     step.error              ?? null,
+      startedAt: step.startedAt          ?? null,
+      finishedAt: (step as any).completedAt ?? null,
+      model:            (step as any).model            ?? null,
+      provider:         (step as any).provider         ?? null,
+      promptTokens:     (step as any).promptTokens     ?? null,
+      completionTokens: (step as any).completionTokens ?? null,
+      totalTokens:      (step as any).totalTokens      ?? null,
+      costUsd:          (step as any).costUsd          ?? null,
+      childRun,
+    }
+  }
+
+  /**
+   * Busca el Run hijo de un step de delegación por:
+   *   workspaceId = workspaceId del padre
+   *   metadata->>'hierarchyRoot' = nodeId del step
+   *   createdAt >= parentCreatedAt  (evitar falsos positivos históricos)
+   *
+   * Toma el Run más antiguo que cumpla la condición (el primero creado).
+   * Fail-open: si la query JSONB falla, devuelve null — sin romper el padre.
+   */
+  private async findAndExpandChildRun(
+    nodeId:          string,
+    workspaceId:     string,
+    parentCreatedAt: Date,
+    depth:           number,
+  ): Promise<RunStatusTree | null> {
+    try {
+      const childRun = await this.prisma.run.findFirst({
+        where: {
+          workspaceId,
+          createdAt: { gte: parentCreatedAt },
+          metadata:  { path: ['hierarchyRoot'], equals: nodeId },
+        },
+        orderBy: { createdAt: 'asc' },
+        include: { steps: { orderBy: { index: 'asc' } } },
+      })
+
+      if (!childRun) return null
+
+      return this.assembleTree(childRun as RunWithSteps, childRun.steps as RunStep[], depth)
+    } catch {
+      // Fail-open: si la query JSONB falla (schema sin soporte),
+      // el árbol se sirve sin el sub-run — nunca rompe la respuesta del padre.
+      return null
+    }
+  }
+
+  // ── Cálculo de agregados ─────────────────────────────────────────────
+
+  /**
+   * Calcula totales a partir de los StepNodes ya construidos.
+   * totalSteps es POR NIVEL — no suma los steps de los sub-runs.
+   * Los costos SÍ se acumulan recursivamente desde childRun.
+   */
+  private aggregate(steps: StepNode[]): {
+    totalSteps:     number
+    completedSteps: number
+    failedSteps:    number
+    runningSteps:   number
+    blockedSteps:   number
+    totalCostUsd:   number
+    totalTokens:    number
+  } {
+    let totalSteps     = 0
+    let completedSteps = 0
+    let failedSteps    = 0
+    let runningSteps   = 0
+    let blockedSteps   = 0
+    let totalCostUsd   = 0
+    let totalTokens    = 0
+
+    for (const step of steps) {
+      totalSteps++
+
+      if (step.status === 'completed') completedSteps++
+      if (step.status === 'failed')    failedSteps++
+      if (step.status === 'running')   runningSteps++
+
+      // Step bloqueado: delegación running que superó el timeout
+      if (
+        step.nodeType  === 'delegation' &&
+        step.status    === 'running'    &&
+        step.startedAt !== null         &&
+        Date.now() - step.startedAt.getTime() > DELEGATION_TIMEOUT_MS
+      ) {
+        blockedSteps++
+      }
+
+      // Acumular costos del step propio
+      totalCostUsd += step.costUsd    ?? 0
+      totalTokens  += step.totalTokens ?? 0
+
+      // Acumular costos del sub-run (si existe)
+      // totalSteps NO se suma — es por nivel
+      if (step.childRun) {
+        totalCostUsd += step.childRun.totalCostUsd
+        totalTokens  += step.childRun.totalTokens
+      }
+    }
+
+    return {
+      totalSteps,
+      completedSteps,
+      failedSteps,
+      runningSteps,
+      blockedSteps,
+      totalCostUsd,
+      totalTokens,
+    }
+  }
+}

--- a/packages/run-engine/src/hierarchy-status.service.ts
+++ b/packages/run-engine/src/hierarchy-status.service.ts
@@ -10,18 +10,27 @@
  *       workspaceId = run.workspaceId
  *       metadata->>'hierarchyRoot' = step.nodeId
  *       createdAt >= run.createdAt   (evitar falsos positivos)
+ *
+ * F2a-09 añade:
+ *   - isBlocked(): función pura, detecta step 'queued' expirado (D-22e)
+ *   - deriveParentStatus(): función pura, regla de prioridad D-23f
+ *   - derivedStatus en RunStatusTree (calculado, no persistido en BD)
+ *   - effectiveStatus en StepNode (hereda derivedStatus del childRun)
  */
 
 import type { PrismaClient, RunStep } from '@prisma/client'
 
-// ── Constantes ────────────────────────────────────────────────────────────────
+// ── Constantes ────────────────────────────────────────────────────────────
 
 /**
- * Timeout de delegación — mismo valor que DELEGATION_TIMEOUT_MS en F2a-07.
- * TODO: reemplazar por import desde hierarchy-orchestrator.ts una vez
- * que F2a-07 esté mergeado en main.
+ * Timeout de delegación — D-22e: 30 segundos por defecto, configurable por env.
+ * TODO: cuando F2a-07 esté en main, reemplazar por import de DELEGATION_TIMEOUT_MS
+ *       desde hierarchy-orchestrator.ts.
  */
-const DELEGATION_TIMEOUT_MS = 10 * 60 * 1000  // 10 minutos
+const DELEGATION_TIMEOUT_MS = parseInt(
+  process.env['DELEGATION_TIMEOUT_MS'] ?? '30000',
+  10,
+)
 
 /** Profundidad máxima de expansión de sub-runs */
 const MAX_DEPTH = 5
@@ -31,6 +40,85 @@ const MAX_DEPTH = 5
 type RunWithSteps = NonNullable<
   Awaited<ReturnType<PrismaClient['run']['findUnique']>>
 > & { steps: RunStep[] }
+
+/**
+ * Status efectivo de un nodo para el cálculo de deriveParentStatus.
+ * 'blocked' es virtual: no existe en BD, lo produce isBlocked().
+ */
+type NodeStatus = {
+  status:
+    | 'queued'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'skipped'
+    | 'cancelled'
+    | 'waitingapproval'
+    | 'blocked'   // virtual — producido por isBlocked()
+}
+
+// ── Funciones puras exportadas ─────────────────────────────────────────────
+
+/**
+ * Determina si un RunStep de delegación está bloqueado.
+ *
+ * Un step está bloqueado cuando (D-22e):
+ *   - Está en 'queued' (nunca llegó a 'running')
+ *   - startedAt es null (confirma que nunca arranó)
+ *   - Lleva más de DELEGATION_TIMEOUT_MS desde createdAt sin iniciar
+ *
+ * 'blocked' es un status VIRTUAL — no existe en BD.
+ * Lo consume deriveParentStatus() para calcular el status del padre.
+ *
+ * @param step  Campos mínimos necesarios para la evaluación
+ * @returns     true si el step está bloqueado
+ */
+export function isBlocked(step: {
+  status:    string
+  startedAt: Date | null
+  createdAt: Date
+}): boolean {
+  return (
+    step.status    === 'queued' &&
+    step.startedAt === null     &&
+    Date.now() - step.createdAt.getTime() > DELEGATION_TIMEOUT_MS
+  )
+}
+
+/**
+ * Deriva el status de un nodo padre a partir de los status de sus hijos.
+ * Aplica la regla de prioridad D-23f.
+ *
+ * Orden de prioridad (el primero que se cumple gana):
+ *   1. failed   ← cualquier hijo fallido
+ *   2. blocked  ← cualquier hijo bloqueado (status virtual)
+ *   3. running  ← cualquier hijo en ejecución
+ *   4. queued   ← cualquier hijo encolado
+ *   5. completed ← todos los hijos terminados (completed | skipped | cancelled)
+ *   6. running  ← fallback (waitingapproval u otro estado activo no previsto)
+ *
+ * Los llamadores deben mapear cada hijo a NodeStatus ANTES de llamar
+ * esta función, aplicando isBlocked() para producir el status virtual
+ * 'blocked' cuando corresponda.
+ *
+ * @param children  Array de NodeStatus de los steps/runs hijos.
+ *                  Array vacío → devuelve 'completed' (nada que esperar).
+ * @returns         Status derivado del padre.
+ */
+export function deriveParentStatus(children: NodeStatus[]): string {
+  if (children.length === 0) return 'completed'
+
+  if (children.some((c) => c.status === 'failed'))  return 'failed'
+  if (children.some((c) => c.status === 'blocked')) return 'blocked'
+  if (children.some((c) => c.status === 'running')) return 'running'
+  if (children.some((c) => c.status === 'queued'))  return 'queued'
+
+  const terminalStatuses = new Set(['completed', 'skipped', 'cancelled'])
+  if (children.every((c) => terminalStatuses.has(c.status))) return 'completed'
+
+  // waitingapproval u otro estado activo no previsto → activo en espera
+  return 'running'
+}
 
 // ── Tipos públicos ────────────────────────────────────────────────────────────
 
@@ -49,6 +137,7 @@ export interface StepNode {
   error:     string | null
   startedAt: Date | null
   finishedAt: Date | null
+  createdAt: Date   // necesario para isBlocked()
 
   // Métricas LLM (null si nodeType es 'delegation' o no hay datos)
   model:            string | null
@@ -57,6 +146,13 @@ export interface StepNode {
   completionTokens: number | null
   totalTokens:      number | null
   costUsd:          number | null
+
+  /**
+   * Para steps de delegación: hereda el derivedStatus del childRun si existe.
+   * Para otros tipos: igual que status.
+   * Usa este campo en la UI para mostrar el estado real al usuario.
+   */
+  effectiveStatus: string
 
   // Si nodeType === 'delegation': sub-árbol del Run hijo
   // null si el Run hijo aún no fue creado o no se encontró
@@ -71,7 +167,9 @@ export interface RunStatusTree {
   runId:       string
   workspaceId: string
   agentId:     string | null
-  status:      string
+  status:        string   // status real en BD — NO se modifica
+  derivedStatus: string   // calculado por deriveParentStatus()
+                           // puede diferir de status si BD está desactualizada
   inputData:   unknown
   outputData:  unknown
   error:       string | null
@@ -86,7 +184,7 @@ export interface RunStatusTree {
   completedSteps: number
   failedSteps:    number
   runningSteps:   number
-  /** Steps de delegación en 'running' que superaron DELEGATION_TIMEOUT_MS */
+  /** Steps de delegación en 'queued' (sin startedAt) que superaron DELEGATION_TIMEOUT_MS */
   blockedSteps:   number
   totalCostUsd:   number
   totalTokens:    number
@@ -108,6 +206,7 @@ export class HierarchyStatusService {
    * - Para cada RunStep con nodeType 'delegation': expande el
    *   Run hijo recursivamente (hasta MAX_DEPTH niveles)
    * - Calcula agregados: costo total, tokens, steps bloqueados
+   * - Calcula derivedStatus con deriveParentStatus()
    *
    * @param runId  ID del Run a consultar
    * @returns      RunStatusTree completo, o null si no existe
@@ -171,6 +270,7 @@ export class HierarchyStatusService {
   /**
    * Ensambla RunStatusTree dado un Run y sus steps ya cargados.
    * Expande steps de delegación buscando el Run hijo.
+   * Calcula derivedStatus mediante deriveParentStatus().
    *
    * Separado de buildTree para poder ser llamado desde listWorkspaceRuns
    * sin una query adicional.
@@ -187,23 +287,37 @@ export class HierarchyStatusService {
       )
     )
 
-    // Calcular agregados (por nivel — no suma steps de sub-runs)
+    // Mapear steps a NodeStatus para derivación (isBlocked() produce 'blocked' virtual)
+    const nodeStatuses: NodeStatus[] = stepNodes.map((step) => ({
+      status: isBlocked({
+        status:    step.status,
+        startedAt: step.startedAt,
+        createdAt: step.createdAt,
+      })
+        ? 'blocked'
+        : (step.status as NodeStatus['status']),
+    }))
+
+    const derivedStatus = deriveParentStatus(nodeStatuses)
+
+    // Calcular agregados por nivel
     const agg = this.aggregate(stepNodes)
 
     return {
-      runId:       run.id,
-      workspaceId: run.workspaceId,
-      agentId:     run.agentId   ?? null,
-      status:      run.status,
-      inputData:   run.inputData,
-      outputData:  (run as any).outputData ?? null,
-      error:       run.error     ?? null,
-      createdAt:   run.createdAt,
-      startedAt:   run.startedAt ?? null,
-      finishedAt:  (run as any).completedAt ?? null,
-      steps:       stepNodes,
+      runId:         run.id,
+      workspaceId:   run.workspaceId,
+      agentId:       run.agentId   ?? null,
+      status:        run.status,       // valor real en BD
+      derivedStatus,                   // valor calculado
+      inputData:     run.inputData,
+      outputData:    (run as any).outputData ?? null,
+      error:         run.error     ?? null,
+      createdAt:     run.createdAt,
+      startedAt:     run.startedAt ?? null,
+      finishedAt:    (run as any).completedAt ?? null,
+      steps:         stepNodes,
       ...agg,
-      durationMs:  run.startedAt
+      durationMs:    run.startedAt
         ? (((run as any).completedAt ?? new Date()).getTime() - run.startedAt.getTime())
         : null,
       depth,
@@ -213,6 +327,7 @@ export class HierarchyStatusService {
   /**
    * Construye un StepNode.
    * Si nodeType === 'delegation': busca el Run hijo y lo expande.
+   * Calcula effectiveStatus: hereda derivedStatus del childRun si existe.
    */
   private async buildStepNode(
     step:            RunStep,
@@ -231,6 +346,12 @@ export class HierarchyStatusService {
       )
     }
 
+    // effectiveStatus: para delegaciones, hereda derivedStatus del hijo
+    const effectiveStatus =
+      step.nodeType === 'delegation' && childRun !== null
+        ? childRun.derivedStatus
+        : step.status
+
     return {
       stepId:    step.id,
       nodeId:    step.nodeId,
@@ -242,12 +363,14 @@ export class HierarchyStatusService {
       error:     step.error              ?? null,
       startedAt: step.startedAt          ?? null,
       finishedAt: (step as any).completedAt ?? null,
+      createdAt:  step.createdAt,
       model:            (step as any).model            ?? null,
       provider:         (step as any).provider         ?? null,
       promptTokens:     (step as any).promptTokens     ?? null,
       completionTokens: (step as any).completionTokens ?? null,
       totalTokens:      (step as any).totalTokens      ?? null,
       costUsd:          (step as any).costUsd          ?? null,
+      effectiveStatus,
       childRun,
     }
   }
@@ -294,6 +417,9 @@ export class HierarchyStatusService {
    * Calcula totales a partir de los StepNodes ya construidos.
    * totalSteps es POR NIVEL — no suma los steps de los sub-runs.
    * Los costos SÍ se acumulan recursivamente desde childRun.
+   *
+   * blockedSteps (D-22e): delegation step en 'queued' sin startedAt
+   * que lleva más de DELEGATION_TIMEOUT_MS desde createdAt.
    */
   private aggregate(steps: StepNode[]): {
     totalSteps:     number
@@ -319,12 +445,14 @@ export class HierarchyStatusService {
       if (step.status === 'failed')    failedSteps++
       if (step.status === 'running')   runningSteps++
 
-      // Step bloqueado: delegación running que superó el timeout
+      // Step bloqueado (D-22e): delegación en 'queued' que nunca arranó
       if (
         step.nodeType  === 'delegation' &&
-        step.status    === 'running'    &&
-        step.startedAt !== null         &&
-        Date.now() - step.startedAt.getTime() > DELEGATION_TIMEOUT_MS
+        isBlocked({
+          status:    step.status,
+          startedAt: step.startedAt,
+          createdAt: step.createdAt,
+        })
       ) {
         blockedSteps++
       }

--- a/packages/run-engine/src/index.ts
+++ b/packages/run-engine/src/index.ts
@@ -7,5 +7,5 @@ export type { AgentExecutorFn } from './agent-executor.service';
 export { FlowExecutor } from './flow-executor';
 export type { FlowSpec, FlowNode } from './flow-executor';
 export { executeCondition, ConditionSyntaxError, ConditionRuntimeError } from './execute-condition';
-export { HierarchyStatusService } from './hierarchy-status.service.js';
+export { HierarchyStatusService, isBlocked, deriveParentStatus } from './hierarchy-status.service.js';
 export type { RunStatusTree, StepNode } from './hierarchy-status.service.js';

--- a/packages/run-engine/src/index.ts
+++ b/packages/run-engine/src/index.ts
@@ -7,3 +7,5 @@ export type { AgentExecutorFn } from './agent-executor.service';
 export { FlowExecutor } from './flow-executor';
 export type { FlowSpec, FlowNode } from './flow-executor';
 export { executeCondition, ConditionSyntaxError, ConditionRuntimeError } from './execute-condition';
+export { HierarchyStatusService } from './hierarchy-status.service.js';
+export type { RunStatusTree, StepNode } from './hierarchy-status.service.js';


### PR DESCRIPTION
# F2a-09 — `deriveParentStatus()` + `isBlocked()`

## Correcciones obligatorias sobre F2a-08 (D-22e canónico)

| Campo | F2a-08 (incorrecto) | Este PR (correcto) |
|---|---|---|
| `DELEGATION_TIMEOUT_MS` | `10 * 60 * 1000` hardcoded | `parseInt(process.env['DELEGATION_TIMEOUT_MS'] ?? '30000', 10)` |
| Condición bloqueado | `status === 'running' && startedAt !== null` | `status === 'queued' && startedAt === null && createdAt expired` |

## Cambios F2a-09

### Tipo interno `NodeStatus`
- Cubre todos los status reales + `'blocked'` (virtual, no existe en BD)

### `isBlocked()` — función pura exportada
- `status === 'queued'` + `startedAt === null` + `Date.now() - createdAt > DELEGATION_TIMEOUT_MS`
- Configurable por env var, default 30 s

### `deriveParentStatus()` — función pura exportada
Regla de prioridad D-23f:
1. `failed` > 2. `blocked` > 3. `running` > 4. `queued` > 5. `completed` (skipped/cancelled terminan el padre) > 6. `running` (fallback)

### `StepNode` extendido
- Añade `createdAt: Date` (necesario para `isBlocked()`)
- Añade `effectiveStatus: string` (hereda `derivedStatus` del `childRun` para delegation steps)

### `RunStatusTree` extendido
- Añade `derivedStatus: string` (calculado, nunca persistido)
- `status` (valor real en BD) se conserva intacto

### `assembleTree()` integrado
- Mapea steps a `NodeStatus` aplicando `isBlocked()`
- Llama `deriveParentStatus(nodeStatuses)` → `derivedStatus`
- Calcula `effectiveStatus` en `buildStepNode()`

### `index.ts`
- Exporta `isBlocked`, `deriveParentStatus`

## Tests: 5 de F2a-08 + 15 nuevos = 20 total

| Rango | Cubre |
|---|---|
| 1–5 | Escenarios F2a-08 (mantenidos) |
| 6–9 | `isBlocked()` (4 escenarios) |
| 10–18 | `deriveParentStatus()` (9 escenarios) |
| 19–20 | Integración `assembleTree()` |

## Restricciones del Plan Maestro cumplidas

- ✅ `run.status` en BD **nunca** se modifica
- ✅ `'blocked'` **no** se persiste (solo virtual en `NodeStatus`)
- ✅ `DELEGATION_TIMEOUT_MS` desde `process.env` con default 30000
- ✅ `isBlocked()` y `deriveParentStatus()` son funciones puras
- ✅ `assembleTree()` es el único punto de integración
- ✅ No se modifica `RunRepository` ni `schema.prisma`

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hierarchical status tracking for nested and delegated runs
  * Automatic status derivation based on child run statuses
  * Detection of blocked delegations
  * Aggregate metrics (cost, tokens, duration) across run hierarchies
  * New API to query and filter workspace runs by status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->