### PR TITLE
feat(F2b-01): add propagateUp() — orchestrators-only profile propagation

### DIFF
--- a/packages/profile-engine/src/__tests__/profile-propagator-propagate-up.test.ts
+++ b/packages/profile-engine/src/__tests__/profile-propagator-propagate-up.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for ProfilePropagatorService.propagateUp() — F2b-01
+ *
+ * Verifica que propagateUp() solo propaga al orchestratorId de cada nivel
+ * y nunca itera sobre colecciones de agentes (D-24f).
+ *
+ * Usa Prisma completamente mockeado con jest.fn() — no instancia real.
+ */
+
+import { ProfilePropagatorService } from '../profile-propagator.service.js'
+import type { PropagateProfileInput, ResolvedProfile } from '../profile-propagator.service.js'
+
+// ── Helpers para construir mocks ──────────────────────────────────────────
+
+const NOW = new Date('2024-01-01T00:00:00.000Z')
+
+function makeResolvedProfile(agentId: string, version = 1): ResolvedProfile {
+  return {
+    agentId,
+    version,
+    systemPrompt:   'mock prompt',
+    persona:        {},
+    knowledgeBase:  [],
+    responseFormat: null,
+    contextWindow:  8192,
+    memoryEnabled:  false,
+    propagatedAt:   NOW,
+  }
+}
+
+const INPUT: PropagateProfileInput = { systemPrompt: 'test prompt' }
+
+// ── Mock factory ─────────────────────────────────────────────────────────
+
+function buildPrismaMock(overrides: {
+  agent?:       { workspaceId: string } | null
+  workspace?:   { id: string; orchestratorId: string | null; departmentId: string | null } | null
+  department?:  { id: string; orchestratorId: string | null; agencyId: string | null } | null
+  agency?:      { id: string; orchestratorId: string | null } | null
+  agentProfile?: unknown
+}) {
+  return {
+    agent: {
+      findUnique: jest.fn().mockResolvedValue(overrides.agent ?? null),
+    },
+    workspace: {
+      findUnique: jest.fn().mockResolvedValue(overrides.workspace ?? null),
+    },
+    department: {
+      findUnique: jest.fn().mockResolvedValue(overrides.department ?? null),
+    },
+    agency: {
+      findUnique: jest.fn().mockResolvedValue(overrides.agency ?? null),
+    },
+    agentProfile: {
+      findUnique: jest.fn().mockResolvedValue(overrides.agentProfile ?? null),
+      upsert:     jest.fn(),
+    },
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('ProfilePropagatorService.propagateUp()', () => {
+  const AGENT_ID = 'agent-1'
+  const WS_ORCH  = 'ws-orchestrator'
+  const DEP_ORCH = 'dep-orchestrator'
+  const AGC_ORCH = 'agc-orchestrator'
+
+  // ── Case 1: propaga al workspace orchestrator cuando existe y es distinto al agentId ──
+  it('propaga al orchestratorId del workspace cuando existe y es distinto al agentId', async () => {
+    const prisma = buildPrismaMock({
+      agent:        { workspaceId: 'ws-1' },
+      workspace:    { id: 'ws-1', orchestratorId: WS_ORCH, departmentId: null },
+      agentProfile: null,
+    })
+    // Mock the profile returned by upsert (used internally by propagate())
+    prisma.agentProfile.upsert.mockResolvedValue({
+      systemPrompt: 'test prompt', persona: {}, knowledgeBase: [],
+      responseFormat: null, contextWindow: 8192, memoryEnabled: false,
+      version: 1, propagatedAt: NOW,
+    })
+    // propagate() calls agent.findUnique too — make it return valid agent for orchestrator
+    prisma.agent.findUnique
+      .mockResolvedValueOnce({ workspaceId: 'ws-1' })  // call for agentId
+      .mockResolvedValueOnce({ id: WS_ORCH, name: 'WS Orch' }) // call inside propagate()
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    const result = await svc.propagateUp(AGENT_ID, INPUT)
+
+    expect(result.updated).toHaveLength(1)
+    expect(result.updated[0].agentId).toBe(WS_ORCH)
+    expect(result.skipped).toHaveLength(0)
+  })
+
+  // ── Case 2: propaga a workspace + department + agency cuando todos tienen orchestratorId ──
+  it('propaga a workspace, department y agency cuando todos tienen orchestratorId', async () => {
+    const prisma = buildPrismaMock({
+      agent:      { workspaceId: 'ws-1' },
+      workspace:  { id: 'ws-1', orchestratorId: WS_ORCH,  departmentId: 'dep-1' },
+      department: { id: 'dep-1', orchestratorId: DEP_ORCH, agencyId: 'agc-1' },
+      agency:     { id: 'agc-1', orchestratorId: AGC_ORCH },
+    })
+
+    const mockUpsert = (agentId: string) => ({
+      systemPrompt: 'prompt', persona: {}, knowledgeBase: [],
+      responseFormat: null, contextWindow: 8192, memoryEnabled: false,
+      version: 1, propagatedAt: NOW,
+    })
+
+    // agent.findUnique: first call = source agent, subsequent = inside propagate() per orchestrator
+    prisma.agent.findUnique
+      .mockResolvedValueOnce({ workspaceId: 'ws-1' })          // propagateUp source
+      .mockResolvedValueOnce({ id: WS_ORCH,  name: 'WS Orch' })  // inside propagate(WS_ORCH)
+      .mockResolvedValueOnce({ id: DEP_ORCH, name: 'Dep Orch' }) // inside propagate(DEP_ORCH)
+      .mockResolvedValueOnce({ id: AGC_ORCH, name: 'Agc Orch' }) // inside propagate(AGC_ORCH)
+
+    prisma.agentProfile.upsert
+      .mockResolvedValueOnce(mockUpsert(WS_ORCH))
+      .mockResolvedValueOnce(mockUpsert(DEP_ORCH))
+      .mockResolvedValueOnce(mockUpsert(AGC_ORCH))
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    const result = await svc.propagateUp(AGENT_ID, INPUT)
+
+    expect(result.updated).toHaveLength(3)
+    expect(result.updated[0].agentId).toBe(WS_ORCH)
+    expect(result.updated[1].agentId).toBe(DEP_ORCH)
+    expect(result.updated[2].agentId).toBe(AGC_ORCH)
+    expect(result.skipped).toHaveLength(0)
+  })
+
+  // ── Case 3: añade a skipped cuando workspace.orchestratorId es null ──
+  it('añade a skipped cuando workspace.orchestratorId es null', async () => {
+    const prisma = buildPrismaMock({
+      agent:     { workspaceId: 'ws-1' },
+      workspace: { id: 'ws-1', orchestratorId: null, departmentId: null },
+    })
+    prisma.agent.findUnique.mockResolvedValueOnce({ workspaceId: 'ws-1' })
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    const result = await svc.propagateUp(AGENT_ID, INPUT)
+
+    expect(result.updated).toHaveLength(0)
+    expect(result.skipped).toContain('workspace:ws-1')
+  })
+
+  // ── Case 4: añade a skipped cuando workspace.orchestratorId === agentId (anti-loop) ──
+  it('añade a skipped cuando workspace.orchestratorId === agentId (anti-loop)', async () => {
+    const prisma = buildPrismaMock({
+      agent:     { workspaceId: 'ws-1' },
+      workspace: { id: 'ws-1', orchestratorId: AGENT_ID, departmentId: null },
+    })
+    prisma.agent.findUnique.mockResolvedValueOnce({ workspaceId: 'ws-1' })
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    const result = await svc.propagateUp(AGENT_ID, INPUT)
+
+    expect(result.updated).toHaveLength(0)
+    expect(result.skipped).toContain('workspace:ws-1')
+  })
+
+  // ── Case 5: no propaga a niveles intermedios ausentes (workspace sin departmentId) ──
+  it('no propaga a department ni agency cuando workspace.departmentId es null', async () => {
+    const prisma = buildPrismaMock({
+      agent:     { workspaceId: 'ws-1' },
+      workspace: { id: 'ws-1', orchestratorId: WS_ORCH, departmentId: null },
+    })
+    prisma.agent.findUnique
+      .mockResolvedValueOnce({ workspaceId: 'ws-1' })
+      .mockResolvedValueOnce({ id: WS_ORCH, name: 'WS Orch' })
+    prisma.agentProfile.upsert.mockResolvedValueOnce({
+      systemPrompt: 'prompt', persona: {}, knowledgeBase: [],
+      responseFormat: null, contextWindow: 8192, memoryEnabled: false,
+      version: 1, propagatedAt: NOW,
+    })
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    const result = await svc.propagateUp(AGENT_ID, INPUT)
+
+    expect(result.updated).toHaveLength(1)
+    expect(prisma.department.findUnique).not.toHaveBeenCalled()
+    expect(prisma.agency.findUnique).not.toHaveBeenCalled()
+  })
+
+  // ── Case 6: lanza Error si el agente no existe en BD ──
+  it('lanza Error si el agente no existe en BD', async () => {
+    const prisma = buildPrismaMock({ agent: null })
+    prisma.agent.findUnique.mockResolvedValueOnce(null)
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    await expect(svc.propagateUp('non-existent', INPUT)).rejects.toThrow(
+      'Agent "non-existent" not found',
+    )
+  })
+
+  // ── Case 7: updated contiene los ResolvedProfile en orden workspace → department → agency ──
+  it('updated contiene ResolvedProfile en orden: workspace → department → agency', async () => {
+    const prisma = buildPrismaMock({
+      agent:      { workspaceId: 'ws-1' },
+      workspace:  { id: 'ws-1', orchestratorId: WS_ORCH,  departmentId: 'dep-1' },
+      department: { id: 'dep-1', orchestratorId: DEP_ORCH, agencyId: 'agc-1' },
+      agency:     { id: 'agc-1', orchestratorId: AGC_ORCH },
+    })
+
+    prisma.agent.findUnique
+      .mockResolvedValueOnce({ workspaceId: 'ws-1' })
+      .mockResolvedValueOnce({ id: WS_ORCH,  name: 'WS Orch' })
+      .mockResolvedValueOnce({ id: DEP_ORCH, name: 'Dep Orch' })
+      .mockResolvedValueOnce({ id: AGC_ORCH, name: 'Agc Orch' })
+
+    const makeProfile = (id: string) => ({
+      systemPrompt: `${id} prompt`, persona: {}, knowledgeBase: [],
+      responseFormat: null, contextWindow: 8192, memoryEnabled: false,
+      version: 1, propagatedAt: NOW,
+    })
+
+    prisma.agentProfile.upsert
+      .mockResolvedValueOnce(makeProfile(WS_ORCH))
+      .mockResolvedValueOnce(makeProfile(DEP_ORCH))
+      .mockResolvedValueOnce(makeProfile(AGC_ORCH))
+
+    const svc = new ProfilePropagatorService(prisma as never)
+    const result = await svc.propagateUp(AGENT_ID, INPUT)
+
+    const ids = result.updated.map((p) => p.agentId)
+    expect(ids).toEqual([WS_ORCH, DEP_ORCH, AGC_ORCH])
+  })
+})

--- a/packages/profile-engine/src/index.ts
+++ b/packages/profile-engine/src/index.ts
@@ -17,6 +17,7 @@ export type {
   KnowledgeBaseEntry,
   PropagateProfileInput,
   ResolvedProfile,
+  PropagateUpResult,
 } from './profile-propagator.service.js'
 
 export { ProfilePropagatorService } from './profile-propagator.service.js'

--- a/packages/profile-engine/src/profile-propagator.service.ts
+++ b/packages/profile-engine/src/profile-propagator.service.ts
@@ -9,6 +9,7 @@
  *   2. getProfile(agentId)      — lee el perfil activo desde Prisma
  *   3. buildSystemPrompt(profile) — compila el system prompt final para LLMStepExecutor
  *   4. resolveForAgent(agentId) — shortcut: getProfile + buildSystemPrompt
+ *   5. propagateUp(agentId, input) — [F2b-01] propaga al orchestrator de cada nivel jerárquico
  *
  * Diseño:
  *   - Un solo registro por agente (1-to-1 con Agent).
@@ -59,6 +60,16 @@ export interface ResolvedProfile {
   contextWindow:  number
   memoryEnabled:  boolean
   propagatedAt:   Date
+}
+
+/**
+ * [F2b-01] Resultado de propagateUp().
+ * - updated: perfiles actualizados en orden workspace → department → agency
+ * - skipped: IDs de niveles sin orchestratorId o que son el propio agentId (anti-loop)
+ */
+export interface PropagateUpResult {
+  updated: ResolvedProfile[]
+  skipped: string[]   // IDs de niveles sin orchestratorId o que son el propio agentId
 }
 
 // ── Service ────────────────────────────────────────────────────────────────
@@ -113,6 +124,78 @@ export class ProfilePropagatorService {
     })
 
     return this.toResolved(agentId, profile)
+  }
+
+  /**
+   * [F2b-01] Propaga el perfil hacia arriba por la jerarquía:
+   *   Agent → Workspace orchestrator → Department orchestrator → Agency orchestrator
+   *
+   * Regla irrevocable (D-24f): solo se llama a this.propagate() con el
+   * orchestratorId de cada entidad padre — nunca con todos los agentes del scope.
+   * Si un nivel no tiene orchestratorId, se añade al array `skipped`.
+   * Si el orchestratorId es igual al agentId fuente, se añade a `skipped` (anti-loop).
+   *
+   * @param agentId  ID del agente cuyo perfil se propaga hacia arriba
+   * @param input    Datos del perfil a propagar (misma shape que propagate())
+   */
+  async propagateUp(
+    agentId: string,
+    input: PropagateProfileInput,
+  ): Promise<PropagateUpResult> {
+    const updated: ResolvedProfile[] = []
+    const skipped: string[] = []
+
+    // 1. Leer el agente y su workspaceId
+    const agent = await this.prisma.agent.findUnique({
+      where:   { id: agentId },
+      select:  { workspaceId: true },
+    })
+    if (!agent) throw new Error(`Agent "${agentId}" not found`)
+
+    // 2. Leer el workspace (con departmentId para navegar hacia arriba)
+    const workspace = await this.prisma.workspace.findUnique({
+      where:   { id: agent.workspaceId },
+      select:  { id: true, orchestratorId: true, departmentId: true },
+    })
+    if (!workspace) throw new Error(`Workspace not found for agent "${agentId}"`)
+
+    // 3. Nivel Workspace — propagar al orchestrator si existe y no es el fuente
+    if (!workspace.orchestratorId || workspace.orchestratorId === agentId) {
+      skipped.push(`workspace:${workspace.id}`)
+    } else {
+      const profile = await this.propagate(workspace.orchestratorId, input)
+      updated.push(profile)
+    }
+
+    // 4. Nivel Department (si el workspace pertenece a uno)
+    if (workspace.departmentId) {
+      const department = await this.prisma.department.findUnique({
+        where:  { id: workspace.departmentId },
+        select: { id: true, orchestratorId: true, agencyId: true },
+      })
+      if (!department?.orchestratorId || department.orchestratorId === agentId) {
+        skipped.push(`department:${workspace.departmentId}`)
+      } else {
+        const profile = await this.propagate(department.orchestratorId, input)
+        updated.push(profile)
+      }
+
+      // 5. Nivel Agency (si el department pertenece a una)
+      if (department?.agencyId) {
+        const agency = await this.prisma.agency.findUnique({
+          where:  { id: department.agencyId },
+          select: { id: true, orchestratorId: true },
+        })
+        if (!agency?.orchestratorId || agency.orchestratorId === agentId) {
+          skipped.push(`agency:${department.agencyId}`)
+        } else {
+          const profile = await this.propagate(agency.orchestratorId, input)
+          updated.push(profile)
+        }
+      }
+    }
+
+    return { updated, skipped }
   }
 
   // ── Lectura ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Add PropagateUpResult interface (updated: ResolvedProfile[], skipped: string[])
