### PR TITLE
feat(F2b-02): add findOrchestratorAgent() to workspace, department & …

### DIFF
--- a/packages/run-engine/src/repositories/agency.repository.ts
+++ b/packages/run-engine/src/repositories/agency.repository.ts
@@ -116,6 +116,12 @@ export class AgencyRepository {
    * Nunca itera colecciones — navega solo por el nodo orquestador de cada nivel.
    */
   async findOrchestratorAgent(agencyId: string) {
+    const agency = await this.prisma.agency.findFirst({
+      where:  { id: agencyId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!agency) return null
+
     // 1. Department orquestador de la agency
     const department = await this.prisma.department.findFirst({
       where:  { agencyId, isLevelOrchestrator: true, deletedAt: null },

--- a/packages/run-engine/src/repositories/agency.repository.ts
+++ b/packages/run-engine/src/repositories/agency.repository.ts
@@ -12,7 +12,7 @@
 
 import type { PrismaClient } from '@prisma/client'
 
-// ── DTOs ──────────────────────────────────────────────────────────────────────
+// ── DTOs ───────────────────────────────────────────────────────────────────
 
 export interface CreateAgencyInput {
   name:            string
@@ -34,12 +34,12 @@ export interface FindAgenciesOptions {
   offset?: number
 }
 
-// ── Repository ────────────────────────────────────────────────────────────────
+// ── Repository ──────────────────────────────────────────────────────────────────
 
 export class AgencyRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
-  // ── Write ─────────────────────────────────────────────────────────────
+  // ── Write ───────────────────────────────────────────────────────────────
 
   async create(input: CreateAgencyInput) {
     return this.prisma.agency.create({
@@ -73,7 +73,7 @@ export class AgencyRepository {
     })
   }
 
-  // ── Read ──────────────────────────────────────────────────────────────
+  // ── Read ─────────────────────────────────────────────────────────────────
 
   async findById(id: string) {
     return this.prisma.agency.findFirst({
@@ -104,6 +104,35 @@ export class AgencyRepository {
       orderBy: { createdAt: 'asc' },
       take:    opts.limit  ?? 50,
       skip:    opts.offset ?? 0,
+    })
+  }
+
+  /**
+   * [F2b-02] Retorna el Agent con isLevelOrchestrator = true
+   * dentro de la Agency dada, navegando la cadena completa:
+   *   Agency → Department orquestador → Workspace orquestador → Agent orquestador
+   *
+   * Devuelve null en cualquier nivel si la cadena está incompleta.
+   * Nunca itera colecciones — navega solo por el nodo orquestador de cada nivel.
+   */
+  async findOrchestratorAgent(agencyId: string) {
+    // 1. Department orquestador de la agency
+    const department = await this.prisma.department.findFirst({
+      where:  { agencyId, isLevelOrchestrator: true, deletedAt: null },
+      select: { id: true },
+    })
+    if (!department) return null
+
+    // 2. Workspace orquestador de ese department
+    const workspace = await this.prisma.workspace.findFirst({
+      where:  { departmentId: department.id, isLevelOrchestrator: true, deletedAt: null },
+      select: { id: true },
+    })
+    if (!workspace) return null
+
+    // 3. Agent orquestador dentro de ese workspace
+    return this.prisma.agent.findFirst({
+      where: { workspaceId: workspace.id, isLevelOrchestrator: true, deletedAt: null },
     })
   }
 

--- a/packages/run-engine/src/repositories/department.repository.ts
+++ b/packages/run-engine/src/repositories/department.repository.ts
@@ -115,6 +115,12 @@ export class DepartmentRepository {
    * Nunca itera colecciones — navega solo por el nodo orquestador de cada nivel.
    */
   async findOrchestratorAgent(departmentId: string) {
+    const department = await this.prisma.department.findFirst({
+      where:  { id: departmentId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!department) return null
+
     // 1. Workspace orquestador del department
     const workspace = await this.prisma.workspace.findFirst({
       where:  { departmentId, isLevelOrchestrator: true, deletedAt: null },

--- a/packages/run-engine/src/repositories/department.repository.ts
+++ b/packages/run-engine/src/repositories/department.repository.ts
@@ -13,7 +13,7 @@
 
 import type { PrismaClient } from '@prisma/client'
 
-// ── DTOs ──────────────────────────────────────────────────────────────────────
+// ── DTOs ───────────────────────────────────────────────────────────────────
 
 export interface CreateDepartmentInput {
   agencyId:             string
@@ -35,12 +35,12 @@ export interface FindDepartmentsOptions {
   offset?: number
 }
 
-// ── Repository ────────────────────────────────────────────────────────────────
+// ── Repository ──────────────────────────────────────────────────────────────────
 
 export class DepartmentRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
-  // ── Write ─────────────────────────────────────────────────────────────
+  // ── Write ───────────────────────────────────────────────────────────────
 
   async create(input: CreateDepartmentInput) {
     return this.prisma.department.create({
@@ -73,7 +73,7 @@ export class DepartmentRepository {
     })
   }
 
-  // ── Read ──────────────────────────────────────────────────────────────
+  // ── Read ─────────────────────────────────────────────────────────────────
 
   async findById(id: string) {
     return this.prisma.department.findFirst({
@@ -103,6 +103,28 @@ export class DepartmentRepository {
   async findOrchestrator(agencyId: string) {
     return this.prisma.department.findFirst({
       where: { agencyId, isLevelOrchestrator: true, deletedAt: null },
+    })
+  }
+
+  /**
+   * [F2b-02] Retorna el Agent con isLevelOrchestrator = true
+   * dentro del Department dado, navegando la cadena:
+   *   Department → Workspace orquestador → Agent orquestador
+   *
+   * Devuelve null en cualquier nivel si la cadena está incompleta.
+   * Nunca itera colecciones — navega solo por el nodo orquestador de cada nivel.
+   */
+  async findOrchestratorAgent(departmentId: string) {
+    // 1. Workspace orquestador del department
+    const workspace = await this.prisma.workspace.findFirst({
+      where:  { departmentId, isLevelOrchestrator: true, deletedAt: null },
+      select: { id: true },
+    })
+    if (!workspace) return null
+
+    // 2. Agent orquestador dentro de ese workspace
+    return this.prisma.agent.findFirst({
+      where: { workspaceId: workspace.id, isLevelOrchestrator: true, deletedAt: null },
     })
   }
 

--- a/packages/run-engine/src/repositories/workspace.repository.ts
+++ b/packages/run-engine/src/repositories/workspace.repository.ts
@@ -121,6 +121,12 @@ export class WorkspaceRepository {
    * Nunca usa findMany — el partial unique index C-20 garantiza unicidad.
    */
   async findOrchestratorAgent(workspaceId: string) {
+    const workspace = await this.prisma.workspace.findFirst({
+      where:  { id: workspaceId, deletedAt: null },
+      select: { id: true },
+    })
+    if (!workspace) return null
+
     return this.prisma.agent.findFirst({
       where: { workspaceId, isLevelOrchestrator: true, deletedAt: null },
     })

--- a/packages/run-engine/src/repositories/workspace.repository.ts
+++ b/packages/run-engine/src/repositories/workspace.repository.ts
@@ -13,7 +13,7 @@
 
 import type { PrismaClient } from '@prisma/client'
 
-// ── DTOs ──────────────────────────────────────────────────────────────────────
+// ── DTOs ───────────────────────────────────────────────────────────────────
 
 export interface CreateWorkspaceInput {
   departmentId:         string
@@ -37,12 +37,12 @@ export interface FindWorkspacesOptions {
   offset?: number
 }
 
-// ── Repository ────────────────────────────────────────────────────────────────
+// ── Repository ──────────────────────────────────────────────────────────────────
 
 export class WorkspaceRepository {
   constructor(private readonly prisma: PrismaClient) {}
 
-  // ── Write ─────────────────────────────────────────────────────────────
+  // ── Write ───────────────────────────────────────────────────────────────
 
   async create(input: CreateWorkspaceInput) {
     return this.prisma.workspace.create({
@@ -77,7 +77,7 @@ export class WorkspaceRepository {
     })
   }
 
-  // ── Read ──────────────────────────────────────────────────────────────
+  // ── Read ─────────────────────────────────────────────────────────────────
 
   async findById(id: string) {
     return this.prisma.workspace.findFirst({
@@ -107,6 +107,22 @@ export class WorkspaceRepository {
   async findOrchestrator(departmentId: string) {
     return this.prisma.workspace.findFirst({
       where: { departmentId, isLevelOrchestrator: true, deletedAt: null },
+    })
+  }
+
+  /**
+   * [F2b-02] Retorna el Agent con isLevelOrchestrator = true
+   * dentro del Workspace dado.
+   *
+   * Es la hoja final de la cadena de navegación jerárquica:
+   *   Agency → Department → Workspace → Agent (este método)
+   *
+   * Devuelve null si el workspace no tiene ningún agente orquestador activo.
+   * Nunca usa findMany — el partial unique index C-20 garantiza unicidad.
+   */
+  async findOrchestratorAgent(workspaceId: string) {
+    return this.prisma.agent.findFirst({
+      where: { workspaceId, isLevelOrchestrator: true, deletedAt: null },
     })
   }
 


### PR DESCRIPTION
…agency repos

- WorkspaceRepository.findOrchestratorAgent(workspaceId): queries agent with isLevelOrchestrator=true inside the given workspace (single Prisma call)
- DepartmentRepository.findOrchestratorAgent(departmentId): resolves orchestrator workspace then orchestrator agent (2 Prisma calls, no findMany)
- AgencyRepository.findOrchestratorAgent(agencyId): resolves orchestrator department → workspace → agent (3 Prisma calls, no findMany)
- All methods return null at each missing level, never throw on absent data
- No prisma.*.findMany() used; navigation is strictly via isLevelOrchestrator

Closes #48

✅ **Implementación completa — F2b-01**

## Commit entregado

**SHA:** `e7067a3ecfb6dd3670769d5650ad01ed0831d4ab`  
**Rama:** `feat/phase-F2b-propagacion-perfiles`  
**Repositorio:** [[lssmanager/agent-visualstudio](https://github.com/lssmanager/agent-visualstudio/commit/e7067a3ecfb6dd3670769d5650ad01ed0831d4ab)](https://github.com/lssmanager/agent-visualstudio/commit/e7067a3ecfb6dd3670769d5650ad01ed0831d4ab)

***

## Qué se implementó

### 1. `packages/profile-engine/src/profile-propagator.service.ts`
Se añadieron dos elementos sobre el SHA original `19cf478c`:

- **`PropagateUpResult`** — interfaz nueva exportada con los campos `updated: ResolvedProfile[]` y `skipped: string[]`
- **`propagateUp(agentId, input)`** — método nuevo en `ProfilePropagatorService` que navega la jerarquía `Agent → Workspace → Department → Agency` y llama a `this.propagate()` **únicamente** sobre el `orchestratorId` de cada nivel, respetando la regla D-24f

Las restricciones absolutas se cumplen: no hay ninguna llamada a `prisma.agent.findMany()`, no se itera sobre colecciones de agentes, y el método `propagate()` existente no fue modificado.

### 2. `packages/profile-engine/src/index.ts`
Se añadió `PropagateUpResult` al bloque de exports existente del servicio, manteniéndolo junto a los demás tipos del mismo archivo.

### 3. `packages/profile-engine/src/__tests__/profile-propagator-propagate-up.test.ts`
Archivo de test nuevo con **7 casos** cubriendo todos los items del criterio de cierre:

| # | Caso |
|---|------|
| 1 | Propaga al workspace orchestrator cuando existe y es distinto al `agentId` |
| 2 | Propaga a workspace + department + agency cuando todos tienen `orchestratorId` |
| 3 | Añade a `skipped` cuando `workspace.orchestratorId` es `null` |
| 4 | Añade a `skipped` cuando `workspace.orchestratorId === agentId` (anti-loop) |
| 5 | No invoca `department.findUnique` ni `agency.findUnique` cuando `departmentId` es null |
| 6 | Lanza `Error` si el agente no existe en BD |
| 7 | `updated` contiene perfiles en orden `workspace → department → agency` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Can now locate orchestrator agents at agency, department, and workspace levels, with clear absent-agent handling to improve reliability when no orchestrator is present.

* **Style**
  * Minor comment/header formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->