### PR TITLE
feat(F2b-04): inject PropagateHook into AgentRepository.create/softDe…

### DIFF
--- a/packages/run-engine/src/repositories/__tests__/agent-propagate-hook.test.ts
+++ b/packages/run-engine/src/repositories/__tests__/agent-propagate-hook.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests para el PropagateHook en AgentRepository — F2b-04
+ *
+ * Estrategia: Prisma mock con jest.fn() — sin BD real.
+ * 8 casos cubriendo todos los criterios de cierre.
+ */
+
+import { AgentRepository } from '../agent.repository'
+import type { CreateAgentInput, UpdateAgentInput } from '../agent.repository'
+
+// ── Prisma mock factory ────────────────────────────────────────────────────
+
+function makePrismaMock() {
+  return {
+    agent: {
+      create: jest.fn(),
+      update: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+  }
+}
+
+const FAKE_AGENT = {
+  id:                  'agent-uuid-001',
+  workspaceId:         'ws-001',
+  name:                'Test Agent',
+  slug:                'test-agent',
+  kind:                null,
+  systemPrompt:        null,
+  isLevelOrchestrator: false,
+  modelId:             null,
+  providerId:          null,
+  maxTokens:           null,
+  temperature:         null,
+  metadata:            {},
+  deletedAt:           null,
+  createdAt:           new Date(),
+  updatedAt:           new Date(),
+}
+
+const CREATE_INPUT: CreateAgentInput = {
+  workspaceId: 'ws-001',
+  name:        'Test Agent',
+  slug:        'test-agent',
+}
+
+// ── create() con hook ──────────────────────────────────────────────────
+
+describe('create() con hook', () => {
+  it('hook es llamado DESPUÉS de que prisma.agent.create resuelve', async () => {
+    const prisma = makePrismaMock()
+    const callOrder: string[] = []
+
+    prisma.agent.create.mockImplementation(async () => {
+      callOrder.push('prisma.create')
+      return FAKE_AGENT
+    })
+
+    const hook = jest.fn(async () => {
+      callOrder.push('hook')
+    })
+
+    const repo = new AgentRepository(prisma as never, hook)
+    await repo.create(CREATE_INPUT)
+    // Esperar microtask del fire-and-forget
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(callOrder).toEqual(['prisma.create', 'hook'])
+  })
+
+  it('hook recibe el agentId retornado por prisma (no el input)', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.create.mockResolvedValue(FAKE_AGENT)
+
+    const hook = jest.fn().mockResolvedValue(undefined)
+    const repo = new AgentRepository(prisma as never, hook)
+    await repo.create(CREATE_INPUT)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(hook).toHaveBeenCalledWith(FAKE_AGENT.id)
+  })
+
+  it('create() devuelve el agent de Prisma aunque el hook falle', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.create.mockResolvedValue(FAKE_AGENT)
+
+    const hook = jest.fn().mockRejectedValue(new Error('propagation failed'))
+    const repo = new AgentRepository(prisma as never, hook)
+
+    const result = await repo.create(CREATE_INPUT)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(result).toEqual(FAKE_AGENT)
+  })
+
+  it('si el hook falla, console.warn es llamado con el agentId', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.create.mockResolvedValue(FAKE_AGENT)
+
+    const hook = jest.fn().mockRejectedValue(new Error('hook error'))
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const repo = new AgentRepository(prisma as never, hook)
+    await repo.create(CREATE_INPUT)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(FAKE_AGENT.id),
+      expect.any(String),
+    )
+
+    warnSpy.mockRestore()
+  })
+})
+
+// ── softDelete() con hook ──────────────────────────────────────────────
+
+describe('softDelete() con hook', () => {
+  const DELETED_AGENT = { ...FAKE_AGENT, deletedAt: new Date() }
+
+  it('hook es llamado después de que prisma.agent.update (softDelete) resuelve', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.update.mockResolvedValue(DELETED_AGENT)
+
+    const hook = jest.fn().mockResolvedValue(undefined)
+    const repo = new AgentRepository(prisma as never, hook)
+    await repo.softDelete(FAKE_AGENT.id)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(hook).toHaveBeenCalledWith(FAKE_AGENT.id)
+  })
+
+  it('softDelete() devuelve el agent actualizado aunque el hook falle', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.update.mockResolvedValue(DELETED_AGENT)
+
+    const hook = jest.fn().mockRejectedValue(new Error('soft-delete hook failed'))
+    const repo = new AgentRepository(prisma as never, hook)
+
+    const result = await repo.softDelete(FAKE_AGENT.id)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(result).toEqual(DELETED_AGENT)
+  })
+})
+
+// ── update() — SIN hook ────────────────────────────────────────────────
+
+describe('update() — sin hook', () => {
+  it('hook NO es llamado cuando se llama update()', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.update.mockResolvedValue(FAKE_AGENT)
+
+    const hook = jest.fn().mockResolvedValue(undefined)
+    const repo = new AgentRepository(prisma as never, hook)
+
+    const updateData: UpdateAgentInput = { name: 'New Name' }
+    await repo.update(FAKE_AGENT.id, updateData)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(prisma.agent.update).toHaveBeenCalledTimes(1)
+    expect(hook).not.toHaveBeenCalled()
+  })
+})
+
+// ── sin hook (backward compat) ──────────────────────────────────────────
+
+describe('sin hook (backward compat)', () => {
+  it('create() y softDelete() funcionan sin errores cuando propagateHook no es pasado', async () => {
+    const prisma = makePrismaMock()
+    prisma.agent.create.mockResolvedValue(FAKE_AGENT)
+    prisma.agent.update.mockResolvedValue({ ...FAKE_AGENT, deletedAt: new Date() })
+
+    // Sin segundo argumento — backward compat
+    const repo = new AgentRepository(prisma as never)
+
+    await expect(repo.create(CREATE_INPUT)).resolves.toEqual(FAKE_AGENT)
+    await expect(repo.softDelete(FAKE_AGENT.id)).resolves.toBeDefined()
+  })
+})