- Implement propagateUp(agentId, input) in ProfilePropagatorService
- Traverses hierarchy: Agent → Workspace orchestrator → Department orchestrator → Agency orchestrator
- Enforces D-24f: only propagates to orchestratorId, never iterates agent collections
- Anti-loop guard: skips level if orchestratorId === agentId
- Export PropagateUpResult from packages/profile-engine/src/index.ts
- Add unit tests (7 cases) with full Prisma mock coverage

Closes #F2b-01✅ **Implementación completa — F2b-01**

## Commit entregado

**SHA:** `e7067a3ecfb6dd3670769d5650ad01ed0831d4ab`  
**Rama:** `feat/phase-F2b-propagacion-perfiles`  
**Repositorio:** [[lssmanager/agent-visualstudio](https://github.com/lssmanager/agent-visualstudio/commit/e7067a3ecfb6dd3670769d5650ad01ed0831d4ab)](https://github.com/lssmanager/agent-visualstudio/commit/e7067a3ecfb6dd3670769d5650ad01ed0831d4ab)

***

## Qué se implementó

### 1. `packages/profile-engine/src/profile-propagator.service.ts`
Se añadieron dos elementos sobre el SHA original `19cf478c`:

- **`PropagateUpResult`** — interfaz nueva exportada con los campos `updated: ResolvedProfile[]` y `skipped: string[]`
- **`propagateUp(agentId, input)`** — método nuevo en `ProfilePropagatorService` que navega la jerarquía `Agent → Workspace → Department → Agency` y llama a `this.propagate()` **únicamente** sobre el `orchestratorId` de cada nivel, respetando la regla D-24f

Las restricciones absolutas se cumplen: no hay ninguna llamada a `prisma.agent.findMany()`, no se itera sobre colecciones de agentes, y el método `propagate()` existente no fue modificado.

### 2. `packages/profile-engine/src/index.ts`
Se añadió `PropagateUpResult` al bloque de exports existente del servicio, manteniéndolo junto a los demás tipos del mismo archivo.

### 3. `packages/profile-engine/src/__tests__/profile-propagator-propagate-up.test.ts`
Archivo de test nuevo con **7 casos** cubriendo todos los items del criterio de cierre:

| # | Caso |
|---|------|
| 1 | Propaga al workspace orchestrator cuando existe y es distinto al `agentId` |
| 2 | Propaga a workspace + department + agency cuando todos tienen `orchestratorId` |
| 3 | Añade a `skipped` cuando `workspace.orchestratorId` es `null` |
| 4 | Añade a `skipped` cuando `workspace.orchestratorId === agentId` (anti-loop) |
| 5 | No invoca `department.findUnique` ni `agency.findUnique` cuando `departmentId` es null |
| 6 | Lanza `Error` si el agente no existe en BD |
| 7 | `updated` contiene perfiles en orden `workspace → department → agency` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upward profile propagation for agents. Automatically updates parent organizational levels (workspace, department, agency) when an agent's profile changes, with built-in safeguards to prevent circular propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->