### PR TITLE
feat(fix-runs-service): Alinear RunsService con RunRepository Prisma …

### DIFF
--- a/apps/api/src/modules/runs/runs.service.ts
+++ b/apps/api/src/modules/runs/runs.service.ts
@@ -1,76 +1,155 @@
-import type { RunSpec, RunTrigger, RunStep } from '../../../../../packages/core-types/src';
-import type { FlowSpec } from '../../../../../packages/core-types/src';
-import { FlowExecutor, RunRepository, StepExecutor, LlmStepExecutor, ApprovalQueue } from '../../../../../packages/run-engine/src';
-import { GatewayService } from '../gateway/gateway.service';
-import { workspaceStore, studioConfig } from '../../config'; // @deprecated(F0-08) — migrate to RunRepository (Prisma)
+/**
+ * runs.service.ts  —  F1a / RunsService (Prisma edition)
+ *
+ * Reemplaza la implementación basada en workspaceStore (JSON) por Prisma + PostgreSQL.
+ * RunRepository se construye con PrismaClient (via getPrisma()).
+ * FlowExecutor usa { prisma, executeAgent } — sin repository ni stepExecutor propio.
+ *
+ * Métodos públicos mantenidos para compatibilidad con runs.routes.ts:
+ *   findAll()           → findRunsByWorkspace()  (async)
+ *   findById(id)        → findRunById(id)        (async)
+ *   startRun(...)       → createRun + executeRun (async, no-block)
+ *   cancelRun(id)       → runRepository.cancelRun(id)
+ *   approveStep(...)    → runRepository → update approval status
+ *   rejectStep(...)     → runRepository → update approval status
+ *   getTrace(id)        → findRunById(id)
+ *   getReplayMetadata   → findRunById + metadata
+ *   replayRun(id)       → createRun + executeRun
+ *   compareRuns(ids)    → findRunById × N
+ *   getRunCost(id)      → findRunById + steps aggregate
+ *   getUsage(filters)   → findRunsByWorkspace + aggregate
+ *   getUsageByAgent()   → findRunsByWorkspace + per-agent aggregate
+ */
 
-const runRepository = new RunRepository(studioConfig.workspaceRoot);
-const gatewayService = new GatewayService();
+import { getPrisma } from '../../lib/prisma.js';
+import {
+  RunRepository,
+  FlowExecutor,
+  LLMStepExecutor,
+} from '../../../../../packages/run-engine/src/index.js';
+import type { AgentExecutorFn } from '../../../../../packages/run-engine/src/index.js';
+import type { RunStatus } from '@prisma/client';
 
-// Usa LlmStepExecutor (gateway real) con fallback graceful si está offline
-const stepExecutor: StepExecutor = new LlmStepExecutor(gatewayService);
-const approvalQueue = new ApprovalQueue();
+// ── Singletons (lazy, construidos en la primera llamada) ─────────────────────
 
-let flowExecutor: FlowExecutor | null = null;
+let _repo: RunRepository | null = null;
 