--- a/packages/run-engine/src/repositories/agent.repository.ts
+++ b/packages/run-engine/src/repositories/agent.repository.ts
@@ -8,6 +8,11 @@
  * findById incluye opcionalmente skills y subagentes para evitar N+1 en el
  * orquestador de jerarquía.
  *
+ * [F2b-04] PropagateHook:
+ *   create() y softDelete() llaman this.#triggerPropagate(agentId) después
+ *   del write en BD. El hook se inyecta en el constructor para evitar
+ *   dependencia circular con packages/hierarchy.
+ *
  * Convenciones:
  *   - Clase stateless; PrismaClient inyectado en constructor.
  *   - softDelete: marca deletedAt.
@@ -16,7 +21,7 @@
 
 import type { PrismaClient } from '@prisma/client'
 
-// ── DTOs ──────────────────────────────────────────────────────────────────────
+// ── DTOs ──────────────────────────────────────────────────────────────────────────────
 
 export interface CreateAgentInput {
   workspaceId:          string
@@ -46,23 +51,46 @@ export interface UpdateAgentInput {
 }
 
 export interface FindAgentsOptions {
-  limit?:       number
-  offset?:      number
-  kind?:        string
+  limit?:         number
+  offset?:        number
+  kind?:          string
   /** Incluir relaciones (skills, subagentes) en el resultado. */
   withSkills?:    boolean
   withSubagents?: boolean
 }
 
-// ── Repository ────────────────────────────────────────────────────────────────
+/**
+ * [F2b-04] Callback inyectado en AgentRepository para disparar propagateUp()
+ * cuando un Agent es creado o eliminado (soft-delete).
+ *
+ * El caller (service layer / DI container) resuelve la implementación real.
+ * El repo no importa nada de packages/hierarchy — sin dependencia circular.
+ *
+ * Contrato:
+ *   - Recibe el agentId afectado.
+ *   - Debe resolver sin lanzar (errores internos gestionados por el caller).
+ *   - Si lanza de todas formas, AgentRepository lo traga silenciosamente
+ *     (el write en BD ya se completó).
+ */
+export type PropagateHook = (agentId: string) => Promise<void>
+
+// ── Repository ──────────────────────────────────────────────────────────────────
 
 export class AgentRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(
+    private readonly prisma:         PrismaClient,
+    /**
+     * [F2b-04] Hook opcional de propagación de perfiles.
+     * Si se omite (undefined), create() y softDelete() funcionan igual
+     * que antes — sin cambio de comportamiento hacia atrás.
+     */
+    private readonly propagateHook?: PropagateHook,
+  ) {}
 
-  // ── Write ─────────────────────────────────────────────────────────────
+  // ── Write ───────────────────────────────────────────────────────────────
 
   async create(input: CreateAgentInput) {
-    return this.prisma.agent.create({
+    const agent = await this.prisma.agent.create({
       data: {
         workspaceId:         input.workspaceId,
         name:                input.name,
@@ -77,6 +105,12 @@ export class AgentRepository {
         metadata:            (input.metadata ?? {}) as never,
       },
     })
+
+    // [F2b-04] Disparar propagación después del write exitoso.
+    // Fire-and-forget: el caller no espera — errores son tragados.
+    this.#triggerPropagate(agent.id)
+
+    return agent
   }
 
   async update(id: string, data: UpdateAgentInput) {
@@ -95,13 +129,21 @@ export class AgentRepository {
         ...(data.metadata            !== undefined && { metadata:            data.metadata as never }),
       },
     })
+    // Nota: update() NO dispara propagación — solo create/softDelete
+    // porque update no cambia la composición del equipo del orchestrator.
   }
 
   async softDelete(id: string) {
-    return this.prisma.agent.update({
+    const agent = await this.prisma.agent.update({
       where: { id },
       data:  { deletedAt: new Date() },
     })
+
+    // [F2b-04] Disparar propagación después del soft-delete exitoso.
+    // Fire-and-forget: idem create().
+    this.#triggerPropagate(agent.id)
+
+    return agent
   }
 
   // ── Read ──────────────────────────────────────────────────────────────
@@ -165,5 +207,28 @@ export class AgentRepository {
 
   async count(workspaceId: string) {
     return this.prisma.agent.count({ where: { workspaceId, deletedAt: null } })
+  }
+
+  // ── Privado — F2b-04 ──────────────────────────────────────────────
+
+  /**
+   * [F2b-04] Dispara el hook de propagación de forma fire-and-forget.
+   *
+   * Contrato:
+   *   - No lanza nunca. Errores del hook son tragados con console.warn.
+   *   - No bloquea al caller — el await interno es best-effort.
+   *   - Si propagateHook no está inyectado, no-op silencioso.
+   */
+  #triggerPropagate(agentId: string): void {
+    if (!this.propagateHook) return
+
+    this.propagateHook(agentId).catch((err) => {
+      // Best-effort: el write en BD ya se completó.
+      // En producción este warn debe conectarse al logger de la app.
+      console.warn(
+        `[F2b-04] propagateHook failed for agent ${agentId}:`,
+        err instanceof Error ? err.message : String(err),
+      )
+    })
   }
 }

--- a/packages/run-engine/src/repositories/index.ts
+++ b/packages/run-engine/src/repositories/index.ts
@@ -7,7 +7,7 @@
  * Skills (F1b-08):    Skill + AgentSkill
  */
 
-// ── Jerarquía ──────────────────────────────────────────────────────────────────
+// ── Jerarquía ──────────────────────────────────────────────────────────────────────────────
 
 export { AgencyRepository } from './agency.repository'
 export type {
@@ -35,9 +35,10 @@ export type {
   CreateAgentInput,
   UpdateAgentInput,
   FindAgentsOptions,
+  PropagateHook,          // [F2b-04] hook type para inyección desde service layer
 } from './agent.repository'
 
-// ── Ejecución ────────────────────────────────────────────────────────────────
+// ── Ejecución ────────────────────────────────────────────────────────────────────────
 
 export { RunRepository } from './run.repository'
 export type {
@@ -54,7 +55,7 @@ export type {
   FindStepsOptions,
 } from './run-step.repository'
 
-// ── Gateway / Conversaciones ─────────────────────────────────────────────
+// ── Gateway / Conversaciones ───────────────────────────────────────────────
 
 export { ConversationMessageRepository } from './conversation-message.repository'
 export type {
@@ -63,7 +64,7 @@ export type {
   MessageRole,
 } from './conversation-message.repository'
 
-// ── Skills ───────────────────────────────────────────────────────────────────
+// ── Skills ─────────────────────────────────────────────────────────────────────────────
 
 export { SkillRepository } from './skill.repository.js'
 export type {


### PR DESCRIPTION
…lete

- agent.repository.ts:
  - Export type PropagateHook = (agentId: string) => Promise<void>
  - Constructor accepts optional second param propagateHook?: PropagateHook
  - create() stores result, calls #triggerPropagate(agent.id), returns agent
  - softDelete() stores result, calls #triggerPropagate(agent.id), returns agent
  - update() does NOT trigger hook (team composition unchanged)
  - Private #triggerPropagate(): fire-and-forget, swallows errors with console.warn
  - Backward compatible: new AgentRepository(prisma) without hook still works
  - Zero imports from packages/hierarchy (no circular dependency)
- repositories/index.ts:
  - Added PropagateHook to export type block for AgentRepository
- repositories/__tests__/agent-propagate-hook.test.ts:
  - 8 test cases covering hook invocation, error swallowing, update exclusion, backward compat, console.warn spy, and agentId forwarding

Closes #49

Implementación completada. Aquí el resumen:

***

## F2b-04 — `PropagateHook` en `AgentRepository`

### Commit SHA

**`24d0b286322c8f18f5d706cb9dea1b7921507ff6`**

Rama: [`[feat/F2b-04-agent-repo-propagate-hook](https://github.com/lssmanager/agent-visualstudio/tree/feat/F2b-04-agent-repo-propagate-hook)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F2b-04-agent-repo-propagate-hook)

***

### Archivos modificados / creados

**1. `packages/run-engine/src/repositories/agent.repository.ts`** ← Modificado
- Nuevo `export type PropagateHook = (agentId: string) => Promise<void>`
- Constructor acepta segundo parámetro opcional `propagateHook?: PropagateHook`
- `create()` guarda el resultado en `agent`, llama `#triggerPropagate(agent.id)` y retorna el agent
- `softDelete()` ídem — captura el resultado antes de disparar el hook
- `update()` **no** dispara el hook (comentario explicativo incluido)
- Método privado `#triggerPropagate()` — fire-and-forget, `.catch()` traga errores con `console.warn`
- **Cero imports de `packages/hierarchy`** — sin dependencia circular

**2. `packages/run-engine/src/repositories/index.ts`** ← Modificado
- `PropagateHook` añadido al bloque `export type` de `AgentRepository`

**3. `packages/run-engine/src/repositories/__tests__/agent-propagate-hook.test.ts`** ← Nuevo
- **8 tests** cubriendo todos los criterios de cierre:
  - Hook llamado después de `prisma.create` (verificación de orden)
  - Hook recibe el `agentId` de Prisma, no del input
  - `create()` resuelve aunque el hook falle
  - `console.warn` es llamado con el `agentId` cuando el hook falla
  - `softDelete()` dispara el hook y devuelve el agent actualizado aunque el hook falle
  - `update()` **no** llama el hook
  - Backward compat: `new AgentRepository(prisma)` sin segundo argumento funciona sin errores

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional propagation hook capability to agent repository, enabling custom actions to trigger automatically when agents are created or soft-deleted.

* **Tests**
  * Introduced comprehensive test suite for propagation hook functionality, validating execution, error handling, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->