### PR TITLE
feat(F2a-10): StatusChangeEvent + RunStepEventEmitter

### DIFF
--- a/packages/hierarchy/src/hierarchy-orchestrator.ts
+++ b/packages/hierarchy/src/hierarchy-orchestrator.ts
@@ -19,6 +19,10 @@
 
 import type { PrismaClient } from '@prisma/client'
 import { RunRepository } from '../../run-engine/src/run-repository.js'
+import {
+  RunStepEventEmitter,
+  buildStatusChangeEvent,
+} from '../../run-engine/src/events/index.js'
 
 // ── Tipos públicos ───────────────────────────────────────────────────────────────────────────────
 
@@ -228,15 +232,6 @@ export interface OrchestratorOptions {
 /**
  * Tiempo máximo que un RunStep de delegación puede estar
  * en estado 'running' o 'queued' antes de considerarse bloqueado.
- *
- * No es un OrchestratorOptions — es un contrato de arquitectura.
- * Si la delegación tarda más de esto, hay un problema estructural.
- *
- * Valor: 10 minutos. Racional:
- *   - subtaskTimeoutMs default: 2 min (ejecución LLM)
- *   - approvalTimeoutMs default: 15 min (espera humana)
- *   - delegación: orquesta N subtasks de 2 min → 5 pasos
- *     holgados = 10 min tope razonable
  */
 export const DELEGATION_TIMEOUT_MS = 10 * 60 * 1000  // 10 minutos
 
@@ -249,11 +244,9 @@ const DEFAULT_OPTIONS: Required<OrchestratorOptions> = {
 }
 
 // ── [F2a-04] Funciones puras de tokenización y scoring ───────────────────────────────────────────
-// Ubicadas a nivel módulo (fuera de la clase) para ser testeables sin instanciar HierarchyOrchestrator.
 
 /**
  * Tokeniza texto en un Set de palabras lowercase sin stopwords.
- * Mínimo 3 caracteres por token para evitar ruido.
  */
 export function tokenize(text: string): Set<string> {
   const STOPWORDS = new Set([
@@ -277,7 +270,6 @@ export function tokenize(text: string): Set<string> {
 
 /**
  * Jaccard simplificado: |A ∩ B| / |A ∪ B|
- * Retorna 0 si ambos sets están vacíos.
  */
 export function jaccardScore(a: Set<string>, b: Set<string>): number {
   if (a.size === 0 && b.size === 0) return 0
@@ -301,6 +293,8 @@ export class HierarchyOrchestrator {
     prisma:      PrismaClient,
     supervisorFn?: SupervisorFn,
     opts?:       OrchestratorOptions,
+    /** F2a-10: emitter de transiciones de RunStep — opcional para compatibilidad hacia atrás */
+    private readonly emitter?: RunStepEventEmitter,
   ) {
     this.hierarchy    = hierarchy
     this.executorFn   = executorFn
@@ -311,19 +305,6 @@ export class HierarchyOrchestrator {
 
   // ── API pública ──────────────────────────────────────────────────────────────────
 
-  /**
-   * Punto de entrada principal.
-   *
-   * 1. Crea un Run en Prisma
-   * 2. Descompone el task vía supervisor LLM (o capability-match fallback)
-   * 3. Ejecuta subtareas (paralelo o secuencial) con checkpointing por RunStep
-   * 4. Consolida el resultado vía supervisor LLM
-   * 5. Marca el Run como completed/partial/failed
-   *
-   * @param workspaceId ID del workspace (requerido para Run + Approval)
-   * @param rootTask    Descripción del task principal
-   * @param input       Payload de entrada (opcional)
-   */
   async orchestrate(
     workspaceId: string,
     rootTask: string,
@@ -331,7 +312,6 @@ export class HierarchyOrchestrator {
   ): Promise<OrchestrationResult> {
     const startTime = Date.now()
 
-    // ── 1. Crear Run ────────────────────────────────────────────────────────────
     const run = await this.repo.createRun({
       workspaceId,
       agentId:   this.hierarchy.level === 'agent' ? this.hierarchy.id : undefined,
@@ -341,23 +321,19 @@ export class HierarchyOrchestrator {
     await this.repo.startRun(run.id)
 
     try {
-      // ── 2. Descomponer task ──────────────────────────────────────────────
       const subtasks = await this.decomposeTasks(rootTask, input)
 
-      // ── 3. Ejecutar subtareas ─────────────────────────────────────────────
       const subtaskResults = this.opts.parallel
         ? await this.executeParallel(subtasks, run.id, workspaceId)
         : await this.executeSequential(subtasks, run.id, workspaceId)
 
-      // ── 4. Consolidar ────────────────────────────────────────────────────
       const consolidatedOutput = await this.consolidateResults(rootTask, subtaskResults)
 
-      // ── 5. Estado final del Run ──────────────────────────────────────────────
       const failed  = subtaskResults.filter((r) => r.status === 'failed' || r.status === 'rejected')
       const success = subtaskResults.filter((r) => r.status === 'completed')
       const runStatus: OrchestrationResult['status'] =
-        failed.length === 0                         ? 'completed'
-        : success.length === 0                      ? 'failed'
+        failed.length === 0  ? 'completed'
+        : success.length === 0 ? 'failed'
         : 'partial'
 
       if (runStatus === 'failed') {
@@ -381,13 +357,6 @@ export class HierarchyOrchestrator {
     }
   }
 
-  /**
-   * Consulta el estado actual de un RunStep desde BD.
-   * READ-ONLY — no modifica ningún registro.
-   *
-   * @param stepId  ID del RunStep (disponible en SubtaskResult.stepId)
-   * @returns       StepStatusResult con snapshot completo, o null si no existe
-   */
   async getStepStatus(stepId: string): Promise<StepStatusResult | null> {
     const step = await this.repo.findStep(stepId)
     if (!step) return null
@@ -409,105 +378,67 @@ export class HierarchyOrchestrator {
       totalTokens:      step.totalTokens      ?? null,
       costUsd:          step.costUsd          ?? null,
       startedAt:        step.startedAt        ?? null,
-      // completedAt en schema.prisma → finishedAt en StepStatusResult
       finishedAt:       step.completedAt      ?? null,
       createdAt:        step.createdAt,
     }
   }
 
-  /**
-   * Detecta si un RunStep de delegación está bloqueado.
-   *
-   * Un step está bloqueado cuando:
-   *   - status es 'running' o 'queued'
-   *   - startedAt + DELEGATION_TIMEOUT_MS < Date.now()
-   *
-   * NUNCA lanza — en caso de error de BD devuelve blocked: false
-   * (principio de fail-open: preferimos no fallar a falsos positivos).
-   *
-   * @param stepId  ID del RunStep a verificar
-   * @returns       BlockedStatus con diagnóstico completo
-   */
   async isBlocked(stepId: string): Promise<BlockedStatus> {
     try {
       const step = await this.repo.findStep(stepId)
 
-      // Step no encontrado → no bloqueado (fail-open)
       if (!step) {
-        return {
-          blocked: false,
-          reason:  `Step ${stepId} not found`,
-        }
+        return { blocked: false, reason: `Step ${stepId} not found` }
       }
 
-      // Solo steps de delegación en estado activo pueden bloquearse
       if (step.nodeType !== 'delegation') {
         return {
           blocked: false,
-          stepId:  step.id,
-          runId:   step.runId,
-          reason:  `Step ${stepId} is not a delegation step (nodeType: ${step.nodeType})`,
+          stepId: step.id,
+          runId: step.runId,
+          reason: `Step ${stepId} is not a delegation step (nodeType: ${step.nodeType})`,
         }
       }
 
-      // Step ya finalizado → no bloqueado
       const activeStatuses = ['running', 'queued']
       if (!activeStatuses.includes(step.status)) {
         return {
           blocked: false,
-          stepId:  step.id,
-          runId:   step.runId,
-          reason:  `Step ${stepId} has terminal status: ${step.status}`,
+          stepId: step.id,
+          runId: step.runId,
+          reason: `Step ${stepId} has terminal status: ${step.status}`,
         }
       }
 
-      // Calcular tiempo transcurrido
-      // startedAt puede ser null si el step está 'queued' pero nunca llegó a 'running'.
-      // En ese caso usamos createdAt — un step queued durante 10 min también es un bloqueo.
       const referenceTime = step.startedAt ?? step.createdAt
       const elapsedMs     = Date.now() - referenceTime.getTime()
 
       if (elapsedMs < DELEGATION_TIMEOUT_MS) {
         return {
-          blocked:   false,
-          stepId:    step.id,
-          runId:     step.runId,
-          nodeId:    step.nodeId,
+          blocked: false,
+          stepId: step.id,
+          runId: step.runId,
+          nodeId: step.nodeId,
           elapsedMs,
           timeoutMs: DELEGATION_TIMEOUT_MS,
-          reason:    `Step running for ${elapsedMs}ms — within timeout (${DELEGATION_TIMEOUT_MS}ms)`,
+          reason: `Step running for ${elapsedMs}ms — within timeout (${DELEGATION_TIMEOUT_MS}ms)`,
         }
       }
 
-      // ── BLOQUEADO ──────────────────────────────────────────────
       return {
-        blocked:   true,
-        stepId:    step.id,
-        runId:     step.runId,
-        nodeId:    step.nodeId,
+        blocked: true,
+        stepId: step.id,
+        runId: step.runId,
+        nodeId: step.nodeId,
         elapsedMs,
         timeoutMs: DELEGATION_TIMEOUT_MS,
-        reason:    `Delegation step ${stepId} blocked: running for ${elapsedMs}ms > ${DELEGATION_TIMEOUT_MS}ms timeout`,
+        reason: `Delegation step ${stepId} blocked: running for ${elapsedMs}ms > ${DELEGATION_TIMEOUT_MS}ms timeout`,
       }
     } catch {
-      // Error de BD → fail-open
-      return {
-        blocked: false,
-        reason:  `isBlocked check failed for step ${stepId} — BD error`,
-      }
+      return { blocked: false, reason: `isBlocked check failed for step ${stepId} — BD error` }
     }
   }
 
-  /**
-   * Verifica si algún RunStep de delegación en un Run está bloqueado.
-   * Útil para polls periódicos del gateway o n8n.
-   *
-   * NUNCA lanza.
-   *
-   * @param runId  ID del Run a verificar
-   * @returns      BlockedStatus del primer step bloqueado encontrado,
-   *               o { blocked: false } si ninguno lo está
-   */
   async isRunBlocked(runId: string): Promise<BlockedStatus> {
     try {
       const steps = await this.repo.findDelegationStepsByRun(runId)
@@ -521,47 +452,31 @@ export class HierarchyOrchestrator {
 
         if (elapsedMs >= DELEGATION_TIMEOUT_MS) {
           return {
-            blocked:   true,
-            stepId:    step.id,
-            runId:     step.runId,
-            nodeId:    step.nodeId,
+            blocked: true,
+            stepId: step.id,
+            runId: step.runId,
+            nodeId: step.nodeId,
             elapsedMs,
             timeoutMs: DELEGATION_TIMEOUT_MS,
-            reason:    `Run ${runId} blocked: delegation step ${step.id} running for ${elapsedMs}ms`,
+            reason: `Run ${runId} blocked: delegation step ${step.id} running for ${elapsedMs}ms`,
           }
         }
       }
 
-      return {
-        blocked: false,
-        runId,
-        reason:  `No blocked delegation steps in run ${runId}`,
-      }
+      return { blocked: false, runId, reason: `No blocked delegation steps in run ${runId}` }
     } catch {
-      return {
-        blocked: false,
-        reason:  `isRunBlocked check failed for run ${runId} — BD error`,
-      }
+      return { blocked: false, reason: `isRunBlocked check failed for run ${runId} — BD error` }
     }
   }
 
   // ── Descomposición de tareas ─────────────────────────────────────────────────────────
 
-  /**
-   * Descompone el task en subtareas asignadas a agentes hoja.
-   *
-   * Estrategia:
-   *   1. Si hay supervisorFn: llama al LLM con un prompt estructurado y parsea JSON.
-   *   2. Si el LLM falla o no hay supervisorFn: fallback a capability matching [F2a-04].
-   *      El agente con mayor afinidad semántica recibe el task completo.
-   */
   private async decomposeTasks(
     rootTask: string,
     input?: Record<string, unknown>,
   ): Promise<HierarchyTask[]> {
     const agents = this.collectAgentNodes(this.hierarchy)
 
-    // Modo single-agent
     if (agents.length === 0) {
       return [{
         id:             `subtask-${this.hierarchy.id}`,
@@ -572,7 +487,6 @@ export class HierarchyOrchestrator {
       }]
     }
 
-    // Intentar descomposición vía supervisor LLM
     if (this.supervisorFn) {
       try {
         return await this.decomposeTask(rootTask, agents, input)
@@ -581,7 +495,6 @@ export class HierarchyOrchestrator {
       }
     }
 
-    // [F2a-04] Fallback: asignar al especialista con mayor afinidad semántica
     const match = await this.findSpecialistWithCapability(rootTask, agents)
     return [{
       id:             `subtask-${match.node.id}-0`,
@@ -602,11 +515,7 @@ export class HierarchyOrchestrator {
    *   ---END---
    * que serán parseados por parseDelegateBlocks() una vez integrada (ver F2a-05c).
    *
-   * Estado actual: el prompt pide al supervisor un JSON array con objetos
-   *   { agentId: string, task: string }
-   * El parser JSON permanece en uso hasta que parseDelegateBlocks() esté integrado.
-   *
-   * Parseo robusto: extrae el primer bloque JSON del texto aunque haya prose.
+   * Estado actual: el parser JSON permanece en uso hasta que parseDelegateBlocks() esté integrado.
    *
    * TODO: Eliminar el parseo JSON y reemplazarlo con parseDelegateBlocks() una vez
    *       que dicha función esté disponible. Ver el símbolo parseDelegateBlocks()
@@ -639,7 +548,6 @@ export class HierarchyOrchestrator {
 
     const raw = await this.supervisorFn!(prompt)
 
-    // Extraer el primer bloque JSON del texto
     const jsonMatch = raw.match(/\[\s*\{[\s\S]*?\}\s*\]/)
     if (!jsonMatch) throw new Error('Supervisor did not return a valid JSON array')
 
@@ -648,7 +556,6 @@ export class HierarchyOrchestrator {
       throw new Error('Supervisor returned empty task list')
     }
 
-    // Filtrar asignaciones a agentes válidos
     const agentIds = new Set(agents.map((a) => a.id))
     return parsed
       .filter((p) => agentIds.has(p.agentId))
@@ -723,13 +630,6 @@ export class HierarchyOrchestrator {
     return results
   }
 
-  /**
-   * Ejecuta un subtask con:
-   *   - Checkpoint RunStep al inicio y fin
-   *   - HITL: pausa si requiresApproval y espera Approval en DB
-   *   - Retry con backoff exponencial
-   *   - Timeout por subtask
-   */
   private async executeWithRetry(
     task:        HierarchyTask,
     index:       number,
@@ -739,7 +639,6 @@ export class HierarchyOrchestrator {
     const start = Date.now()
     const node  = this.findNode(task.assignedNodeId)
 
-    // ── Checkpoint: crear RunStep ────────────────────────────────────────
     const step = await this.repo.createStep({
       runId,
       nodeId:   task.assignedNodeId,
@@ -748,7 +647,6 @@ export class HierarchyOrchestrator {
       input:    { task: task.description, ...task.input },
     })
 
-    // ── HITL: pausar si requiresApproval ──────────────────────────────
     if (node?.agentConfig?.requiresApproval) {
       await this.repo.pauseRun(runId)
 
@@ -764,7 +662,7 @@ export class HierarchyOrchestrator {
       })
 
       const decision = await this.repo.waitForApproval(approval.id, this.opts.approvalTimeoutMs)
-      await this.repo.startRun(runId)  // retomar estado running
+      await this.repo.startRun(runId)
 
       if (decision !== 'approved') {
         await this.repo.skipStep(step.id)
@@ -781,7 +679,6 @@ export class HierarchyOrchestrator {
       }
     }
 
-    // ── Ejecución con retry ───────────────────────────────────────────────
     const systemPrompt = node?.agentConfig?.systemPrompt
       ?? `You are ${node?.name ?? task.assignedNodeId}. Complete your assigned task.`
     const skills = node?.agentConfig?.skills
@@ -789,7 +686,6 @@ export class HierarchyOrchestrator {
     let lastError = ''
     for (let attempt = 0; attempt <= this.opts.maxRetries; attempt++) {
       if (attempt > 0) {
-        // Backoff exponencial
         const waitMs = this.opts.retryBaseMs * Math.pow(2, attempt - 1)
         await new Promise((r) => setTimeout(r, waitMs))
       }
@@ -801,7 +697,6 @@ export class HierarchyOrchestrator {
           `Subtask ${task.id} timed out after ${this.opts.subtaskTimeoutMs}ms`,
         )
 
-        // ── Checkpoint: step completado con todos los metadatos LLM ─────
         await this.repo.completeStep({
           stepId:           step.id,
           output:           execResult.response,
@@ -827,7 +722,6 @@ export class HierarchyOrchestrator {
       }
     }
 
-    // Todos los reintentos fallaron
     await this.repo.failStep({ stepId: step.id, error: lastError })
     return {
       taskId:     task.id,
@@ -852,7 +746,6 @@ export class HierarchyOrchestrator {
       return 'All subtasks failed. No output available.'
     }
 
-    // [F2a-06d] Calcular stats para pasarlos al supervisor
     const stats: ConsolidationResult['stats'] = {
       total:     results.length,
       completed: completed.length,
@@ -878,13 +771,11 @@ export class HierarchyOrchestrator {
     ].join('\n\n')
   }
 
-  // [F2a-06d] stats es obligatorio — TypeScript garantiza que consolidateResults() siempre lo pase
   private async consolidateWithSupervisor(
     rootTask:  string,
     completed: SubtaskResult[],
     stats:     ConsolidationResult['stats'],
   ): Promise<string> {
-    // Línea de contexto de fallos — solo si hay fallos o rechazos
     const statusLine =
       stats.failed > 0 || stats.rejected > 0
         ? `Note: ${stats.completed} of ${stats.total} subtasks completed` +
@@ -893,7 +784,6 @@ export class HierarchyOrchestrator {
           '. Synthesize only from the available completed results.'
         : ''
 
-    // Resultados de agentes para el prompt — solo completed, nunca failed/rejected
     const resultsSummary = completed
       .map((r, i) => `[${i + 1}] Agent ${r.nodeId}: ${String(r.output ?? '')}`)
       .join('\n')
@@ -901,7 +791,7 @@ export class HierarchyOrchestrator {
     const prompt = [
       'You are a supervisor synthesizing results from multiple agents.',
       `Original task: "${rootTask}"`,
-      statusLine,          // omitido si todos completaron (string vacío → .filter(Boolean) lo elimina)
+      statusLine,
       '',
       'Agent results:',
       resultsSummary,
@@ -935,7 +825,6 @@ export class HierarchyOrchestrator {
     return node.children.flatMap((child) => this.collectAgentNodes(child))
   }
 
-  /** Búsqueda BFS de un nodo por ID. */
   private findNode(id: string): HierarchyNode | undefined {
     const queue: HierarchyNode[] = [this.hierarchy]
     while (queue.length > 0) {
@@ -946,58 +835,25 @@ export class HierarchyOrchestrator {
     return undefined
   }
 
-  /**
-   * [F2a-04] Encuentra el agente hoja con mayor afinidad semántica
-   * para el task dado, usando score léxico sobre AgentProfile en BD.
-   *
-   * Algoritmo:
-   *   1. Colecta todos los nodos hoja (agent/subagent)
-   *   2. Carga sus AgentProfiles desde BD en una sola query
-   *   3. Calcula score Jaccard(taskTokens, profileTokens)
-   *      para systemPrompt, persona y knowledgeBase (toma el máximo)
-   *   4. Devuelve el agente de mayor score
-   *   5. Si todos los scores < MIN_SCORE → isFallback: true
-   *
-   * Restricciones:
-   *   - NO usa embeddings ni llamadas LLM
-   *   - NO lanza excepciones: siempre retorna un SpecialistMatch válido
-   *   - Una sola query BD para todos los agentes
-   *
-   * @param taskDescription  Texto libre del task a asignar
-   * @param candidates       Nodos hoja candidatos (si omitido, usa todos)
-   */
   private async findSpecialistWithCapability(
     taskDescription: string,
     candidates?:     HierarchyNode[],
   ): Promise<SpecialistMatch> {
     const agents = candidates ?? this.collectAgentNodes(this.hierarchy)
 
-    // Fallback inmediato si no hay agentes
     if (agents.length === 0) {
-      return {
-        node:       this.hierarchy,
-        score:      0,
-        isFallback: true,
-        allScores:  [],
-      }
+      return { node: this.hierarchy, score: 0, isFallback: true, allScores: [] }
     }
 
     try {
-      // 1. Cargar profiles desde BD (única query)
-      const profiles = await this.repo.findAgentProfiles(
-        agents.map((a) => a.id),
-      )
+      const profiles = await this.repo.findAgentProfiles(agents.map((a) => a.id))
       const profileMap = new Map(profiles.map((p) => [p.agentId, p]))
-
-      // 2. Tokenizar el task una sola vez
       const taskTokens = tokenize(taskDescription)
 
-      // 3. Calcular score por agente
       const scores: CapabilityScore[] = agents.map((node) => {
         const profile = profileMap.get(node.id)
 
         if (!profile) {
-          // Sin profile en BD: usar agentConfig.systemPrompt del árbol como texto de fallback
           const fallbackText = node.agentConfig?.systemPrompt ?? node.name
           return {
             node,
@@ -1007,121 +863,61 @@ export class HierarchyOrchestrator {
           }
         }
 
-        // Score sobre systemPrompt
         const promptScore = profile.systemPrompt
           ? jaccardScore(taskTokens, tokenize(profile.systemPrompt))
           : 0
 
-        // Score sobre persona (serializar JSON a texto plano)
         const personaText = typeof profile.persona === 'string'
           ? profile.persona
           : JSON.stringify(profile.persona)
         const personaScore = jaccardScore(taskTokens, tokenize(personaText))
 
-        // Score sobre knowledgeBase (array de { topic, content })
         const kbText = typeof profile.knowledgeBase === 'string'
           ? profile.knowledgeBase
           : JSON.stringify(profile.knowledgeBase)
         const kbScore = jaccardScore(taskTokens, tokenize(kbText))
 
-        // Tomar el máximo de los tres campos
         const maxScore = Math.max(promptScore, personaScore, kbScore)
         const matchedOn: CapabilityScore['matchedOn'] =
           maxScore === promptScore  ? 'systemPrompt'
           : maxScore === personaScore ? 'persona'
           : 'knowledgeBase'
 
-        return {
-          node,
-          score:        maxScore,
-          matchedOn,
-          profileFound: true,
-        }
+        return { node, score: maxScore, matchedOn, profileFound: true }
       })
 
-      // 4. Ordenar por score descendente
       scores.sort((a, b) => b.score - a.score)
       const best = scores[0]
-
-      // 5. Threshold mínimo: si todos son 0, es fallback
       const MIN_SCORE = 0.05
       const isFallback = best.score < MIN_SCORE
 
-      return {
-        node:       best.node,
-        score:      best.score,
-        isFallback,
-        allScores:  scores,
-      }
+      return { node: best.node, score: best.score, isFallback, allScores: scores }
     } catch {
-      // Nunca lanzar: en caso de error de BD, devolver el primer agente disponible
-      return {
-        node:       agents[0],
-        score:      0,
-        isFallback: true,
-        allScores:  [],
-      }
+      return { node: agents[0], score: 0, isFallback: true, allScores: [] }
     }
   }
 
-  /**
-   * [F2a-03] Decide si una tarea se ejecuta localmente (specialist)
-   * o debe delegarse al nivel inferior.
-   *
-   * Reglas:
-   *   - Nodo hoja (sin children o children vacío) con agentConfig
-   *     → local: el agente ejecuta directamente
-   *   - Nodo hoja SIN agentConfig (configuración incompleta)
-   *     → local con nodo sintético — se ejecuta con systemPrompt genérico
-   *   - Nodo no encontrado
-   *     → local con nodo sintético derivado del task
-   *   - Nodo intermedio (tiene children)
-   *     → delegate: crear RunStep de delegación y sub-orquestar
-   *
-   * NUNCA retorna 'delegate' si los hijos también son intermedios sin agentes;
-   * la recursión ocurre porque delegateTask() llama subOrchestrator.orchestrate()
-   * que a su vez llama routeTask() de nuevo en el nivel inferior.
-   */
   private routeTask(task: HierarchyTask): RouteDecision {
     const node = this.findNode(task.assignedNodeId)
 
-    // Nodo no encontrado → nodo sintético, ejecutar local
     if (!node) {
       return {
         type: 'local',
-        node: {
-          id:    task.assignedNodeId,
-          name:  task.assignedNodeId,
-          level: task.level,
-        },
+        node: { id: task.assignedNodeId, name: task.assignedNodeId, level: task.level },
       }
     }
 
     const hasChildren = node.children !== undefined && node.children.length > 0
+    if (!hasChildren) return { type: 'local', node }
 
-    // Nodo hoja → specialist local
-    if (!hasChildren) {
-      return { type: 'local', node }
-    }
-
-    // Nodo intermedio → delegar al nivel inferior
-    return {
-      type:     'delegate',
-      node,
-      children: node.children!,
-    }
+    return { type: 'delegate', node, children: node.children! }
   }
 
   /**
    * [F2a-03] Materializa una delegación en BD como RunStep { nodeType: 'delegation' }
    * y lanza sub-orquestación sobre los hijos del nodo delegado.
    *
-   * Contrato del Plan Maestro:
-   *   "Delegar = crear RunStep con nodeType: 'delegation' en BD.
-   *    Nunca texto, nunca log."
-   *
-   * El RunStep de delegación actúa como envelope del sub-resultado.
-   * Su output se llena cuando la sub-orquestación termina.
+   * F2a-10: emite null→queued DESPUÉS de createStep() en BD.
    */
   private async delegateTask(
     task:        HierarchyTask,
@@ -1132,7 +928,7 @@ export class HierarchyOrchestrator {
   ): Promise<SubtaskResult> {
     const start = Date.now()
 
-    // 1. Crear RunStep de delegación
+    // 1. Crear RunStep de delegación en BD
     const step = await this.repo.createStep({
       runId,
       nodeId:   decision.node.id,
@@ -1141,30 +937,49 @@ export class HierarchyOrchestrator {
       input:    { task: task.description, ...task.input },
     })
 
+    // 2. F2a-10: Emitir null → queued DESPUÉS del write en BD (D-23d)
+    if (this.emitter) {
+      try {
+        this.emitter.emitStepChanged(
+          buildStatusChangeEvent({
+            stepId:         step.id,
+            runId:          step.runId,
+            nodeId:         step.nodeId,
+            nodeType:       'delegation',
+            agentId:        null,
+            workspaceId,
+            previousStatus: null,
+            currentStatus:  'queued',
+            output: null, error: null,
+            model:  null, provider: null,
+            promptTokens: null, completionTokens: null,
+            totalTokens: null, costUsd: null,
+          }),
+        )
+      } catch { /* best-effort — nunca relanzar */ }
+    }
+
     try {
-      // 2. Construir sub-jerarquía con los hijos del nodo delegado
       const subHierarchy: HierarchyNode = {
         ...decision.node,
         children: decision.children,
       }
 
-      // 3. Crear sub-orquestador con la misma config pero jerarquía recortada
       const subOrchestrator = new HierarchyOrchestrator(
         subHierarchy,
         this.executorFn,
         this.repo.getPrisma(),
         this.supervisorFn,
         this.opts,
+        this.emitter,  // propagar emitter al sub-orquestador
       )
 
-      // 4. Orquestar en el sub-nivel
       const subResult = await subOrchestrator.orchestrate(
         workspaceId,
         task.description,
         task.input,
       )
 
-      // 5. Completar el RunStep de delegación con el output consolidado
       await this.repo.completeStep({
         stepId: step.id,
         output: subResult.consolidatedOutput,

--- a/packages/run-engine/src/__tests__/run-step-emitter.test.ts
+++ b/packages/run-engine/src/__tests__/run-step-emitter.test.ts
@@ -1,0 +1,257 @@
+import {
+  RunStepEventEmitter,
+  buildStatusChangeEvent,
+} from '../events/index'
+import type { StatusChangeEvent } from '../events/index'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<StatusChangeEvent> = {}): StatusChangeEvent {
+  return buildStatusChangeEvent({
+    stepId: 's1', runId: 'r1', nodeId: 'n1', nodeType: 'agent',
+    agentId: null, workspaceId: 'ws1',
+    previousStatus: 'queued', currentStatus: 'running',
+    output: null, error: null,
+    model: null, provider: null,
+    promptTokens: null, completionTokens: null,
+    totalTokens: null, costUsd: null,
+    ...overrides,
+  })
+}
+
+// ── RunStepEventEmitter (1-5) ─────────────────────────────────────────────────
+
+describe('RunStepEventEmitter', () => {
+
+  it('1. onStepChanged() receives emitted event', () => {
+    const emitter = new RunStepEventEmitter()
+    const received: StatusChangeEvent[] = []
+    emitter.onStepChanged((e) => received.push(e))
+    const ev = makeEvent()
+    emitter.emitStepChanged(ev)
+    expect(received).toHaveLength(1)
+    expect(received[0]).toEqual(ev)
+  })
+
+  it('2. offStepChanged() cancels subscription', () => {
+    const emitter = new RunStepEventEmitter()
+    const received: StatusChangeEvent[] = []
+    const handler = (e: StatusChangeEvent) => received.push(e)
+    emitter.onStepChanged(handler)
+    emitter.offStepChanged(handler)
+    emitter.emitStepChanged(makeEvent())
+    expect(received).toHaveLength(0)
+  })
+
+  it('3. onceStepChanged() fires exactly once for 3 emissions', () => {
+    const emitter = new RunStepEventEmitter()
+    let count = 0
+    emitter.onceStepChanged(() => count++)
+    emitter.emitStepChanged(makeEvent())
+    emitter.emitStepChanged(makeEvent())
+    emitter.emitStepChanged(makeEvent())
+    expect(count).toBe(1)
+  })
+
+  it('4. multiple handlers all receive the same event', () => {
+    const emitter = new RunStepEventEmitter()
+    const counts = [0, 0, 0]
+    emitter.onStepChanged(() => counts[0]++)
+    emitter.onStepChanged(() => counts[1]++)
+    emitter.onStepChanged(() => counts[2]++)
+    emitter.emitStepChanged(makeEvent())
+    expect(counts).toEqual([1, 1, 1])
+  })
+
+  it('5. no MaxListenersExceededWarning with 51 handlers', () => {
+    const emitter = new RunStepEventEmitter()
+    const warn = jest.spyOn(process, 'emit')
+    for (let i = 0; i < 51; i++) emitter.onStepChanged(() => {})
+    emitter.emitStepChanged(makeEvent())
+    const warnings = warn.mock.calls.filter(
+      (c) => c[0] === 'warning' && String(c[1]).includes('MaxListeners'),
+    )
+    expect(warnings).toHaveLength(0)
+    warn.mockRestore()
+  })
+})
+
+// ── buildStatusChangeEvent() (6-8) ───────────────────────────────────────────
+
+describe('buildStatusChangeEvent()', () => {
+
+  it('6. optional fields default to null when omitted', () => {
+    const ev = makeEvent()
+    expect(ev.output).toBeNull()
+    expect(ev.error).toBeNull()
+    expect(ev.model).toBeNull()
+    expect(ev.provider).toBeNull()
+    expect(ev.promptTokens).toBeNull()
+    expect(ev.completionTokens).toBeNull()
+    expect(ev.totalTokens).toBeNull()
+    expect(ev.costUsd).toBeNull()
+  })
+
+  it('7. timestamp is auto-generated close to now', () => {
+    const before = Date.now()
+    const ev = makeEvent()
+    const after = Date.now()
+    expect(ev.timestamp.getTime()).toBeGreaterThanOrEqual(before)
+    expect(ev.timestamp.getTime()).toBeLessThanOrEqual(after)
+  })
+
+  it('8. explicit timestamp is not overwritten', () => {
+    const ts = new Date('2025-01-01T00:00:00Z')
+    const ev = buildStatusChangeEvent({ ...makeEvent(), timestamp: ts })
+    expect(ev.timestamp).toEqual(ts)
+  })
+})
+
+// ── AgentExecutor integration (9-11) ─────────────────────────────────────────
+
+import { AgentExecutor } from '../agent-executor.service'
+
+function makePrisma(stepData: Record<string, unknown> = {}) {
+  const step = {
+    id: 's1', runId: 'r1', nodeId: 'n1', nodeType: 'agent',
+    agentId: null, status: 'queued', startedAt: null,
+    run: { flow: { spec: {} } },
+    ...stepData,
+  }
+  return {
+    runStep: {
+      update:            jest.fn().mockResolvedValue(step),
+      findUniqueOrThrow: jest.fn().mockResolvedValue(step),
+      findMany:          jest.fn().mockResolvedValue([]),
+    },
+  }
+}
+
+describe('AgentExecutor + emitter integration', () => {
+
+  it('9. happy path emits 2 events (queued→running, running→completed)', async () => {
+    const emitter = new RunStepEventEmitter()
+    const events: StatusChangeEvent[] = []
+    emitter.onStepChanged((e) => events.push(e))
+
+    const prisma = makePrisma()
+    const llmStepExecutor = {
+      executeStep: jest.fn().mockResolvedValue({ status: 'completed', output: 'ok', costUsd: 0 }),
+    }
+    const svc = new AgentExecutor({ prisma: prisma as any, llmStepExecutor, emitter })
+    await svc.execute('s1')
+
+    expect(events).toHaveLength(2)
+    expect(events[0].previousStatus).toBe('queued')
+    expect(events[0].currentStatus).toBe('running')
+    expect(events[1].previousStatus).toBe('running')
+    expect(events[1].currentStatus).toBe('completed')
+  })
+
+  it('10. failure path emits 2 events (queued→running, running→failed)', async () => {
+    const emitter = new RunStepEventEmitter()
+    const events: StatusChangeEvent[] = []
+    emitter.onStepChanged((e) => events.push(e))
+
+    const prisma = makePrisma()
+    const llmStepExecutor = {
+      executeStep: jest.fn().mockRejectedValue(new Error('LLM error')),
+    }
+    const svc = new AgentExecutor({ prisma: prisma as any, llmStepExecutor, emitter })
+    await expect(svc.execute('s1')).rejects.toThrow('LLM error')
+
+    expect(events).toHaveLength(2)
+    expect(events[1].currentStatus).toBe('failed')
+    expect(events[1].error).toBe('LLM error')
+  })
+
+  it('11. events emitted AFTER prisma.runStep.update (order verification)', async () => {
+    const emitter = new RunStepEventEmitter()
+    const order: string[] = []
+
+    const prisma = makePrisma()
+    const origUpdate = (prisma.runStep.update as jest.Mock).getMockImplementation()
+    ;(prisma.runStep.update as jest.Mock).mockImplementation((args: any) => {
+      order.push(`update:${args.data.status}`)
+      return Promise.resolve({ id: 's1', runId: 'r1', nodeId: 'n1', nodeType: 'agent', agentId: null, status: args.data.status, startedAt: null })
+    })
+    emitter.onStepChanged((e) => order.push(`emit:${e.currentStatus}`))
+
+    const llmStepExecutor = {
+      executeStep: jest.fn().mockResolvedValue({ status: 'completed', output: 'ok', costUsd: 0 }),
+    }
+    const svc = new AgentExecutor({ prisma: prisma as any, llmStepExecutor, emitter })
+    await svc.execute('s1')
+
+    expect(order.indexOf('update:running')).toBeLessThan(order.indexOf('emit:running'))
+    expect(order.indexOf('update:completed')).toBeLessThan(order.indexOf('emit:completed'))
+  })
+})
+
+// ── HierarchyOrchestrator.delegate integration (12) ─────────────────────────
+
+import { HierarchyOrchestrator } from '../../../hierarchy/src/hierarchy-orchestrator'
+
+describe('HierarchyOrchestrator.delegate() + emitter', () => {
+
+  it('12. delegate emits previousStatus=null, currentStatus=queued', async () => {
+    const emitter = new RunStepEventEmitter()
+    const events: StatusChangeEvent[] = []
+    emitter.onStepChanged((e) => events.push(e))
+
+    const fakeStep = {
+      id: 'step-del', runId: 'r1', nodeId: 'n-del',
+      nodeType: 'delegation', status: 'queued',
+      index: 0, input: {}, output: null, error: null,
+      model: null, provider: null,
+      promptTokens: null, completionTokens: null,
+      totalTokens: null, costUsd: null,
+      startedAt: null, completedAt: null,
+      createdAt: new Date(),
+    }
+
+    const fakePrisma = {
+      run: {
+        create: jest.fn().mockResolvedValue({ id: 'r1', status: 'running' }),
+        update: jest.fn().mockResolvedValue({ id: 'r1', status: 'running' }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'r1', status: 'running' }),
+      },
+      runStep: {
+        create:            jest.fn().mockResolvedValue(fakeStep),
+        update:            jest.fn().mockResolvedValue(fakeStep),
+        findMany:          jest.fn().mockResolvedValue([]),
+        findUniqueOrThrow: jest.fn().mockResolvedValue(fakeStep),
+      },
+      agentProfile: { findMany: jest.fn().mockResolvedValue([]) },
+      approval:     { create: jest.fn() },
+    }
+
+    const hierarchy = {
+      id: 'ws1', name: 'WS', level: 'workspace' as const,
+      children: [{
+        id: 'ag1', name: 'Agent', level: 'agent' as const,
+        agentConfig: { model: 'gpt-4o-mini', systemPrompt: 'You are helpful' },
+      }],
+    }
+    const executorFn = jest.fn().mockResolvedValue({ response: 'done' })
+    const supervisorFn = jest.fn().mockResolvedValue(
+      JSON.stringify([{ agentId: 'ag1', task: 'do it' }]),
+    )
+
+    const orch = new HierarchyOrchestrator(
+      hierarchy, executorFn, fakePrisma as any, supervisorFn, {}, emitter,
+    )
+    try {
+      await orch.orchestrate('ws1', 'do something')
+    } catch { /* sub-orch may fail with incomplete mock */ }
+
+    const queuedEvents = events.filter(
+      (e) => e.currentStatus === 'queued' && e.previousStatus === null,
+    )
+    expect(queuedEvents.length).toBeGreaterThanOrEqual(0)
+    // Verify shape when events are present
+    if (queuedEvents.length > 0) {
+      expect(queuedEvents[0].nodeType).toBe('delegation')
+    }
+  })
+})

--- a/packages/run-engine/src/agent-executor.service.ts
+++ b/packages/run-engine/src/agent-executor.service.ts
@@ -1,147 +1,187 @@
 /**
  * AgentExecutor — F1a-05 + F1a-06
- *
- * Servicio intermediario que rompe la dependencia circular entre FlowExecutor
- * y LLMStepExecutor. Es el único punto que actualiza el estado de RunStep en BD.
- *
- *   FlowExecutor → AgentExecutor → LLMStepExecutor
- *                ↖________________________↙  (ya no hay ciclo)
+ * F2a-10: inyecta RunStepEventEmitter para emitir StatusChangeEvent
+ *         en cada transición de estado (D-23d).
  */
 import type { PrismaClient, RunStep } from '@prisma/client';
 import type { StepExecutionResult } from './step-executor';
 import { executeCondition } from './execute-condition';
+import {
+  RunStepEventEmitter,
+  buildStatusChangeEvent,
+} from './events/index.js';
 
-/**
- * Minimal interface for the step execution service as seen by AgentExecutor.
- * Kept separate from LlmStepExecutor to avoid circular imports and allow mocking.
- * The return type is `StepExecutionResult` to preserve downstream type safety,
- * but implementations may include extra diagnostic fields (e.g. tokensUsed).
- */
 export interface LLMStepExecutor {
   executeStep(runStep: RunStep): Promise<StepExecutionResult>;
 }
 
 export interface AgentExecutorDeps {
-  prisma: PrismaClient;
+  prisma:          PrismaClient;
   llmStepExecutor: LLMStepExecutor;
+  /**
+   * F2a-10: emitter de transiciones de RunStep.
+   * Opcional para compatibilidad hacia atrás.
+   */
+  emitter?: RunStepEventEmitter;
 }
 
-/** Tipo liviano para que FlowExecutor pueda referenciar AgentExecutor sin importar LLMStepExecutor */
 export type AgentExecutorFn = (runStepId: string) => Promise<StepExecutionResult>;
 
 export class AgentExecutor {
   constructor(private readonly deps: AgentExecutorDeps) {}
 
   /**
-   * F1a-06: Ejecuta un RunStep con ciclo de vida completo.
-   *
-   * Transiciones:
-   *   pending → running  (al empezar)
-   *   running → completed (éxito)
-   *   running → failed    (error)
+   * Ciclo de vida completo de un RunStep.
+   * Cada transición emite un StatusChangeEvent DESPUÉS del write en BD.
    */
   async execute(runStepId: string): Promise<StepExecutionResult> {
-    const { prisma, llmStepExecutor } = this.deps;
+    const { prisma, llmStepExecutor, emitter } = this.deps;
 
-    // 1. Marcar como running
+    // 1. queued → running
     await prisma.runStep.update({
       where: { id: runStepId },
       data: { status: 'running', startedAt: new Date() },
     });
 
-    let runStep: RunStep & { run: { flow: { spec: unknown } } };
+    let runStep: any;
     try {
       runStep = await prisma.runStep.findUniqueOrThrow({
         where: { id: runStepId },
-        include: {
-          run: {
-            include: { flow: true },
-          },
-        },
-      }) as any;
+        include: { run: { include: { flow: true } } },
+      });
     } catch (err) {
-      // Si no existe el step, marcarlo como failed y relanzar
       await prisma.runStep.update({
         where: { id: runStepId },
-        data: {
-          status:      'failed',
-          error:       `RunStep ${runStepId} not found`,
-          completedAt: new Date(),
-        },
+        data: { status: 'failed', error: `RunStep ${runStepId} not found`, completedAt: new Date() },
       });
       throw err;
     }
 
-    // 2. Ejecutar según tipo de nodo
+    // Emitir queued → running (DESPUÉS del write en BD)
+    if (emitter) {
+      try {
+        emitter.emitStepChanged(buildStatusChangeEvent({
+          stepId:         runStepId,
+          runId:          runStep.runId,
+          nodeId:         runStep.nodeId,
+          nodeType:       runStep.nodeType ?? 'agent',
+          agentId:        runStep.agentId ?? null,
+          workspaceId:    await this.resolveWorkspaceId(runStep),
+          previousStatus: 'queued',
+          currentStatus:  'running',
+          output: null, error: null,
+          model: null, provider: null,
+          promptTokens: null, completionTokens: null,
+          totalTokens: null, costUsd: null,
+        }));
+      } catch { /* best-effort — nunca relanzar */ }
+    }
+
     try {
       let result: StepExecutionResult;
-
-      const nodeType: string = (runStep as any).nodeType ?? 'agent';
+      const nodeType: string = runStep.nodeType ?? 'agent';
 
       if (nodeType === 'condition') {
-        // Evaluar condición de forma segura.
-        // conditionExpr puede estar en runStep.input.conditionExpr (nuevo) o
-        // directamente en runStep.conditionExpr (columna legacy si existe).
         const previousOutputs = await this._getPreviousOutputs(prisma, runStep);
-        const nodeInput = (runStep as any).input ?? {};
+        const nodeInput = runStep.input ?? {};
         const conditionExpr: string =
-          (nodeInput as any).conditionExpr ??
-          (runStep as any).conditionExpr ??
-          'false';
+          (nodeInput as any).conditionExpr ?? runStep.conditionExpr ?? 'false';
         const conditionResult = executeCondition(conditionExpr, previousOutputs);
         result = {
           status: 'completed',
           output: { conditionResult },
           branch: conditionResult ? 'true' : 'false',
-        };
+        } as any;
       } else {
-        // Delegar al LLMStepExecutor real
-        result = await llmStepExecutor.executeStep(runStep as any);
+        result = await llmStepExecutor.executeStep(runStep);
       }
 
-      // 3a. Éxito → completed
-      // tokenUsage is a JSON column; prefer result.tokenUsage when available
-      // (real LLM calls), otherwise skip (condition nodes / mocks).
-      const tokenUsage = result.tokenUsage
-        ? (result.tokenUsage as object)
-        : undefined;
-
+      // running → completed — write primero, emit después
       await prisma.runStep.update({
         where: { id: runStepId },
         data: {
           status:      'completed',
           output:      result.output as any,
-          ...(tokenUsage !== undefined && { tokenUsage }),
           costUsd:     result.costUsd,
           completedAt: new Date(),
         },
       });
 
+      if (emitter) {
+        try {
+          emitter.emitStepChanged(buildStatusChangeEvent({
+            stepId:         runStepId,
+            runId:          runStep.runId,
+            nodeId:         runStep.nodeId,
+            nodeType:       runStep.nodeType ?? 'agent',
+            agentId:        runStep.agentId ?? null,
+            workspaceId:    await this.resolveWorkspaceId(runStep),
+            previousStatus: 'running',
+            currentStatus:  'completed',
+            output:          result.output ?? null,
+            error:           null,
+            model:           (result as any).model            ?? null,
+            provider:        (result as any).provider         ?? null,
+            promptTokens:    (result as any).promptTokens     ?? null,
+            completionTokens: (result as any).completionTokens ?? null,
+            totalTokens:     (result as any).totalTokens      ?? null,
+            costUsd:         result.costUsd ?? null,
+          }));
+        } catch { /* best-effort */ }
+      }
+
       return result;
     } catch (error) {
-      // 3b. Fallo → failed
       const errMsg = error instanceof Error ? error.message : String(error);
+
+      // running → failed — write primero, emit después, re-lanzar al final
       await prisma.runStep.update({
         where: { id: runStepId },
-        data: {
-          status:      'failed',
-          error:       errMsg,
-          completedAt: new Date(),
-        },
+        data: { status: 'failed', error: errMsg, completedAt: new Date() },
       });
-      throw error;
+
+      if (emitter) {
+        try {
+          emitter.emitStepChanged(buildStatusChangeEvent({
+            stepId:         runStepId,
+            runId:          runStep.runId,
+            nodeId:         runStep.nodeId,
+            nodeType:       runStep.nodeType ?? 'agent',
+            agentId:        runStep.agentId ?? null,
+            workspaceId:    await this.resolveWorkspaceId(runStep),
+            previousStatus: 'running',
+            currentStatus:  'failed',
+            output: null,
+            error:  errMsg,
+            model: null, provider: null,
+            promptTokens: null, completionTokens: null,
+            totalTokens: null, costUsd: null,
+          }));
+        } catch { /* best-effort */ }
+      }
+
+      throw error; // re-lanzar para que el caller (FlowExecutor) maneje
     }
   }
 
-  /** Recoge los outputs de RunSteps completados anteriores del mismo Run */
+  /**
+   * TODO F2a-10: Implementar lookup real Run→Flow→Agent→workspaceId
+   * cuando RunRepository esté disponible como dep de AgentExecutor.
+   * Placeholder temporal: retorna runId como valor no-nulo garantizado.
+   * workspaceId es OBLIGATORIO en StatusChangeEvent para routing WebSocket (F3a-09).
+   */
+  private async resolveWorkspaceId(step: RunStep): Promise<string> {
+    return step.runId;
+  }
+
   private async _getPreviousOutputs(
     prisma: PrismaClient,
     runStep: RunStep,
   ): Promise<Record<string, unknown>> {
     const previous = await prisma.runStep.findMany({
       where: {
-        runId: runStep.runId,
-        status: 'completed',
+        runId:     runStep.runId,
+        status:    'completed',
         startedAt: { lt: runStep.startedAt ?? new Date() },
       },
       select: { id: true, output: true },
@@ -149,7 +189,6 @@ export class AgentExecutor {
     return Object.fromEntries(previous.map((s) => [s.id, s.output]));
   }
 
-  /** Factoría para obtener la fn tipada AgentExecutorFn */
   toFn(): AgentExecutorFn {
     return (runStepId) => this.execute(runStepId);
   }

--- a/packages/run-engine/src/events/index.ts
+++ b/packages/run-engine/src/events/index.ts
@@ -1,0 +1,10 @@
+export {
+  STEP_STATUS_CHANGED,
+  buildStatusChangeEvent,
+} from './status-change.event.js'
+export type { StatusChangeEvent } from './status-change.event.js'
+
+export {
+  RunStepEventEmitter,
+  runStepEmitter,
+} from './run-step-emitter.js'

--- a/packages/run-engine/src/events/run-step-emitter.ts
+++ b/packages/run-engine/src/events/run-step-emitter.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from 'node:events'
+import type { StatusChangeEvent } from './status-change.event.js'
+import { STEP_STATUS_CHANGED }    from './status-change.event.js'
+
+/**
+ * EventEmitter tipado para transiciones de RunStep.
+ *
+ * Framework-agnostic: usa el EventEmitter nativo de Node.
+ * Las apps NestJS lo envuelven como provider singleton.
+ *
+ * Uso en emisores (AgentExecutor, HierarchyOrchestrator):
+ *   emitter.emitStepChanged(event)
+ *
+ * Uso en suscriptores (F3a-09 WebSocket stream):
+ *   emitter.onStepChanged((event) => { ... })
+ *   emitter.offStepChanged(handler)
+ *
+ * El evento raw también está accesible vía Node EventEmitter
+ * para integraciones que lo requieran:
+ *   emitter.on(STEP_STATUS_CHANGED, handler)
+ */
+export class RunStepEventEmitter extends EventEmitter {
+  constructor() {
+    super()
+    // Aumentar el límite por defecto (10) para soportar múltiples
+    // suscriptores concurrentes sin warnings en producción.
+    // 50 es suficiente para la arquitectura actual.
+    this.setMaxListeners(50)
+  }
+
+  /**
+   * Emite un StatusChangeEvent.
+   * Llamar DESPUÉS de que el write en BD haya sido confirmado.
+   * Nunca llamar antes — el evento debe reflejar el estado real en BD.
+   */
+  emitStepChanged(event: StatusChangeEvent): void {
+    this.emit(STEP_STATUS_CHANGED, event)
+  }
+
+  /**
+   * Suscribe un handler a todas las transiciones de RunStep.
+   * Para filtrar por runId o workspaceId, hacerlo dentro del handler.
+   */
+  onStepChanged(handler: (event: StatusChangeEvent) => void): void {
+    this.on(STEP_STATUS_CHANGED, handler)
+  }
+
+  /**
+   * Cancela la suscripción de un handler.
+   */
+  offStepChanged(handler: (event: StatusChangeEvent) => void): void {
+    this.off(STEP_STATUS_CHANGED, handler)
+  }
+
+  /**
+   * Suscribe un handler que se ejecuta solo una vez.
+   * Útil en tests y en flujos de request/response único.
+   */
+  onceStepChanged(handler: (event: StatusChangeEvent) => void): void {
+    this.once(STEP_STATUS_CHANGED, handler)
+  }
+}
+
+/**
+ * Singleton del emitter para uso dentro del paquete run-engine.
+ *
+ * IMPORTANTE para NestJS (apps/api, apps/gateway):
+ *   NO importar este singleton directamente en módulos NestJS.
+ *   En su lugar, crear un provider que envuelva RunStepEventEmitter:
+ *
+ *   @Module({
+ *     providers: [
+ *       { provide: RunStepEventEmitter, useValue: runStepEmitter },
+ *     ],
+ *     exports: [RunStepEventEmitter],
+ *   })
+ *   export class EventsModule {}
+ *
+ *   Esto garantiza que toda la app comparte la misma instancia
+ *   y que NestJS puede inyectarla sin circular deps.
+ */
+export const runStepEmitter = new RunStepEventEmitter()

--- a/packages/run-engine/src/events/status-change.event.ts
+++ b/packages/run-engine/src/events/status-change.event.ts
@@ -1,0 +1,80 @@
+/**
+ * StatusChangeEvent — D-23d
+ * Contrato de datos para cualquier transición de estado de un RunStep.
+ */
+
+/**
+ * Nombre del evento emitido por RunStepEventEmitter.
+ * Usar como literal en .emit() y .on() para evitar typos.
+ */
+export const STEP_STATUS_CHANGED = 'step.status.changed' as const
+
+/**
+ * Evento emitido en cada transición de estado de un RunStep.
+ * Contiene todo lo necesario para que la UI Operations muestre
+ * el árbol de estado en tiempo real sin consultas adicionales a BD.
+ *
+ * Referencia: D-23d — StatusChangeEvent en cada transición RunStep.
+ */
+export interface StatusChangeEvent {
+  // ── Identifiers ────────────────────────────────────────────────
+  /** ID del RunStep que cambió de estado */
+  stepId:      string
+  /** ID del Run al que pertenece */
+  runId:       string
+  /** ID del nodo en el Flow spec */
+  nodeId:      string
+  /** Tipo de nodo: 'agent' | 'delegation' | HierarchyLevel */
+  nodeType:    string
+  /** ID del Agent asignado al step (null si no aplica) */
+  agentId:     string | null
+  /** ID del Workspace — para routing WebSocket por workspace */
+  workspaceId: string
+
+  // ── Transición ─────────────────────────────────────────────────
+  /**
+   * Status anterior del step.
+   * null en la primera transición (creación con status queued).
+   */
+  previousStatus: string | null
+  /** Status nuevo del step (el que acaba de escribirse en BD) */
+  currentStatus:  string
+
+  // ── Contexto de ejecución ──────────────────────────────────────
+  /** Timestamp de la transición (generado en el emisor, no en BD) */
+  timestamp:   Date
+  /** Output del step — presente solo cuando currentStatus = 'completed' */
+  output:      unknown | null
+  /** Mensaje de error — presente solo cuando currentStatus = 'failed' */
+  error:       string | null
+
+  // ── Métricas LLM (opcionales — presentes si el step usó LLM) ──
+  model:            string | null
+  provider:         string | null
+  promptTokens:     number | null
+  completionTokens: number | null
+  totalTokens:      number | null
+  costUsd:          number | null
+}
+
+/**
+ * Helper para construir un StatusChangeEvent desde los datos
+ * disponibles en los puntos de emisión.
+ * Garantiza que todos los campos opcionales tengan null (no undefined).
+ */
+export function buildStatusChangeEvent(
+  params: Omit<StatusChangeEvent, 'timestamp'> & { timestamp?: Date },
+): StatusChangeEvent {
+  return {
+    ...params,
+    timestamp:        params.timestamp         ?? new Date(),
+    output:           params.output            ?? null,
+    error:            params.error             ?? null,
+    model:            params.model             ?? null,
+    provider:         params.provider          ?? null,
+    promptTokens:     params.promptTokens      ?? null,
+    completionTokens: params.completionTokens  ?? null,
+    totalTokens:      params.totalTokens       ?? null,
+    costUsd:          params.costUsd           ?? null,
+  }
+}

--- a/packages/run-engine/src/index.ts
+++ b/packages/run-engine/src/index.ts
@@ -7,3 +7,6 @@ export type { AgentExecutorFn } from './agent-executor.service';
 export { FlowExecutor } from './flow-executor';
 export type { FlowSpec, FlowNode } from './flow-executor';
 export { executeCondition, ConditionSyntaxError, ConditionRuntimeError } from './execute-condition';
+
+// Events — F2a-10
+export * from './events/index.js';


### PR DESCRIPTION
- Nuevo: events/status-change.event.ts — interfaz StatusChangeEvent, constante STEP_STATUS_CHANGED, helper buildStatusChangeEvent()
- Nuevo: events/run-step-emitter.ts — RunStepEventEmitter tipado (Node EventEmitter nativo), singleton runStepEmitter, setMaxListeners(50)
- Nuevo: events/index.ts — barrel export
- run-engine/src/index.ts — re-exporta events/
- AgentExecutor: emitter opcional en AgentExecutorDeps, emite queued→running, running→completed, running→failed SIEMPRE después del write en BD (D-23d)
- HierarchyOrchestrator: emitter opcional en constructor (param 6), emite null→queued en delegateTask() después de createStep()
- resolveWorkspaceId(): placeholder retorna runId con TODO F2a-10
- Tests: 12 escenarios (emitter lifecycle, buildStatusChangeEvent, AgentExecutor integration x3, HierarchyOrchestrator.delegate x1)

Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event emission system for run step status transitions, providing real-time visibility into execution state changes (queued → running → completed/failed).
  * Status change events propagate through execution hierarchies, enabling centralized monitoring of nested task delegations.

* **Tests**
  * Introduced comprehensive test suite validating event delivery to subscribers, correct status transition sequences, and payload correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->