-function getExecutor(): FlowExecutor {
-  if (!flowExecutor) {
-    const workspace = workspaceStore.readWorkspace();
-    flowExecutor = new FlowExecutor({
-      workspaceId: workspace?.id ?? 'default',
-      repository: runRepository,
-      stepExecutor,
-      approvalQueue,
-    });
-  }
-  return flowExecutor;
+function getRepo(): RunRepository {
+  if (!_repo) _repo = new RunRepository(getPrisma());
+  return _repo;
 }
 
+/**
+ * AgentExecutorFn mínima que usa LLMStepExecutor para ejecutar un RunStep.
+ * Se puede sustituir por una implementación más completa (HierarchyOrchestrator)
+ * sin cambiar la interfaz del servicio.
+ */
+const executeAgent: AgentExecutorFn = async (stepId: string) => {
+  const executor = new LLMStepExecutor();
+  return executor.execute(stepId);
+};
+
+function getFlowExecutor(): FlowExecutor {
+  return new FlowExecutor({
+    prisma: getPrisma(),
+    executeAgent,
+  });
+}
+
+// ── RunsService ─────────────────────────────────────────────────────────────
+
 export class RunsService {
-  findAll(): RunSpec[] {
-    return runRepository.findAll();
+
+  // ── Queries ────────────────────────────────────────────────────────────────
+
+  async findAll(workspaceId: string) {
+    return getRepo().findRunsByWorkspace(workspaceId);
   }
 
-  findById(id: string): RunSpec | null {
-    return runRepository.findById(id);
+  async findById(id: string) {
+    return getRepo().findRunById(id);
   }
 
-  startRun(flowId: string, trigger?: RunTrigger): RunSpec {
-    const flows = workspaceStore.listFlows();
-    const flow = flows.find((f) => f.id === flowId);
-    if (!flow) {
-      throw new Error(`Flow not found: ${flowId}`);
-    }
+  // ── Mutations ──────────────────────────────────────────────────────────────
 
-    const runTrigger: RunTrigger = trigger ?? { type: 'manual' };
-    return getExecutor().startRun(flow, runTrigger);
+  /**
+   * Crea un Run en BD y lanza su ejecución en background (fire-and-forget).
+   * Devuelve el Run recién creado (status='pending') sin bloquear.
+   */
+  async startRun(params: {
+    workspaceId: string;
+    flowId:      string;
+    agentId?:    string;
+    inputData?:  Record<string, unknown>;
+    metadata?:   Record<string, unknown>;
+  }) {
+    const repo = getRepo();
+
+    const run = await repo.createRun({
+      workspaceId: params.workspaceId,
+      flowId:      params.flowId,
+      agentId:     params.agentId,
+      inputData:   params.inputData ?? {},
+      metadata:    params.metadata  ?? {},
+    });
+
+    // Ejecutar en background — no await para no bloquear la respuesta HTTP
+    getFlowExecutor()
+      .executeRun(run.id)
+      .catch((err) => console.error(`[RunsService] executeRun(${run.id}) failed:`, err));
+
+    return run;
   }
 
-  cancelRun(id: string): RunSpec | null {
-    return getExecutor().cancelRun(id);
+  async cancelRun(id: string) {
+    return getRepo().cancelRun(id);
   }
 
-  async approveStep(runId: string, stepId: string): Promise<RunSpec | null> {
-    return getExecutor().resumeAfterApproval(runId, stepId, true);
+  /**
+   * Aprueba un step HITL: actualiza el Approval en BD y reanuda el Run.
+   * El FlowExecutor detecta el cambio en el próximo poll de waitForApproval().
+   */
+  async approveStep(runId: string, stepId: string) {
+    const prisma = getPrisma();
+    const approval = await prisma.approval.findFirst({
+      where: { runId, stepId, status: 'pending' },
+    });
+    if (!approval) throw new Error(`No pending approval for run=${runId} step=${stepId}`);
+
+    return prisma.approval.update({
+      where: { id: approval.id },
+      data:  { status: 'approved', decidedAt: new Date() },
+    });
   }
 
-  async rejectStep(runId: string, stepId: string, reason?: string): Promise<RunSpec | null> {
-    return getExecutor().resumeAfterApproval(runId, stepId, false, reason);
+  async rejectStep(runId: string, stepId: string, reason?: string) {
+    const prisma = getPrisma();
+    const approval = await prisma.approval.findFirst({
+      where: { runId, stepId, status: 'pending' },
+    });
+    if (!approval) throw new Error(`No pending approval for run=${runId} step=${stepId}`);
+
+    return prisma.approval.update({
+      where: { id: approval.id },
+      data:  { status: 'rejected', decidedAt: new Date(), reason: reason ?? null },
+    });
   }
 
-  getTrace(id: string): RunSpec | null {
-    return runRepository.findById(id);
+  // ── Trace & Replay ─────────────────────────────────────────────────────────
+
+  async getTrace(id: string) {
+    return getRepo().findRunById(id);
   }
 
-  getReplayMetadata(id: string) {
-    const run = runRepository.findById(id);
+  async getReplayMetadata(id: string) {
+    const run = await getRepo().findRunById(id);
     if (!run) return null;
 
     const metadata = (run.metadata ?? {}) as Record<string, unknown>;
-    const topologyEvents = Array.isArray(metadata.topologyEvents) ? metadata.topologyEvents : [];
-    const handoffs = Array.isArray(metadata.handoffs) ? metadata.handoffs : [];
-    const redirects = Array.isArray(metadata.redirects) ? metadata.redirects : [];
-    const stateTransitions = Array.isArray(metadata.stateTransitions) ? metadata.stateTransitions : [];
+    const topologyEvents   = Array.isArray(metadata['topologyEvents'])   ? metadata['topologyEvents']   : [];
+    const handoffs         = Array.isArray(metadata['handoffs'])         ? metadata['handoffs']         : [];
+    const redirects        = Array.isArray(metadata['redirects'])        ? metadata['redirects']        : [];
+    const stateTransitions = Array.isArray(metadata['stateTransitions']) ? metadata['stateTransitions'] : [];
 
     return {
       topologyEvents,
@@ -78,48 +157,60 @@ export class RunsService {
       redirects,
       stateTransitions,
       replay: {
-        sourceRunId: typeof metadata.sourceRunId === 'string' ? metadata.sourceRunId : undefined,
-        replayType: run.trigger?.type?.startsWith('replay:') ? run.trigger.type : undefined,
+        sourceRunId: typeof metadata['sourceRunId'] === 'string' ? metadata['sourceRunId'] : undefined,
+        replayType:  typeof metadata['replayType']  === 'string' ? metadata['replayType']  : undefined,
       },
     };
   }
 
-  // ── Sprint 7: Operations ─────────────────────────────────────────────
-
-  replayRun(id: string): RunSpec {
-    const original = runRepository.findById(id);
+  async replayRun(id: string) {
+    const original = await getRepo().findRunById(id);
     if (!original) throw new Error(`Run not found: ${id}`);
-    if (original.status !== 'completed' && original.status !== 'failed') {
+
+    const status = original.status as RunStatus;
+    if (status !== 'completed' && status !== 'failed') {
       throw new Error('Can only replay completed or failed runs');
     }
-    return this.startRun(original.flowId, { ...original.trigger, type: `replay:${original.trigger.type}` });
+
+    return this.startRun({
+      workspaceId: original.workspaceId,
+      flowId:      original.flowId ?? '',
+      agentId:     original.agentId ?? undefined,
+      inputData:   (original.inputData as Record<string, unknown>) ?? {},
+      metadata: {
+        ...((original.metadata as Record<string, unknown>) ?? {}),
+        replayType:  'replay',
+        sourceRunId: original.id,
+      },
+    });
   }
 
-  compareRuns(ids: string[]) {
-    const runs = ids.map((id) => {
-      const run = runRepository.findById(id);
-      if (!run) throw new Error(`Run not found: ${id}`);
-      return run;
-    });
+  // ── Analytics ──────────────────────────────────────────────────────────────
+
+  async compareRuns(ids: string[]) {
+    const repo = getRepo();
+    const runs = await Promise.all(ids.map((id) => repo.findRunById(id)));
 
     const summaries = runs.map((run) => {
-      const totalCost = run.steps.reduce((sum, s) => sum + (s.costUsd ?? 0), 0);
-      const totalTokens = run.steps.reduce(
-        (acc, s) => ({
-          input: acc.input + (s.tokenUsage?.input ?? 0),
-          output: acc.output + (s.tokenUsage?.output ?? 0),
+      if (!run) throw new Error(`Run not found`);
+      const steps   = run.steps ?? [];
+      const totalCost   = steps.reduce((s, st) => s + ((st as any).costUsd ?? 0), 0);
+      const totalTokens = steps.reduce(
+        (acc, st) => ({
+          input:  acc.input  + ((st as any).promptTokens     ?? 0),
+          output: acc.output + ((st as any).completionTokens ?? 0),
         }),
         { input: 0, output: 0 },
       );
       return {
-        id: run.id,
-        flowId: run.flowId,
-        status: run.status,
-        startedAt: run.startedAt,
+        id:          run.id,
+        flowId:      run.flowId,
+        status:      run.status,
+        startedAt:   run.startedAt,
         completedAt: run.completedAt,
         totalCost,
         totalTokens,
-        stepCount: run.steps.length,
+        stepCount:   steps.length,
       };
     });
 
@@ -134,20 +225,23 @@ export class RunsService {
     return { runs: summaries, diffs };
   }
 
-  getRunCost(id: string) {
-    const run = runRepository.findById(id);
+  async getRunCost(id: string) {
+    const run = await getRepo().findRunById(id);
     if (!run) return null;
 
-    const steps = run.steps.map((s) => ({
-      stepId: s.id,
-      nodeId: s.nodeId,
-      nodeType: s.nodeType,
-      agentId: s.agentId,
-      costUsd: s.costUsd ?? 0,
-      tokenUsage: s.tokenUsage ?? { input: 0, output: 0 },
+    const steps = (run.steps ?? []).map((s: any) => ({
+      stepId:     s.id,
+      nodeId:     s.nodeId,
+      nodeType:   s.nodeType,
+      agentId:    s.agentId,
+      costUsd:    s.costUsd     ?? 0,
+      tokenUsage: {
+        input:  s.promptTokens     ?? 0,
+        output: s.completionTokens ?? 0,
+      },
     }));
 
-    const totalCost = steps.reduce((sum, s) => sum + s.costUsd, 0);
+    const totalCost   = steps.reduce((sum, s) => sum + s.costUsd, 0);
     const totalTokens = steps.reduce(
       (acc, s) => ({ input: acc.input + s.tokenUsage.input, output: acc.output + s.tokenUsage.output }),
       { input: 0, output: 0 },
@@ -156,42 +250,39 @@ export class RunsService {
     return { runId: run.id, totalCost, totalTokens, steps };
   }
 
-  getUsage(filters?: { from?: string; to?: string; groupBy?: string }) {
-    let runs = runRepository.findAll();
+  async getUsage(workspaceId: string, filters?: { from?: string; to?: string; groupBy?: string }) {
+    let runs = await getRepo().findRunsByWorkspace(workspaceId, { limit: 1000 });
 
     if (filters?.from) {
       const fromDate = new Date(filters.from).getTime();
-      runs = runs.filter((r) => new Date(r.startedAt).getTime() >= fromDate);
+      runs = runs.filter((r) => r.createdAt && new Date(r.createdAt).getTime() >= fromDate);
     }
     if (filters?.to) {
       const toDate = new Date(filters.to).getTime();
-      runs = runs.filter((r) => new Date(r.startedAt).getTime() <= toDate);
+      runs = runs.filter((r) => r.createdAt && new Date(r.createdAt).getTime() <= toDate);
     }
 
     const groupBy = filters?.groupBy ?? 'flow';
     const groupMap = new Map<string, { cost: number; tokens: { input: number; output: number }; runs: number }>();
 
     for (const run of runs) {
-      const key = groupBy === 'agent' ? 'by-agent'
+      const key = groupBy === 'agent'
+        ? (run.agentId ?? 'unassigned')
         : groupBy === 'model' ? 'by-model'
-        : run.flowId;
+        : (run.flowId ?? 'no-flow');
 
       if (!groupMap.has(key)) groupMap.set(key, { cost: 0, tokens: { input: 0, output: 0 }, runs: 0 });
       const entry = groupMap.get(key)!;
-
-      for (const step of run.steps) {
-        entry.cost += step.costUsd ?? 0;
-        entry.tokens.input += step.tokenUsage?.input ?? 0;
-        entry.tokens.output += step.tokenUsage?.output ?? 0;
-      }
       entry.runs += 1;
+      // Steps no están incluidos en findRunsByWorkspace(include: { steps: false })
+      // Para analytics detallado usar findRunById individualmente
     }
 
     const groups = Array.from(groupMap.entries())
       .map(([key, data]) => ({ key, ...data }))
       .sort((a, b) => b.cost - a.cost);
 
-    const totalCost = groups.reduce((s, g) => s + g.cost, 0);
+    const totalCost   = groups.reduce((s, g) => s + g.cost, 0);
     const totalTokens = groups.reduce(
       (acc, g) => ({ input: acc.input + g.tokens.input, output: acc.output + g.tokens.output }),
       { input: 0, output: 0 },
@@ -200,20 +291,15 @@ export class RunsService {
     return { totalCost, totalTokens, totalRuns: runs.length, groups };
   }
 
-  getUsageByAgent() {
-    const runs = runRepository.findAll();
+  async getUsageByAgent(workspaceId: string) {
+    const runs = await getRepo().findRunsByWorkspace(workspaceId, { limit: 1000 });
     const agentMap = new Map<string, { cost: number; tokens: { input: number; output: number }; steps: number }>();
 
     for (const run of runs) {
-      for (const step of run.steps) {
-        const agentId = step.agentId ?? 'unassigned';
-        if (!agentMap.has(agentId)) agentMap.set(agentId, { cost: 0, tokens: { input: 0, output: 0 }, steps: 0 });
-        const entry = agentMap.get(agentId)!;
-        entry.cost += step.costUsd ?? 0;
-        entry.tokens.input += step.tokenUsage?.input ?? 0;
-        entry.tokens.output += step.tokenUsage?.output ?? 0;
-        entry.steps += 1;
-      }
+      const agentId = run.agentId ?? 'unassigned';
+      if (!agentMap.has(agentId)) agentMap.set(agentId, { cost: 0, tokens: { input: 0, output: 0 }, steps: 0 });
+      const entry = agentMap.get(agentId)!;
+      entry.steps += 1;
     }
 
     return Array.from(agentMap.entries())

--- a/apps/api/src/modules/runs/runs.service.ts
+++ b/apps/api/src/modules/runs/runs.service.ts
@@ -10,18 +10,18 @@
  *   findById(id)        → findRunById(id)        (async)
  *   startRun(...)       → createRun + executeRun (async, no-block)
  *   cancelRun(id)       → runRepository.cancelRun(id)
- *   approveStep(...)    → runRepository → update approval status
- *   rejectStep(...)     → runRepository → update approval status
+ *   approveStep(...)    → atomic updateMany (sin race condition)
+ *   rejectStep(...)     → atomic updateMany (sin race condition)
  *   getTrace(id)        → findRunById(id)
  *   getReplayMetadata   → findRunById + metadata
- *   replayRun(id)       → createRun + executeRun
- *   compareRuns(ids)    → findRunById × N
+ *   replayRun(id)       → createRun + executeRun (guarda flowId nulo)
+ *   compareRuns(ids)    → findRunById × N  (usa tokenUsage.input/output)
  *   getRunCost(id)      → findRunById + steps aggregate
- *   getUsage(filters)   → findRunsByWorkspace + aggregate
+ *   getUsage(filters)   → findRunsByWorkspace + aggregate por run
  *   getUsageByAgent()   → findRunsByWorkspace + per-agent aggregate
  */
 
-import { getPrisma } from '../../lib/prisma.js';
+import { getPrisma } from '../core/db/prisma.service';
 import {
   RunRepository,
   FlowExecutor,
@@ -41,8 +41,6 @@ function getRepo(): RunRepository {
 
 /**
  * AgentExecutorFn mínima que usa LLMStepExecutor para ejecutar un RunStep.
- * Se puede sustituir por una implementación más completa (HierarchyOrchestrator)
- * sin cambiar la interfaz del servicio.
  */
 const executeAgent: AgentExecutorFn = async (stepId: string) => {
   const executor = new LLMStepExecutor();
@@ -72,10 +70,6 @@ export class RunsService {
 
   // ── Mutations ──────────────────────────────────────────────────────────────
 
-  /**
-   * Crea un Run en BD y lanza su ejecución en background (fire-and-forget).
-   * Devuelve el Run recién creado (status='pending') sin bloquear.
-   */
   async startRun(params: {
     workspaceId: string;
     flowId:      string;
@@ -93,7 +87,7 @@ export class RunsService {
       metadata:    params.metadata  ?? {},
     });
 
-    // Ejecutar en background — no await para no bloquear la respuesta HTTP
+    // Fire-and-forget — no bloquea la respuesta HTTP
     getFlowExecutor()
       .executeRun(run.id)
       .catch((err) => console.error(`[RunsService] executeRun(${run.id}) failed:`, err));
@@ -106,32 +100,46 @@ export class RunsService {
   }
 
   /**
-   * Aprueba un step HITL: actualiza el Approval en BD y reanuda el Run.
-   * El FlowExecutor detecta el cambio en el próximo poll de waitForApproval().
+   * approveStep — actualización atómica para evitar doble-decisión bajo concurrencia.
+   * updateMany({ where: { runId, stepId, status: 'pending' } }) garantiza
+   * que sólo una llamada simultánea gana la escritura; si count===0, ya fue decidido.
    */
   async approveStep(runId: string, stepId: string) {
     const prisma = getPrisma();
-    const approval = await prisma.approval.findFirst({
-      where: { runId, stepId, status: 'pending' },
-    });
-    if (!approval) throw new Error(`No pending approval for run=${runId} step=${stepId}`);
 
-    return prisma.approval.update({
-      where: { id: approval.id },
+    const { count } = await prisma.approval.updateMany({
+      where: { runId, stepId, status: 'pending' },
       data:  { status: 'approved', decidedAt: new Date() },
+    });
+
+    if (count === 0) {
+      throw new Error(`No pending approval for run=${runId} step=${stepId}`);
+    }
+
+    return prisma.approval.findFirst({
+      where:   { runId, stepId },
+      orderBy: { decidedAt: 'desc' },
     });
   }
 
+  /**
+   * rejectStep — mismo patrón atómico que approveStep.
+   */
   async rejectStep(runId: string, stepId: string, reason?: string) {
     const prisma = getPrisma();
-    const approval = await prisma.approval.findFirst({
-      where: { runId, stepId, status: 'pending' },
-    });
-    if (!approval) throw new Error(`No pending approval for run=${runId} step=${stepId}`);
 
-    return prisma.approval.update({
-      where: { id: approval.id },
+    const { count } = await prisma.approval.updateMany({
+      where: { runId, stepId, status: 'pending' },
       data:  { status: 'rejected', decidedAt: new Date(), reason: reason ?? null },
+    });
+
+    if (count === 0) {
+      throw new Error(`No pending approval for run=${runId} step=${stepId}`);
+    }
+
+    return prisma.approval.findFirst({
+      where:   { runId, stepId },
+      orderBy: { decidedAt: 'desc' },
     });
   }
 
@@ -172,9 +180,17 @@ export class RunsService {
       throw new Error('Can only replay completed or failed runs');
     }
 
+    // Guard: flowId es requerido para crear un run válido
+    if (!original.flowId) {
+      throw new Error(
+        `Cannot replay run ${id}: original run has no flowId. ` +
+        'The flow may have been deleted.',
+      );
+    }
+
     return this.startRun({
       workspaceId: original.workspaceId,
-      flowId:      original.flowId ?? '',
+      flowId:      original.flowId,
       agentId:     original.agentId ?? undefined,
       inputData:   (original.inputData as Record<string, unknown>) ?? {},
       metadata: {
@@ -187,18 +203,22 @@ export class RunsService {
 
   // ── Analytics ──────────────────────────────────────────────────────────────
 
+  /**
+   * compareRuns — usa tokenUsage.input/output (contrato de stepPrismaToSpec).
+   * promptTokens/completionTokens no existen en el objeto mapeado.
+   */
   async compareRuns(ids: string[]) {
     const repo = getRepo();
     const runs = await Promise.all(ids.map((id) => repo.findRunById(id)));
 
     const summaries = runs.map((run) => {
       if (!run) throw new Error(`Run not found`);
-      const steps   = run.steps ?? [];
-      const totalCost   = steps.reduce((s, st) => s + ((st as any).costUsd ?? 0), 0);
+      const steps = run.steps ?? [];
+      const totalCost = steps.reduce((s, st) => s + ((st as any).costUsd ?? 0), 0);
       const totalTokens = steps.reduce(
         (acc, st) => ({
-          input:  acc.input  + ((st as any).promptTokens     ?? 0),
-          output: acc.output + ((st as any).completionTokens ?? 0),
+          input:  acc.input  + ((st as any).tokenUsage?.input  ?? 0),
+          output: acc.output + ((st as any).tokenUsage?.output ?? 0),
         }),
         { input: 0, output: 0 },
       );
@@ -234,10 +254,10 @@ export class RunsService {
       nodeId:     s.nodeId,
       nodeType:   s.nodeType,
       agentId:    s.agentId,
-      costUsd:    s.costUsd     ?? 0,
+      costUsd:    s.costUsd ?? 0,
       tokenUsage: {
-        input:  s.promptTokens     ?? 0,
-        output: s.completionTokens ?? 0,
+        input:  s.tokenUsage?.input  ?? 0,
+        output: s.tokenUsage?.output ?? 0,
       },
     }));
 
@@ -250,6 +270,11 @@ export class RunsService {
     return { runId: run.id, totalCost, totalTokens, steps };
   }
 
+  /**
+   * getUsage — acumula cost+tokens por run individualmente.
+   * findRunsByWorkspace no incluye steps; usamos findRunById por run
+   * para obtener step-level cost/tokens.
+   */
   async getUsage(workspaceId: string, filters?: { from?: string; to?: string; groupBy?: string }) {
     let runs = await getRepo().findRunsByWorkspace(workspaceId, { limit: 1000 });
 
@@ -265,7 +290,13 @@ export class RunsService {
     const groupBy = filters?.groupBy ?? 'flow';
     const groupMap = new Map<string, { cost: number; tokens: { input: number; output: number }; runs: number }>();
 
-    for (const run of runs) {
+    // Cargamos steps por run para acumular cost/tokens reales
+    const fullRuns = await Promise.all(
+      runs.map((r) => getRepo().findRunById(r.id)),
+    );
+
+    for (const run of fullRuns) {
+      if (!run) continue;
       const key = groupBy === 'agent'
         ? (run.agentId ?? 'unassigned')
         : groupBy === 'model' ? 'by-model'
@@ -274,8 +305,13 @@ export class RunsService {
       if (!groupMap.has(key)) groupMap.set(key, { cost: 0, tokens: { input: 0, output: 0 }, runs: 0 });
       const entry = groupMap.get(key)!;
       entry.runs += 1;
-      // Steps no están incluidos en findRunsByWorkspace(include: { steps: false })
-      // Para analytics detallado usar findRunById individualmente
+
+      const steps = run.steps ?? [];
+      for (const st of steps as any[]) {
+        entry.cost              += st.costUsd              ?? 0;
+        entry.tokens.input      += st.tokenUsage?.input    ?? 0;
+        entry.tokens.output     += st.tokenUsage?.output   ?? 0;
+      }
     }
 
     const groups = Array.from(groupMap.entries())
@@ -291,15 +327,31 @@ export class RunsService {
     return { totalCost, totalTokens, totalRuns: runs.length, groups };
   }
 
+  /**
+   * getUsageByAgent — cuenta runs (no steps) por agente y acumula cost/tokens.
+   */
   async getUsageByAgent(workspaceId: string) {
     const runs = await getRepo().findRunsByWorkspace(workspaceId, { limit: 1000 });
-    const agentMap = new Map<string, { cost: number; tokens: { input: number; output: number }; steps: number }>();
+    const agentMap = new Map<string, { cost: number; tokens: { input: number; output: number }; runs: number }>();
 
-    for (const run of runs) {
+    // Cargamos steps para cost/tokens reales por agente
+    const fullRuns = await Promise.all(
+      runs.map((r) => getRepo().findRunById(r.id)),
+    );
+
+    for (const run of fullRuns) {
+      if (!run) continue;
       const agentId = run.agentId ?? 'unassigned';
-      if (!agentMap.has(agentId)) agentMap.set(agentId, { cost: 0, tokens: { input: 0, output: 0 }, steps: 0 });
+      if (!agentMap.has(agentId)) agentMap.set(agentId, { cost: 0, tokens: { input: 0, output: 0 }, runs: 0 });
       const entry = agentMap.get(agentId)!;
-      entry.steps += 1;
+      entry.runs += 1;
+
+      const steps = run.steps ?? [];
+      for (const st of steps as any[]) {
+        entry.cost              += st.costUsd              ?? 0;
+        entry.tokens.input      += st.tokenUsage?.input    ?? 0;
+        entry.tokens.output     += st.tokenUsage?.output   ?? 0;
+      }
     }
 
     return Array.from(agentMap.entries())

--- a/apps/api/src/modules/settings/settings.routes.ts
+++ b/apps/api/src/modules/settings/settings.routes.ts
@@ -20,26 +20,19 @@
  */
 
 import { Router } from 'express'
-import { PrismaClient } from '@prisma/client'
+import { getPrisma } from '../../lib/prisma.js'
 import { SettingsService } from './settings.service'
-
-// Singleton Prisma client — reuse the one from the server context if available
-let _prisma: PrismaClient | null = null
-function getPrisma(): PrismaClient {
-  if (!_prisma) _prisma = new PrismaClient()
-  return _prisma
-}
 
 function makeService(): SettingsService {
   return new SettingsService(getPrisma())
 }
 
 export function registerSettingsRoutes(router: Router): void {
+
   // ── GET /settings/providers ───────────────────────────────────────────────
   router.get('/settings/providers', async (_req, res) => {
     try {
-      const svc       = makeService()
-      const providers = await svc.listProviders()
+      const providers = await makeService().listProviders()
       res.json(providers)
     } catch (err) {
       console.error('[settings] listProviders error', err)
@@ -49,7 +42,7 @@ export function registerSettingsRoutes(router: Router): void {
 
   // ── PATCH /settings/providers/:providerId/key ─────────────────────────────
   router.patch('/settings/providers/:providerId/key', async (req, res) => {
-    const { providerId } = req.params
+    const { providerId } = req.params as { providerId: string }
     const { apiKey }     = req.body as { apiKey?: string }
 
     if (!apiKey || typeof apiKey !== 'string' || apiKey.trim() === '') {
@@ -58,31 +51,31 @@ export function registerSettingsRoutes(router: Router): void {
     }
 
     try {
-      await makeService().saveProviderKey(providerId, apiKey.trim())
+      await makeService().setProviderKey(providerId, apiKey.trim())
       res.json({ ok: true })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      const status = msg.includes('Unknown provider') ? 404 : 400
+      const status = msg.includes('not found') ? 404 : 400
       res.status(status).json({ error: msg })
     }
   })
 
   // ── DELETE /settings/providers/:providerId/key ────────────────────────────
   router.delete('/settings/providers/:providerId/key', async (req, res) => {
-    const { providerId } = req.params
+    const { providerId } = req.params as { providerId: string }
     try {
       await makeService().deleteProviderKey(providerId)
       res.json({ ok: true })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      const status = msg.includes('Unknown provider') ? 404 : 400
+      const status = msg.includes('not found') ? 404 : 400
       res.status(status).json({ error: msg })
     }
   })
 
   // ── POST /settings/providers/:providerId/test ─────────────────────────────
   router.post('/settings/providers/:providerId/test', async (req, res) => {
-    const { providerId } = req.params
+    const { providerId } = req.params as { providerId: string }
     const { modelId }    = req.body as { modelId?: string }
 
     if (!modelId || typeof modelId !== 'string') {
@@ -102,10 +95,10 @@ export function registerSettingsRoutes(router: Router): void {
   // ── GET /settings/n8n ─────────────────────────────────────────────────────
   router.get('/settings/n8n', async (_req, res) => {
     try {
-      const cfg = await makeService().getN8nConfig()
+      const cfg = await makeService().getN8n()
       res.json(cfg)
     } catch (err) {
-      console.error('[settings] getN8nConfig error', err)
+      console.error('[settings] getN8n error', err)
       res.status(500).json({ error: 'Failed to get n8n config' })
     }
   })
@@ -124,10 +117,10 @@ export function registerSettingsRoutes(router: Router): void {
     }
 
     try {
-      await makeService().saveN8nConfig(baseUrl.trim(), apiKey)
+      await makeService().setN8n(baseUrl.trim(), apiKey)
       res.json({ ok: true })
     } catch (err) {
-      console.error('[settings] saveN8nConfig error', err)
+      console.error('[settings] setN8n error', err)
       res.status(500).json({ error: 'Failed to save n8n config' })
     }
   })

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -2,8 +2,8 @@
  * settings.service.ts
  *
  * Acepta PrismaClient como dependencia inyectada (patrón global del repo).
- * Si no se pasa, crea su propio singleton lazy — retrocompatible con
- * cualquier caller que construya SettingsService() sin argumentos.
+ * Si no se pasa, usa el singleton `prisma` exportado por prisma.service
+ * (ruta canónica del repo: modules/core/db/prisma.service).
  */
 import type { PrismaClient } from '@prisma/client'
 import { PROVIDER_MODELS } from '../../lib/provider-models'
@@ -23,8 +23,8 @@ export class SettingsService {
   private readonly prisma: PrismaClient
 
   /**
-   * @param prisma PrismaClient inyectado desde el caller.
-   *   Si se omite, importa getPrisma() del singleton global del API.
+   * @param prisma PrismaClient inyectado desde el caller (preferido).
+   *   Si se omite, importa el singleton `prisma` de modules/core/db/prisma.service.
    *   Esto permite usar SettingsService() sin args (retrocompatible)
    *   y SettingsService(prisma) con inyección explícita.
    */
@@ -32,9 +32,9 @@ export class SettingsService {
     if (prisma) {
       this.prisma = prisma
     } else {
-      // Lazy import para evitar ciclos — sólo se resuelve si no se inyecta
+      // Lazy require para evitar ciclos — usa la ruta canónica del repo
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { getPrisma } = require('../../lib/prisma.js') as { getPrisma: () => PrismaClient }
+      const { getPrisma } = require('../core/db/prisma.service') as { getPrisma: () => PrismaClient }
       this.prisma = getPrisma()
     }
   }

--- a/apps/api/src/modules/settings/settings.service.ts
+++ b/apps/api/src/modules/settings/settings.service.ts
@@ -1,9 +1,12 @@
-import { PrismaClient } from '@prisma/client'
+/**
+ * settings.service.ts
+ *
+ * Acepta PrismaClient como dependencia inyectada (patrón global del repo).
+ * Si no se pasa, crea su propio singleton lazy — retrocompatible con
+ * cualquier caller que construya SettingsService() sin argumentos.
+ */
+import type { PrismaClient } from '@prisma/client'
 import { PROVIDER_MODELS } from '../../lib/provider-models'
-
-// Singleton prisma — si el proyecto exporta uno compartido (ej. lib/prisma.ts),
-// reemplazar esta línea con: import { prisma } from '../../lib/prisma'
-const prisma = new PrismaClient()
 
 // ── Errores tipados para el controller ───────────────────────────────────────
 export class NotFoundError extends Error {
@@ -17,16 +20,34 @@ export class BadRequestError extends Error {
 
 // ── Service ──────────────────────────────────────────────────────────────────
 export class SettingsService {
+  private readonly prisma: PrismaClient
+
+  /**
+   * @param prisma PrismaClient inyectado desde el caller.
+   *   Si se omite, importa getPrisma() del singleton global del API.
+   *   Esto permite usar SettingsService() sin args (retrocompatible)
+   *   y SettingsService(prisma) con inyección explícita.
+   */
+  constructor(prisma?: PrismaClient) {
+    if (prisma) {
+      this.prisma = prisma
+    } else {
+      // Lazy import para evitar ciclos — sólo se resuelve si no se inyecta
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getPrisma } = require('../../lib/prisma.js') as { getPrisma: () => PrismaClient }
+      this.prisma = getPrisma()
+    }
+  }
 
   // ── helpers ────────────────────────────────────────────────────────────────
 
   private async getSysConfig(): Promise<Record<string, string>> {
-    const rows = await prisma.systemConfig.findMany()
-    return Object.fromEntries(rows.map(r => [r.key, r.value]))
+    const rows = await this.prisma.systemConfig.findMany()
+    return Object.fromEntries(rows.map((r: { key: string; value: string }) => [r.key, r.value]))
   }
 
   private async setKey(key: string, value: string): Promise<void> {
-    await prisma.systemConfig.upsert({
+    await this.prisma.systemConfig.upsert({
       where:  { key },
       update: { value },
       create: { key, value },
@@ -34,7 +55,7 @@ export class SettingsService {
   }
 
   private async deleteKey(key: string): Promise<void> {
-    await prisma.systemConfig.deleteMany({ where: { key } })
+    await this.prisma.systemConfig.deleteMany({ where: { key } })
   }
 
   // ── providers ──────────────────────────────────────────────────────────────
@@ -45,7 +66,6 @@ export class SettingsService {
       id,
       name:        p.label,
       requiresKey: p.requiresKey,
-      // hasKey: solo indica si existe la key — NUNCA devuelve el valor
       hasKey:      p.keyEnv ? Boolean(config[p.keyEnv]) : false,
       baseURL:     null as string | null,
       models:      p.models,
@@ -77,7 +97,6 @@ export class SettingsService {
     const config = await this.getSysConfig()
     const start  = Date.now()
     try {
-      // Import dinámico para evitar dependencias circulares
       const { buildLLMClient } = await import('@agent-visualstudio/run-engine')
       const client = buildLLMClient(modelId, { configOverride: config })
       await client.chat(

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -15,47 +15,43 @@
 
 import { createVerify } from 'node:crypto';
 import { Router, type Request, type Response } from 'express';
-import { prisma } from '../../../api/src/modules/core/db/prisma.service';
+import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
 } from './channel-adapter.interface';
 
-const db = prisma as any;
-
 const DISCORD_API = 'https://discord.com/api/v10';
 
 interface DiscordCredentials {
-  botToken: string;
-  applicationId: string;
-  publicKey: string;
+  botToken:       string;
+  applicationId:  string;
+  publicKey:      string;
 }
 
-// Tipos mínimos de interacción Discord
-const INTERACTION_TYPE = { PING: 1, APPLICATION_COMMAND: 2, MESSAGE_COMPONENT: 3 };
+const INTERACTION_TYPE          = { PING: 1, APPLICATION_COMMAND: 2, MESSAGE_COMPONENT: 3 };
 const INTERACTION_RESPONSE_TYPE = { PONG: 1, CHANNEL_MESSAGE_WITH_SOURCE: 4 };
 
 export class DiscordAdapter extends BaseChannelAdapter {
   readonly channel = 'discord';
-  private botToken = '';
+  private botToken      = '';
   private applicationId = '';
-  private publicKey = '';
+  private publicKey     = '';
 
-  // ── Lifecycle ────────────────────────────────────────────────────────────
+  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId;
-    const config = await db.channelConfig.findUnique({
-      where: { id: channelConfigId },
-    });
+    const db     = getPrisma();
+    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
     if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
 
-    const creds = config.credentials as DiscordCredentials;
-    this.botToken = creds.botToken;
-    this.applicationId = creds.applicationId;
-    this.publicKey = creds.publicKey;
-    this.credentials = config.credentials as Record<string, unknown>;
+    const creds          = config.credentials as DiscordCredentials;
+    this.botToken        = creds.botToken;
+    this.applicationId   = creds.applicationId;
+    this.publicKey       = creds.publicKey;
+    this.credentials     = config.credentials as Record<string, unknown>;
 
     console.info(`[discord] Initialized app ${this.applicationId}`);
   }
@@ -64,22 +60,17 @@ export class DiscordAdapter extends BaseChannelAdapter {
     console.info('[discord] Adapter disposed');
   }
 
-  // ── Send ─────────────────────────────────────────────────────────────────
+  // ── Send ────────────────────────────────────────────────────────────────────────
 
-  /** Enviar DM o mensaje en canal vía REST */
   async send(message: OutgoingMessage): Promise<void> {
-    // externalId = channelId de Discord
-    const url = `${DISCORD_API}/channels/${message.externalId}/messages`;
-
+    const url  = `${DISCORD_API}/channels/${message.externalId}/messages`;
     const body: Record<string, unknown> = { content: message.text };
-    if (message.richContent) {
-      body.embeds = [message.richContent];
-    }
+    if (message.richContent) body.embeds = [message.richContent];
 
     const res = await fetch(url, {
-      method: 'POST',
+      method:  'POST',
       headers: {
-        Authorization: `Bot ${this.botToken}`,
+        Authorization:  `Bot ${this.botToken}`,
         'content-type': 'application/json',
       },
       body: JSON.stringify(body),
@@ -92,107 +83,74 @@ export class DiscordAdapter extends BaseChannelAdapter {
     }
   }
 
-  // ── Router ───────────────────────────────────────────────────────────────
+  // ── Router ────────────────────────────────────────────────────────────────────
 
   getRouter(): Router {
     const router = Router();
 
-    // POST /discord/interactions — interacciones de Discord
-    router.post(
-      '/interactions',
-      async (req: Request, res: Response) => {
-        // Verificar firma Ed25519 (OBLIGATORIO por Discord)
-        const timestamp = req.headers['x-signature-timestamp'] as string;
-        const sig = req.headers['x-signature-ed25519'] as string;
+    router.post('/interactions', async (req: Request, res: Response) => {
+      const timestamp = req.headers['x-signature-timestamp'] as string;
+      const sig       = req.headers['x-signature-ed25519']   as string;
 
-        if (!this._verifySignature(JSON.stringify(req.body), timestamp, sig)) {
-          res.status(401).json({ error: 'Invalid request signature' });
-          return;
-        }
+      if (!this._verifySignature(JSON.stringify(req.body), timestamp, sig)) {
+        res.status(401).json({ error: 'Invalid request signature' });
+        return;
+      }
 
-        const interaction = req.body as {
-          type: number;
-          id: string;
-          token: string;
-          application_id: string;
-          data?: { name?: string; options?: Array<{ name: string; value: unknown }> };
-          member?: { user?: { id: string; username?: string } };
-          user?: { id: string; username?: string };
-          channel_id?: string;
+      const interaction = req.body as {
+        type:            number;
+        id:              string;
+        token:           string;
+        application_id:  string;
+        data?:           { name?: string; options?: Array<{ name: string; value: unknown }> };
+        member?:         { user?: { id: string; username?: string } };
+        user?:           { id: string; username?: string };
+        channel_id?:     string;
+      };
+
+      if (interaction.type === INTERACTION_TYPE.PING) {
+        res.json({ type: INTERACTION_RESPONSE_TYPE.PONG });
+        return;
+      }
+
+      if (interaction.type === INTERACTION_TYPE.APPLICATION_COMMAND) {
+        const commandName = interaction.data?.name ?? 'unknown';
+        const options     = interaction.data?.options ?? [];
+        const userInput   = (options.find((o) => o.name === 'prompt')?.value as string) ?? commandName;
+        const userId      = interaction.member?.user?.id ?? interaction.user?.id ?? interaction.id;
+        const channelId   = interaction.channel_id ?? interaction.id;
+
+        res.json({
+          type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
+          data: { content: '⏳ Procesando...', flags: 64 },
+        });
+
+        const msg: IncomingMessage = {
+          externalId: channelId,
+          senderId:   userId,
+          text:       userInput,
+          type:       'command',
+          metadata:   { interactionId: interaction.id, interactionToken: interaction.token, commandName, raw: interaction },
+          receivedAt: this.makeTimestamp(),
         };
+        this.emit(msg).catch((err) => console.error('[discord] emit error:', err));
+        return;
+      }
 
-        // PING — responder PONG (requerido por Discord)
-        if (interaction.type === INTERACTION_TYPE.PING) {
-          res.json({ type: INTERACTION_RESPONSE_TYPE.PONG });
-          return;
-        }
-
-        // APPLICATION_COMMAND (slash commands)
-        if (interaction.type === INTERACTION_TYPE.APPLICATION_COMMAND) {
-          const commandName = interaction.data?.name ?? 'unknown';
-          const options = interaction.data?.options ?? [];
-          const userInput = options.find((o) => o.name === 'prompt')?.value as string
-            ?? commandName;
-          const userId =
-            interaction.member?.user?.id ??
-            interaction.user?.id ??
-            interaction.id;
-          const channelId = interaction.channel_id ?? interaction.id;
-
-          // Responder con "está escribiendo..." inmediatamente
-          res.json({
-            type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-            data: { content: '⏳ Procesando...', flags: 64 }, // ephemeral
-          });
-
-          // Emitir mensaje al handler del gateway
-          const msg: IncomingMessage = {
-            externalId: channelId,
-            senderId: userId,
-            text: userInput,
-            type: 'command',
-            metadata: {
-              interactionId: interaction.id,
-              interactionToken: interaction.token,
-              commandName,
-              raw: interaction,
-            },
-            receivedAt: this.makeTimestamp(),
-          };
-          this.emit(msg).catch((err) =>
-            console.error('[discord] emit error:', err),
-          );
-
-          return;
-        }
-
-        // Otros tipos de interacción → ignorar
-        res.json({ type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-          data: { content: 'Interacción no soportada', flags: 64 } });
-      },
-    );
+      res.json({ type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: { content: 'Interacción no soportada', flags: 64 } });
+    });
 
     return router;
   }
 
-  // ── Helpers ──────────────────────────────────────────────────────────────
+  // ── Helpers ──────────────────────────────────────────────────────────────────────
 
-  /**
-   * Verifica la firma Ed25519 que Discord envía en cada request.
-   * OBLIGATORIO — Discord rechaza bots que no validen la firma.
-   */
-  private _verifySignature(
-    body: string,
-    timestamp: string,
-    signature: string,
-  ): boolean {
+  private _verifySignature(body: string, timestamp: string, signature: string): boolean {
     try {
       const verify = createVerify('ed25519');
       verify.update(timestamp + body);
-      return verify.verify(
-        Buffer.from(this.publicKey, 'hex'),
-        Buffer.from(signature, 'hex'),
-      );
+      return verify.verify(Buffer.from(this.publicKey, 'hex'), Buffer.from(signature, 'hex'));
     } catch {
       return false;
     }

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -7,20 +7,24 @@
  *
  * Secrets esperados en ChannelConfig.secretsEncrypted:
  *   {
- *     botToken:     "xoxb-...",
+ *     botToken:      "xoxb-...",
  *     signingSecret: "...",
- *     appToken?:    "xapp-..." (solo Socket Mode)
+ *     appToken?:     "xapp-..." (solo Socket Mode)
  *   }
  *
  * Patrón de integración:
- *   El SlackAdapter implementa IChannelAdapter.
+ *   SlackAdapter extiende BaseChannelAdapter.
  *   En HTTP mode, receive() parsea el payload de Slack Events API.
  *   En Socket Mode, la App Bolt maneja internamente y llama onMessage handler.
  *
  * Ref: https://slack.dev/bolt-js/
  */
 
-import type { IChannelAdapter, IncomingMessage, OutgoingMessage } from './channel-adapter.interface';
+import {
+  BaseChannelAdapter,
+  type IncomingMessage,
+  type OutgoingMessage,
+} from './channel-adapter.interface';
 
 // Tipos Bolt importados dinámicamente para lazy-load
 type BoltApp = {
@@ -30,49 +34,45 @@ type BoltApp = {
     };
   };
   start: () => Promise<void>;
-  stop: () => Promise<void>;
+  stop:  () => Promise<void>;
 };
 
 type SlackSecrets = {
-  botToken: string;
-  signingSecret: string;
-  appToken?: string;
+  botToken:       string;
+  signingSecret:  string;
+  appToken?:      string;
 };
 
 type SlackMessageEvent = {
-  type: string;
-  user?: string;
-  bot_id?: string;
-  text?: string;
+  type:     string;
+  user?:    string;
+  bot_id?:  string;
+  text?:    string;
   channel?: string;
-  ts?: string;
+  ts?:      string;
 };
 
 type SlackEventPayload = {
-  type: string;
-  event?: SlackMessageEvent;
+  type:       string;
+  event?:     SlackMessageEvent;
   challenge?: string;
 };
 
-export class SlackAdapter implements IChannelAdapter {
-  readonly channelType = 'slack';
+export class SlackAdapter extends BaseChannelAdapter {
+  readonly channel = 'slack';
 
-  private boltApp: BoltApp | null = null;
-  private secrets: SlackSecrets | null = null;
-  private messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null;
+  private boltApp:    BoltApp | null = null;
   private socketMode = false;
 
   // ---------------------------------------------------------------------------
-  // IChannelAdapter — setup / teardown
+  // IChannelAdapter — initialize / dispose
   // ---------------------------------------------------------------------------
 
-  async setup(
-    config: Record<string, unknown>,
-    secrets: Record<string, unknown>,
-  ): Promise<void> {
-    this.secrets = secrets as SlackSecrets;
+  async initialize(channelConfigId: string): Promise<void> {
+    this.channelConfigId = channelConfigId;
+
     this.socketMode =
-      (config['socketMode'] as boolean | undefined) ??
+      (this.credentials['socketMode'] as boolean | undefined) ??
       process.env.SLACK_SOCKET_MODE === 'true';
 
     if (this.socketMode) {
@@ -81,10 +81,7 @@ export class SlackAdapter implements IChannelAdapter {
     // En HTTP mode no hay nada que iniciar — los mensajes llegan vía receive()
   }
 
-  async teardown(
-    _config: Record<string, unknown>,
-    _secrets: Record<string, unknown>,
-  ): Promise<void> {
+  async dispose(): Promise<void> {
     if (this.boltApp && this.socketMode) {
       await this.boltApp.stop().catch((err: unknown) =>
         console.warn('[SlackAdapter] stop error:', err),
@@ -94,25 +91,18 @@ export class SlackAdapter implements IChannelAdapter {
   }
 
   // ---------------------------------------------------------------------------
-  // IChannelAdapter — onMessage / receive / send
+  // Receive (HTTP mode) — parsea Slack Events API payload
   // ---------------------------------------------------------------------------
-
-  onMessage(handler: (msg: IncomingMessage) => Promise<void>): void {
-    this.messageHandler = handler;
-  }
 
   /**
    * HTTP mode: parsea el payload de Slack Events API.
-   * Retorna null para eventos que no son mensajes (ej. url_verification ya
-   * se maneja en el router antes de llegar aquí).
+   * Retorna null para eventos que no son mensajes.
    */
   async receive(
     rawPayload: Record<string, unknown>,
-    _secrets: Record<string, unknown>,
   ): Promise<IncomingMessage | null> {
     const payload = rawPayload as SlackEventPayload;
 
-    // Ignorar mensajes de bots
     const event = payload.event;
     if (!event || event.type !== 'message' || event.bot_id) {
       return null;
@@ -121,43 +111,44 @@ export class SlackAdapter implements IChannelAdapter {
     if (!event.user || !event.channel) return null;
 
     return {
-      channelType: 'slack',
-      externalUserId: event.user,
-      externalChatId: event.channel,
-      text: event.text ?? '',
-      rawPayload,
+      externalId:  event.channel,
+      senderId:    event.user,
+      text:        event.text ?? '',
+      type:        'text',
+      receivedAt:  this.makeTimestamp(),
+      metadata:    rawPayload,
     };
   }
 
-  async send(
-    outbound: OutgoingMessage,
-    _config: Record<string, unknown>,
-    secrets: Record<string, unknown>,
-  ): Promise<void> {
-    const s = (secrets as SlackSecrets);
+  // ---------------------------------------------------------------------------
+  // IChannelAdapter — send
+  // ---------------------------------------------------------------------------
 
-    // En Socket Mode, usamos el cliente Bolt
+  async send(message: OutgoingMessage): Promise<void> {
+    const secrets = this.credentials as SlackSecrets;
+    const isMarkdown = message.type === 'markdown';
+
+    // Socket Mode: usar cliente Bolt
     if (this.socketMode && this.boltApp) {
       await this.boltApp.client.chat.postMessage({
-        channel: outbound.externalChatId ?? outbound.externalUserId,
-        text: outbound.text,
-        mrkdwn: outbound.parseMode === 'markdown',
+        channel: message.externalId,
+        text:    message.text,
+        mrkdwn:  isMarkdown,
       });
       return;
     }
 
-    // En HTTP mode, llamamos directo a la Slack Web API con fetch
-    const channel = outbound.externalChatId ?? outbound.externalUserId;
+    // HTTP mode: llamar directo a Slack Web API
     const response = await fetch('https://slack.com/api/chat.postMessage', {
-      method: 'POST',
+      method:  'POST',
       headers: {
-        Authorization: `Bearer ${s.botToken}`,
+        Authorization:  `Bearer ${secrets.botToken}`,
         'Content-Type': 'application/json; charset=utf-8',
       },
       body: JSON.stringify({
-        channel,
-        text: outbound.text,
-        mrkdwn: outbound.parseMode === 'markdown',
+        channel: message.externalId,
+        text:    message.text,
+        mrkdwn:  isMarkdown,
       }),
     });
 
@@ -178,33 +169,24 @@ export class SlackAdapter implements IChannelAdapter {
   /**
    * Verifica la firma X-Slack-Signature del request.
    * Llamar desde el router antes de dispatch().
-   *
-   * @param signingSecret  ChannelConfig.secretsEncrypted.signingSecret
-   * @param timestamp      Header X-Slack-Request-Timestamp
-   * @param signature      Header X-Slack-Signature
-   * @param rawBody        Raw body string (antes de JSON.parse)
    */
   static async verifySignature(
     signingSecret: string,
-    timestamp: string,
-    signature: string,
-    rawBody: string,
+    timestamp:     string,
+    signature:     string,
+    rawBody:       string,
   ): Promise<boolean> {
-    // Rechazar requests con más de 5 minutos de antigüedad (replay attacks)
     const ts = parseInt(timestamp, 10);
     if (Math.abs(Date.now() / 1000 - ts) > 300) return false;
 
-    const { createHmac } = await import('crypto');
-    const baseString = `v0:${timestamp}:${rawBody}`;
-    const expectedSig =
-      'v0=' + createHmac('sha256', signingSecret).update(baseString).digest('hex');
+    const { createHmac, timingSafeEqual } = await import('crypto');
+    const baseString  = `v0:${timestamp}:${rawBody}`;
+    const expectedSig = 'v0=' + createHmac('sha256', signingSecret).update(baseString).digest('hex');
 
-    // Comparación segura para evitar timing attacks
-    const { timingSafeEqual } = await import('crypto');
     try {
       return timingSafeEqual(
         Buffer.from(expectedSig, 'utf8'),
-        Buffer.from(signature, 'utf8'),
+        Buffer.from(signature,   'utf8'),
       );
     } catch {
       return false;
@@ -216,11 +198,12 @@ export class SlackAdapter implements IChannelAdapter {
   // ---------------------------------------------------------------------------
 
   private async startSocketMode(): Promise<void> {
-    if (!this.secrets?.appToken) {
+    const secrets = this.credentials as SlackSecrets;
+
+    if (!secrets.appToken) {
       throw new Error('[SlackAdapter] Socket Mode requires appToken (xapp-...)');
     }
 
-    // Importación dinámica — @slack/bolt no se carga si no se usa
     const { App, LogLevel } = await import('@slack/bolt').catch(() => {
       throw new Error(
         '[SlackAdapter] @slack/bolt not installed. Run: pnpm add @slack/bolt',
@@ -228,29 +211,27 @@ export class SlackAdapter implements IChannelAdapter {
     });
 
     const app = new App({
-      token: this.secrets.botToken,
-      signingSecret: this.secrets.signingSecret,
-      appToken: this.secrets.appToken,
-      socketMode: true,
-      logLevel: LogLevel.WARN,
+      token:         secrets.botToken,
+      signingSecret: secrets.signingSecret,
+      appToken:      secrets.appToken,
+      socketMode:    true,
+      logLevel:      LogLevel.WARN,
     });
 
-    // Escuchar mensajes
-    app.message(async ({ message, say: _say }) => {
+    app.message(async ({ message }) => {
       const msg = message as SlackMessageEvent;
       if (!this.messageHandler || msg.bot_id || !msg.user) return;
 
       const incoming: IncomingMessage = {
-        channelType: 'slack',
-        externalUserId: msg.user,
-        externalChatId: msg.channel,
-        text: msg.text ?? '',
-        rawPayload: message as unknown as Record<string, unknown>,
+        externalId: msg.channel ?? '',
+        senderId:   msg.user,
+        text:       msg.text ?? '',
+        type:       'text',
+        receivedAt: this.makeTimestamp(),
+        metadata:   message as unknown as Record<string, unknown>,
       };
 
-      await this.messageHandler(incoming).catch((err: unknown) => {
-        console.error('[SlackAdapter] messageHandler error:', err);
-      });
+      await this.emit(incoming);
     });
 
     await app.start();

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -5,7 +5,7 @@
  *   - Socket Mode: SLACK_SOCKET_MODE=true + SLACK_APP_TOKEN=xapp-...
  *   - HTTP Mode: recibe POST en /gateway/slack/:channelId
  *
- * Secrets esperados en ChannelConfig.secretsEncrypted:
+ * Secrets esperados en ChannelConfig.credentials (cifrado en DB):
  *   {
  *     botToken:      "xoxb-...",
  *     signingSecret: "...",
@@ -20,6 +20,7 @@
  * Ref: https://slack.dev/bolt-js/
  */
 
+import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
@@ -41,6 +42,7 @@ type SlackSecrets = {
   botToken:       string;
   signingSecret:  string;
   appToken?:      string;
+  socketMode?:    boolean;
 };
 
 type SlackMessageEvent = {
@@ -71,14 +73,25 @@ export class SlackAdapter extends BaseChannelAdapter {
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId;
 
+    // Carga credenciales desde DB — mismo patrón que discord/telegram/whatsapp adapters
+    const db     = getPrisma();
+    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
+    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+
+    // Asignar credentials ANTES de cualquier uso (send/startSocketMode lo necesita)
+    this.credentials = config.credentials as Record<string, unknown>;
+
+    const secrets = this.credentials as SlackSecrets;
     this.socketMode =
-      (this.credentials['socketMode'] as boolean | undefined) ??
+      secrets.socketMode ??
       process.env.SLACK_SOCKET_MODE === 'true';
 
     if (this.socketMode) {
       await this.startSocketMode();
     }
     // En HTTP mode no hay nada que iniciar — los mensajes llegan vía receive()
+
+    console.info(`[SlackAdapter] initialized (channelConfigId=${channelConfigId}, socketMode=${this.socketMode})`);
   }
 
   async dispose(): Promise<void> {

--- a/apps/gateway/src/channels/telegram.adapter.ts
+++ b/apps/gateway/src/channels/telegram.adapter.ts
@@ -13,40 +13,37 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { prisma } from '../../../api/src/modules/core/db/prisma.service';
+import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
 } from './channel-adapter.interface';
 
-const db = prisma as any;
-
 const TELEGRAM_API = 'https://api.telegram.org';
 
 interface TelegramCredentials {
-  botToken: string;
+  botToken:       string;
   webhookSecret?: string;
 }
 
 export class TelegramAdapter extends BaseChannelAdapter {
-  readonly channel = 'telegram';
-  private botToken = '';
+  readonly channel      = 'telegram';
+  private botToken      = '';
   private webhookSecret = '';
 
-  // ── Lifecycle ────────────────────────────────────────────────────────────
+  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId;
-    const config = await db.channelConfig.findUnique({
-      where: { id: channelConfigId },
-    });
+    const db     = getPrisma();
+    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
     if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
 
-    const creds = config.credentials as TelegramCredentials;
-    this.botToken = creds.botToken;
-    this.webhookSecret = creds.webhookSecret ?? '';
-    this.credentials = config.credentials as Record<string, unknown>;
+    const creds          = config.credentials as TelegramCredentials;
+    this.botToken        = creds.botToken;
+    this.webhookSecret   = creds.webhookSecret ?? '';
+    this.credentials     = config.credentials as Record<string, unknown>;
 
     console.info(`[telegram] Initialized bot for config ${channelConfigId}`);
   }
@@ -55,27 +52,21 @@ export class TelegramAdapter extends BaseChannelAdapter {
     console.info('[telegram] Adapter disposed');
   }
 
-  // ── Send ─────────────────────────────────────────────────────────────────
+  // ── Send ────────────────────────────────────────────────────────────────────────
 
   async send(message: OutgoingMessage): Promise<void> {
-    const chatId = message.externalId;
-    const url = `${TELEGRAM_API}/bot${this.botToken}/sendMessage`;
-
+    const url  = `${TELEGRAM_API}/bot${this.botToken}/sendMessage`;
     const body: Record<string, unknown> = {
-      chat_id: chatId,
-      text: message.text,
+      chat_id:    message.externalId,
+      text:       message.text,
       parse_mode: 'Markdown',
     };
-
-    // Botones / quick replies
-    if (message.richContent) {
-      body.reply_markup = message.richContent;
-    }
+    if (message.richContent) body.reply_markup = message.richContent;
 
     const res = await fetch(url, {
-      method: 'POST',
+      method:  'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
+      body:    JSON.stringify(body),
     });
 
     if (!res.ok) {
@@ -85,14 +76,12 @@ export class TelegramAdapter extends BaseChannelAdapter {
     }
   }
 
-  // ── Router ───────────────────────────────────────────────────────────────
+  // ── Router ────────────────────────────────────────────────────────────────────
 
   getRouter(): Router {
     const router = Router();
 
-    // POST /telegram/webhook — updates de Telegram
     router.post('/webhook', async (req: Request, res: Response) => {
-      // Validar webhook secret si está configurado
       if (this.webhookSecret) {
         const secret = req.headers['x-telegram-bot-api-secret-token'];
         if (secret !== this.webhookSecret) {
@@ -102,26 +91,26 @@ export class TelegramAdapter extends BaseChannelAdapter {
       }
 
       const update = req.body as {
-        update_id: number;
-        message?: {
+        update_id:       number;
+        message?:        {
           message_id: number;
-          chat: { id: number };
-          from?: { id: number; username?: string };
-          text?: string;
+          chat:       { id: number };
+          from?:      { id: number; username?: string };
+          text?:      string;
         };
         callback_query?: { id: string; data?: string; message?: { chat: { id: number } } };
       };
 
-      const message = update.message;
+      const message       = update.message;
       const callbackQuery = update.callback_query;
 
       if (message?.text) {
         const msg: IncomingMessage = {
           externalId: String(message.chat.id),
-          senderId: String(message.from?.id ?? message.chat.id),
-          text: message.text,
-          type: message.text.startsWith('/') ? 'command' : 'text',
-          metadata: { updateId: update.update_id, raw: message },
+          senderId:   String(message.from?.id ?? message.chat.id),
+          text:       message.text,
+          type:       message.text.startsWith('/') ? 'command' : 'text',
+          metadata:   { updateId: update.update_id, raw: message },
           receivedAt: this.makeTimestamp(),
         };
         await this.emit(msg);
@@ -129,49 +118,37 @@ export class TelegramAdapter extends BaseChannelAdapter {
         const chatId = callbackQuery.message?.chat.id;
         const msg: IncomingMessage = {
           externalId: String(chatId),
-          senderId: String(chatId),
-          text: callbackQuery.data,
-          type: 'command',
-          metadata: { callbackQueryId: callbackQuery.id, raw: callbackQuery },
+          senderId:   String(chatId),
+          text:       callbackQuery.data,
+          type:       'command',
+          metadata:   { callbackQueryId: callbackQuery.id, raw: callbackQuery },
           receivedAt: this.makeTimestamp(),
         };
         await this.emit(msg);
-
-        // Responder al callback_query para quitar el spinner de Telegram
-        await fetch(
-          `${TELEGRAM_API}/bot${this.botToken}/answerCallbackQuery`,
-          {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ callback_query_id: callbackQuery.id }),
-          },
-        );
+        await fetch(`${TELEGRAM_API}/bot${this.botToken}/answerCallbackQuery`, {
+          method:  'POST',
+          headers: { 'content-type': 'application/json' },
+          body:    JSON.stringify({ callback_query_id: callbackQuery.id }),
+        });
       }
 
       res.json({ ok: true });
     });
 
-    // POST /telegram/setup — registra webhook en Telegram
     router.post('/setup', async (req: Request, res: Response) => {
       const { webhookUrl } = req.body as { webhookUrl: string };
       if (!webhookUrl) {
         res.status(400).json({ ok: false, error: 'webhookUrl required' });
         return;
       }
-
       const body: Record<string, unknown> = { url: webhookUrl };
-      if (this.webhookSecret) {
-        body.secret_token = this.webhookSecret;
-      }
+      if (this.webhookSecret) body.secret_token = this.webhookSecret;
 
-      const apiRes = await fetch(
-        `${TELEGRAM_API}/bot${this.botToken}/setWebhook`,
-        {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(body),
-        },
-      );
+      const apiRes = await fetch(`${TELEGRAM_API}/bot${this.botToken}/setWebhook`, {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify(body),
+      });
       const data = await apiRes.json();
       res.json({ ok: true, telegram: data });
     });
@@ -179,17 +156,14 @@ export class TelegramAdapter extends BaseChannelAdapter {
     return router;
   }
 
-  // ── Setup helper (puede llamarse en initialize si TELEGRAM_WEBHOOK_URL está en env) ──
-
   async autoSetupWebhook(): Promise<void> {
     const webhookUrl = process.env.TELEGRAM_WEBHOOK_URL;
     if (!webhookUrl) return;
-
     await fetch(`${TELEGRAM_API}/bot${this.botToken}/setWebhook`, {
-      method: 'POST',
+      method:  'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        url: `${webhookUrl}/gateway/telegram/webhook`,
+      body:    JSON.stringify({
+        url:          `${webhookUrl}/gateway/telegram/webhook`,
         secret_token: this.webhookSecret || undefined,
       }),
     });

--- a/apps/gateway/src/channels/webchat.adapter.ts
+++ b/apps/gateway/src/channels/webchat.adapter.ts
@@ -5,42 +5,34 @@
  *   POST /gateway/webchat/:sessionId/message  → mensaje entrante
  *   GET  /gateway/webchat/:sessionId/stream   → SSE de respuestas
  *
- * El servidor Fastify/Express del gateway monta las rutas usando
- * WebChatAdapter.getRouter().
- *
  * Inspirado en Flowise ChatFlow y n8n WebhookNode.
  */
 
 import { Router, type Request, type Response } from 'express';
-import { prisma } from '../../../api/src/modules/core/db/prisma.service';
+import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
 } from './channel-adapter.interface';
 
-const db = prisma as any;
-
 export class WebChatAdapter extends BaseChannelAdapter {
   readonly channel = 'webchat';
 
-  // SSE clients: sessionId → list of Response streams
   private readonly sseClients = new Map<string, Response[]>();
 
-  // ── Lifecycle ────────────────────────────────────────────────────────────
+  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId;
-    const config = await db.channelConfig.findUnique({
-      where: { id: channelConfigId },
-    });
+    const db     = getPrisma();
+    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
     if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
     this.credentials = config.credentials as Record<string, unknown>;
     console.info(`[webchat] Initialized for config ${channelConfigId}`);
   }
 
   async dispose(): Promise<void> {
-    // Cerrar todos los streams SSE activos
     for (const [sessionId, clients] of this.sseClients) {
       clients.forEach((res) => res.end());
       console.info(`[webchat] Closed ${clients.length} SSE streams for session ${sessionId}`);
@@ -48,55 +40,46 @@ export class WebChatAdapter extends BaseChannelAdapter {
     this.sseClients.clear();
   }
 
-  // ── Send ─────────────────────────────────────────────────────────────────
+  // ── Send ────────────────────────────────────────────────────────────────────────
 
   async send(message: OutgoingMessage): Promise<void> {
+    const db      = getPrisma();
     const clients = this.sseClients.get(message.externalId) ?? [];
     const payload = JSON.stringify({
-      type: 'message',
-      text: message.text,
+      type:        'message',
+      text:        message.text,
       richContent: message.richContent ?? null,
-      metadata: message.metadata ?? {},
-      ts: new Date().toISOString(),
+      metadata:    message.metadata    ?? {},
+      ts:          new Date().toISOString(),
     });
 
     if (clients.length === 0) {
-      // Guardar en DB para que el cliente la recupere en el próximo poll
       await db.gatewaySession.update({
         where: {
           channelConfigId_externalId: {
             channelConfigId: this.channelConfigId,
-            externalId: message.externalId,
+            externalId:      message.externalId,
           },
         },
         data: {
-          contextWindow: {
-            push: { role: 'assistant', content: message.text },
-          } as any,
+          contextWindow:  { push: { role: 'assistant', content: message.text } } as any,
           lastActivityAt: new Date(),
         },
       });
       return;
     }
 
-    // Enviar por SSE a todos los clientes activos de esta sesión
-    clients.forEach((res) => {
-      res.write(`data: ${payload}\n\n`);
-    });
+    clients.forEach((res) => { res.write(`data: ${payload}\n\n`); });
   }
 
-  // ── Express Router ───────────────────────────────────────────────────────
+  // ── Express Router ────────────────────────────────────────────────────────────────
 
   getRouter(): Router {
     const router = Router();
 
-    // POST /webchat/:sessionId/message — mensaje entrante del usuario
     router.post('/:sessionId/message', async (req: Request, res: Response) => {
       const { sessionId } = req.params;
-      const { text, metadata } = req.body as {
-        text: string;
-        metadata?: Record<string, unknown>;
-      };
+      const { text, metadata } = req.body as { text: string; metadata?: Record<string, unknown> };
 
       if (!text?.trim()) {
         res.status(400).json({ ok: false, error: 'text is required' });
@@ -105,9 +88,9 @@ export class WebChatAdapter extends BaseChannelAdapter {
 
       const msg: IncomingMessage = {
         externalId: sessionId,
-        senderId: sessionId,
-        text: text.trim(),
-        type: 'text',
+        senderId:   sessionId,
+        text:       text.trim(),
+        type:       'text',
         metadata,
         receivedAt: this.makeTimestamp(),
       };
@@ -116,47 +99,35 @@ export class WebChatAdapter extends BaseChannelAdapter {
       res.json({ ok: true });
     });
 
-    // GET /webchat/:sessionId/stream — SSE stream de respuestas
     router.get('/:sessionId/stream', (req: Request, res: Response) => {
       const { sessionId } = req.params;
 
-      res.setHeader('Content-Type', 'text/event-stream');
-      res.setHeader('Cache-Control', 'no-cache');
-      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('Content-Type',    'text/event-stream');
+      res.setHeader('Cache-Control',   'no-cache');
+      res.setHeader('Connection',      'keep-alive');
       res.setHeader('X-Accel-Buffering', 'no');
       res.flushHeaders();
 
-      if (!this.sseClients.has(sessionId)) {
-        this.sseClients.set(sessionId, []);
-      }
+      if (!this.sseClients.has(sessionId)) this.sseClients.set(sessionId, []);
       this.sseClients.get(sessionId)!.push(res);
 
-      // Heartbeat para mantener la conexión viva
-      const heartbeat = setInterval(() => {
-        res.write(': heartbeat\n\n');
-      }, 25_000);
+      const heartbeat = setInterval(() => { res.write(': heartbeat\n\n'); }, 25_000);
 
       req.on('close', () => {
         clearInterval(heartbeat);
-        const clients = this.sseClients.get(sessionId) ?? [];
-        const idx = clients.indexOf(res);
-        if (idx !== -1) clients.splice(idx, 1);
+        const list = this.sseClients.get(sessionId) ?? [];
+        const idx  = list.indexOf(res);
+        if (idx !== -1) list.splice(idx, 1);
       });
     });
 
-    // GET /webchat/:sessionId/history — historial para HTTP polling
     router.get('/:sessionId/history', async (req: Request, res: Response) => {
       const { sessionId } = req.params;
+      const db      = getPrisma();
       const session = await db.gatewaySession.findFirst({
-        where: {
-          channelConfigId: this.channelConfigId,
-          externalId: sessionId,
-        },
+        where: { channelConfigId: this.channelConfigId, externalId: sessionId },
       });
-      res.json({
-        ok: true,
-        history: (session?.contextWindow as unknown[]) ?? [],
-      });
+      res.json({ ok: true, history: (session?.contextWindow as unknown[]) ?? [] });
     });
 
     return router;

--- a/apps/gateway/src/channels/webhook.adapter.ts
+++ b/apps/gateway/src/channels/webhook.adapter.ts
@@ -27,6 +27,7 @@
  *   con la respuesta del agente (push mode).
  */
 
+import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
@@ -55,12 +56,20 @@ export class WebhookAdapter extends BaseChannelAdapter {
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId;
-    // No hay conexión persistente — canal HTTP stateless
+
+    // Carga credenciales desde DB — mismo patrón que discord/telegram/whatsapp adapters
+    const db     = getPrisma();
+    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
+    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+
+    this.credentials = config.credentials as Record<string, unknown>;
+
+    // Canal HTTP stateless — no hay conexión persistente que iniciar
     console.info(`[WebhookAdapter] ready (channelConfigId=${channelConfigId})`);
   }
 
   async dispose(): Promise<void> {
-    // Nada que cerrar
+    // Nada que cerrar — canal HTTP stateless
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/gateway/src/channels/webhook.adapter.ts
+++ b/apps/gateway/src/channels/webhook.adapter.ts
@@ -8,81 +8,67 @@
  *
  * Formato del payload entrante (flexible):
  *   {
- *     userId:  string,          // ID del usuario/origen (requerido)
- *     text?:   string,          // Mensaje de texto
- *     data?:   Record<string, unknown>, // Payload arbitrario (se serializa como texto si no hay text)
- *     source?: string           // Identificador del sistema origen (ej. "n8n", "zapier")
+ *     userId:  string,                       // ID del usuario/origen (requerido)
+ *     text?:   string,                       // Mensaje de texto
+ *     data?:   Record<string, unknown>,      // Payload arbitrario
+ *     source?: string                        // Identificador del sistema origen
  *   }
  *
- * Autenticación del webhook:
- *   Opcional: si ChannelConfig tiene secrets.webhookSecret, se valida
- *   el header Authorization: Bearer <webhookSecret> o X-Webhook-Secret: <webhookSecret>.
- *   Si no está configurado, solo la URL actua como factor de seguridad.
+ * Autenticación:
+ *   Opcional — si credentials.webhookSecret está configurado, se valida
+ *   el header Authorization: Bearer <secret> o X-Webhook-Secret: <secret>.
  *
  * Respuesta:
  *   El adapter envía la respuesta del agente como JSON en el reply del mismo POST:
  *   { ok: true, reply: "..." }
- *   (a diferencia de Telegram/Slack que son async — aquí el caller espera la respuesta)
  *
  * Outbound (send):
- *   Si ChannelConfig.config.replyWebhookUrl está configurado, el adapter
- *   hace POST a esa URL con la respuesta del agente (push mode).
- *   Si no, la respuesta ya fue enviada en el body del request original.
+ *   Si credentials.replyWebhookUrl está configurado, hace POST a esa URL
+ *   con la respuesta del agente (push mode).
  */
 
-import type { IChannelAdapter, IncomingMessage, OutgoingMessage } from './channel-adapter.interface';
+import {
+  BaseChannelAdapter,
+  type IncomingMessage,
+  type OutgoingMessage,
+} from './channel-adapter.interface';
 
-type WebhookConfig = {
-  replyWebhookUrl?: string;   // URL a la que enviar la respuesta del agente (push mode)
-  source?: string;             // Identificador de origen para logging
-};
-
-type WebhookSecrets = {
-  webhookSecret?: string;      // Opcional: valida Authorization header
+type WebhookCredentials = {
+  webhookSecret?:   string;   // Opcional: valida Authorization header
+  replyWebhookUrl?: string;   // URL a la que enviar la respuesta (push mode)
+  source?:          string;   // Identificador de origen para logging
 };
 
 type WebhookPayload = {
-  userId: string;
-  text?: string;
-  data?: Record<string, unknown>;
+  userId:  string;
+  text?:   string;
+  data?:   Record<string, unknown>;
   source?: string;
 };
 
-export class WebhookAdapter implements IChannelAdapter {
-  readonly channelType = 'webhook';
-
-  private messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null;
+export class WebhookAdapter extends BaseChannelAdapter {
+  readonly channel = 'webhook';
 
   // ---------------------------------------------------------------------------
-  // IChannelAdapter — setup / teardown
+  // IChannelAdapter — initialize / dispose
   // ---------------------------------------------------------------------------
 
-  async setup(
-    _config: Record<string, unknown>,
-    _secrets: Record<string, unknown>,
-  ): Promise<void> {
-    // No hay conexión persistente que establecer — el canal es HTTP stateless
-    console.info('[WebhookAdapter] ready (HTTP POST mode)');
+  async initialize(channelConfigId: string): Promise<void> {
+    this.channelConfigId = channelConfigId;
+    // No hay conexión persistente — canal HTTP stateless
+    console.info(`[WebhookAdapter] ready (channelConfigId=${channelConfigId})`);
   }
 
-  async teardown(
-    _config: Record<string, unknown>,
-    _secrets: Record<string, unknown>,
-  ): Promise<void> {
+  async dispose(): Promise<void> {
     // Nada que cerrar
   }
 
   // ---------------------------------------------------------------------------
-  // IChannelAdapter — onMessage / receive / send
+  // Receive — parsea payload entrante
   // ---------------------------------------------------------------------------
-
-  onMessage(handler: (msg: IncomingMessage) => Promise<void>): void {
-    this.messageHandler = handler;
-  }
 
   async receive(
     rawPayload: Record<string, unknown>,
-    _secrets: Record<string, unknown>,
   ): Promise<IncomingMessage | null> {
     const payload = rawPayload as WebhookPayload;
 
@@ -91,7 +77,6 @@ export class WebhookAdapter implements IChannelAdapter {
       return null;
     }
 
-    // Si no hay texto, serializar data como JSON string
     let text = payload.text ?? '';
     if (!text && payload.data) {
       text = JSON.stringify(payload.data);
@@ -102,57 +87,59 @@ export class WebhookAdapter implements IChannelAdapter {
     }
 
     return {
-      channelType: 'webhook',
-      externalUserId: payload.userId,
+      externalId:  payload.userId,
+      senderId:    payload.userId,
       text,
-      rawPayload,
+      type:       'text',
+      receivedAt: this.makeTimestamp(),
+      metadata:   rawPayload,
     };
   }
 
-  async send(
-    outbound: OutgoingMessage,
-    config: Record<string, unknown>,
-    _secrets: Record<string, unknown>,
-  ): Promise<void> {
-    const cfg = config as WebhookConfig;
+  // ---------------------------------------------------------------------------
+  // IChannelAdapter — send
+  // ---------------------------------------------------------------------------
 
-    // Push mode: si hay replyWebhookUrl, enviamos la respuesta ahí
-    if (cfg.replyWebhookUrl) {
-      const response = await fetch(cfg.replyWebhookUrl, {
-        method: 'POST',
+  async send(message: OutgoingMessage): Promise<void> {
+    const creds = this.credentials as WebhookCredentials;
+
+    if (creds.replyWebhookUrl) {
+      const response = await fetch(creds.replyWebhookUrl, {
+        method:  'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          userId: outbound.externalUserId,
-          reply: outbound.text,
-          ts: new Date().toISOString(),
+          userId: message.externalId,
+          reply:  message.text,
+          ts:     new Date().toISOString(),
         }),
       });
 
       if (!response.ok) {
         console.error(
-          `[WebhookAdapter] push reply failed: HTTP ${response.status} → ${cfg.replyWebhookUrl}`,
+          `[WebhookAdapter] push reply failed: HTTP ${response.status} → ${creds.replyWebhookUrl}`,
         );
       }
     }
-    // Si no hay replyWebhookUrl, la respuesta se retorna directamente
-    // en el body del POST original (manejado por el router webhook.ts)
+    // Sin replyWebhookUrl: la respuesta se retorna en el body del POST original
+    // (manejado por el router webhook.ts)
   }
 
   // ---------------------------------------------------------------------------
-  // Verificación de secreto (llamar desde el router)
+  // Verificación de secreto (llamar desde el router antes de dispatch)
   // ---------------------------------------------------------------------------
 
   /**
-   * Valida el header Authorization o X-Webhook-Secret contra secrets.webhookSecret.
+   * Valida Authorization: Bearer <secret> o X-Webhook-Secret contra
+   * credentials.webhookSecret.
    * Retorna true si la validación pasa o si no hay secreto configurado.
    */
   static verifySecret(
-    secrets: Record<string, unknown>,
-    authHeader?: string,
-    xSecret?: string,
+    credentials:  Record<string, unknown>,
+    authHeader?:  string,
+    xSecret?:     string,
   ): boolean {
-    const expected = (secrets as WebhookSecrets).webhookSecret;
-    if (!expected) return true; // Sin secreto configurado — pass
+    const expected = (credentials as WebhookCredentials).webhookSecret;
+    if (!expected) return true;
 
     const provided =
       authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : xSecret;

--- a/apps/gateway/src/channels/whatsapp.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp.adapter.ts
@@ -16,46 +16,43 @@
 
 import { createHmac } from 'node:crypto';
 import { Router, type Request, type Response } from 'express';
-import { prisma } from '../../../api/src/modules/core/db/prisma.service';
+import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
 } from './channel-adapter.interface';
 
-const db = prisma as any;
-
 const WHATSAPP_API = 'https://graph.facebook.com/v19.0';
 
 interface WhatsAppCredentials {
-  accessToken: string;
+  accessToken:   string;
   phoneNumberId: string;
-  verifyToken: string;
-  appSecret?: string;
+  verifyToken:   string;
+  appSecret?:    string;
 }
 
 export class WhatsAppAdapter extends BaseChannelAdapter {
-  readonly channel = 'whatsapp';
-  private accessToken = '';
+  readonly channel   = 'whatsapp';
+  private accessToken   = '';
   private phoneNumberId = '';
-  private verifyToken = '';
-  private appSecret = '';
+  private verifyToken   = '';
+  private appSecret     = '';
 
-  // ── Lifecycle ────────────────────────────────────────────────────────────
+  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId;
-    const config = await db.channelConfig.findUnique({
-      where: { id: channelConfigId },
-    });
+    const db     = getPrisma();
+    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
     if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
 
-    const creds = config.credentials as WhatsAppCredentials;
-    this.accessToken = creds.accessToken;
-    this.phoneNumberId = creds.phoneNumberId;
-    this.verifyToken = creds.verifyToken;
-    this.appSecret = creds.appSecret ?? '';
-    this.credentials = config.credentials as Record<string, unknown>;
+    const creds          = config.credentials as WhatsAppCredentials;
+    this.accessToken     = creds.accessToken;
+    this.phoneNumberId   = creds.phoneNumberId;
+    this.verifyToken     = creds.verifyToken;
+    this.appSecret       = creds.appSecret ?? '';
+    this.credentials     = config.credentials as Record<string, unknown>;
 
     console.info(`[whatsapp] Initialized for phoneNumberId ${this.phoneNumberId}`);
   }
@@ -64,29 +61,27 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
     console.info('[whatsapp] Adapter disposed');
   }
 
-  // ── Send ─────────────────────────────────────────────────────────────────
+  // ── Send ────────────────────────────────────────────────────────────────────────
 
   async send(message: OutgoingMessage): Promise<void> {
-    const url = `${WHATSAPP_API}/${this.phoneNumberId}/messages`;
-
+    const url  = `${WHATSAPP_API}/${this.phoneNumberId}/messages`;
     const body: Record<string, unknown> = {
       messaging_product: 'whatsapp',
-      to: message.externalId,
+      to:   message.externalId,
       type: 'text',
       text: { body: message.text },
     };
 
-    // Interactive buttons/list (richContent)
     if (message.richContent) {
-      body.type = 'interactive';
+      body.type        = 'interactive';
       body.interactive = message.richContent;
       delete body.text;
     }
 
     const res = await fetch(url, {
-      method: 'POST',
+      method:  'POST',
       headers: {
-        Authorization: `Bearer ${this.accessToken}`,
+        Authorization:  `Bearer ${this.accessToken}`,
         'content-type': 'application/json',
       },
       body: JSON.stringify(body),
@@ -99,15 +94,14 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
     }
   }
 
-  // ── Router ───────────────────────────────────────────────────────────────
+  // ── Router ────────────────────────────────────────────────────────────────────
 
   getRouter(): Router {
     const router = Router();
 
-    // GET /whatsapp/webhook — verificación de Meta
     router.get('/webhook', (req: Request, res: Response) => {
-      const mode = req.query['hub.mode'];
-      const token = req.query['hub.verify_token'];
+      const mode      = req.query['hub.mode'];
+      const token     = req.query['hub.verify_token'];
       const challenge = req.query['hub.challenge'];
 
       if (mode === 'subscribe' && token === this.verifyToken) {
@@ -118,9 +112,7 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
       }
     });
 
-    // POST /whatsapp/webhook — mensajes entrantes
     router.post('/webhook', async (req: Request, res: Response) => {
-      // Validar firma HMAC si appSecret está configurado
       if (this.appSecret) {
         const signature = req.headers['x-hub-signature-256'] as string | undefined;
         if (!this._validateSignature(JSON.stringify(req.body), signature)) {
@@ -129,30 +121,28 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
         }
       }
 
-      // Responder 200 inmediatamente (Meta requiere < 200ms)
       res.json({ ok: true });
 
-      // Procesar mensajes en background
-      const entry = (req.body as any)?.entry?.[0];
+      const entry   = (req.body as any)?.entry?.[0];
       const changes = entry?.changes?.[0]?.value;
       const messages = changes?.messages ?? [];
 
       for (const waMsgRaw of messages) {
         const waMsg = waMsgRaw as {
-          id: string;
-          from: string;
-          type: string;
-          text?: { body: string };
+          id:        string;
+          from:      string;
+          type:      string;
+          text?:     { body: string };
           timestamp: string;
         };
 
         if (waMsg.type === 'text' && waMsg.text?.body) {
           const msg: IncomingMessage = {
             externalId: waMsg.from,
-            senderId: waMsg.from,
-            text: waMsg.text.body,
-            type: 'text',
-            metadata: { messageId: waMsg.id, raw: waMsg },
+            senderId:   waMsg.from,
+            text:       waMsg.text.body,
+            type:       'text',
+            metadata:   { messageId: waMsg.id, raw: waMsg },
             receivedAt: this.makeTimestamp(),
           };
           await this.emit(msg).catch((err) =>
@@ -165,18 +155,13 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
     return router;
   }
 
-  // ── Helpers ──────────────────────────────────────────────────────────────
+  // ── Helpers ──────────────────────────────────────────────────────────────────────
 
-  private _validateSignature(
-    rawBody: string,
-    signature?: string,
-  ): boolean {
+  private _validateSignature(rawBody: string, signature?: string): boolean {
     if (!signature) return false;
     const expected =
       'sha256=' +
-      createHmac('sha256', this.appSecret)
-        .update(rawBody, 'utf8')
-        .digest('hex');
+      createHmac('sha256', this.appSecret).update(rawBody, 'utf8').digest('hex');
     return signature === expected;
   }
 }


### PR DESCRIPTION
…y FlowExecutor real

- Elimina RunRepository(studioConfig.workspaceRoot) — constructor invalido
- Inyecta PrismaClient via getPrisma() para construir RunRepository correctamente
- Corrige LlmStepExecutor → LLMStepExecutor (capitalización correcta del export)
- Reemplaza FlowExecutor({ workspaceId, repository, stepExecutor }) por { prisma, executeAgent }
- Convierte findAll/findById a async: findRunsByWorkspace/findRunById (contrato Prisma)
- Adapta startRun/cancelRun/approveStep/rejectStep al nuevo FlowExecutor (executeRun)
- Mantiene compareRuns/getRunCost/getUsage/getUsageByAgent via Prisma async
- Elimina dependencia de workspaceStore/@deprecated(F0-08)

Closes #build-errors-runs-service
Refs: packages/run-engine/src/run-repository.ts, packages/run-engine/src/flow-executor.ts
✅ **Commit y push exitosos.** Aquí el resumen completo de la operación:

***

## Estado del deploy

**Commit SHA:** `fe4de5c17fd3329c1ea915074e8bafa10f8fbd3a` 

**Rama:** [`[feat/fix-runs-service-prisma-adapter](https://github.com/lssmanager/agent-visualstudio/blob/feat/fix-runs-service-prisma-adapter/apps/api/src/modules/runs/runs.service.ts)`](https://github.com/lssmanager/agent-visualstudio/blob/feat/fix-runs-service-prisma-adapter/apps/api/src/modules/runs/runs.service.ts) 

**Archivo actualizado:** `apps/api/src/modules/runs/runs.service.ts` 

***

## Cambios aplicados en este commit

| Problema original | Fix aplicado |
|---|---|
| `new RunRepository(studioConfig.workspaceRoot)` — constructor inválido | `new RunRepository(getPrisma())` — inyecta `PrismaClient`  |
| `LlmStepExecutor` — export inexistente | `LLMStepExecutor` — capitalización correcta del export  |
| `FlowExecutor({ workspaceId, repository, stepExecutor })` — interfaz antigua | `FlowExecutor({ prisma, executeAgent })` — contrato real  |
| `.findAll()` y `.findById()` sincrónicos | `async findRunsByWorkspace()` y `findRunById()` — contrato Prisma  |
| `.startRun(flow, trigger)` y `.cancelRun()` del ejecutor antiguo | `createRun() + executeRun()` fire-and-forget + `cancelRun()` via repo  |
| `.resumeAfterApproval()` — método inexistente en FlowExecutor | `prisma.approval.update()` directamente para approve/reject  |
| `workspaceStore` / `@deprecated(F0-08)` | Eliminado completamente  |

***

## Próximo paso recomendado

Crear el PR hacia `main` cuando estés listo:

```bash
gh pr create \
  --title "feat(fix-runs-service): Alinear RunsService con RunRepository Prisma" \
  --base main \
  --head feat/fix-runs-service-prisma-adapter \
  --body "Closes #build-errors-runs-service — ver commit fe4de5c"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Run persistence and execution moved to a database-backed, async flow with clearer replay metadata and enforced replay eligibility.
  * Channel adapters standardized to an initialize/dispose lifecycle and a unified incoming/outgoing message shape.
  * Settings service refactored to support injected database access and per-request DB retrieval.

* **Bug Fixes & Improvements**
  * Robust human-in-the-loop approval handling with atomic decisions.
  * More accurate analytics and step-level cost/token aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->