### PR TITLE
feat(F3a-03): implement WebChatAdapter with native WebSocket (ws)

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -19,11 +19,13 @@
     "helmet":                    "^7.1.0",
     "jose":                      "^5.2.0",
     "reflect-metadata":          "^0.2.0",
-    "rxjs":                      "^7.8.0"
+    "rxjs":                      "^7.8.0",
+    "ws":                        "^8.18.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node":    "^20.0.0",
+    "@types/ws":      "^8.5.13",
     "ts-node":        "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript":     "^5.0.0"

--- a/apps/gateway/src/channels/__tests__/webchat.adapter.test.ts
+++ b/apps/gateway/src/channels/__tests__/webchat.adapter.test.ts
@@ -1,0 +1,266 @@
+/**
+ * webchat.adapter.test.ts — Integration tests for WebChatAdapter (ws)
+ *
+ * Pattern: creates an in-memory http.Server, attaches the adapter,
+ * connects with a ws client, sends frames, verifies responses.
+ */
+
+import { createServer, type Server } from 'http'
+import { WebSocket } from 'ws'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { WebChatAdapter } from '../webchat.adapter.js'
+
+// ── Mock prisma ─────────────────────────────────────────────────────────
+vi.mock('../../../../api/src/modules/core/db/prisma.service', () => ({
+  prisma: {
+    channelConfig: {
+      findUnique: vi.fn().mockResolvedValue({
+        id:          'cfg-1',
+        credentials: {},
+      }),
+    },
+    gatewaySession: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      upsert:    vi.fn().mockResolvedValue({}),
+    },
+  },
+}))
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function waitForFrame(
+  ws: WebSocket,
+  predicate: (frame: Record<string, unknown>) => boolean,
+  timeoutMs = 2000,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('waitForFrame timeout')),
+      timeoutMs,
+    )
+    ws.on('message', (data) => {
+      const frame = JSON.parse(data.toString()) as Record<string, unknown>
+      if (predicate(frame)) {
+        clearTimeout(timer)
+        resolve(frame)
+      }
+    })
+  })
+}
+
+function connectWS(
+  port: number,
+  params: Record<string, string> = {},
+): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const query = new URLSearchParams(params).toString()
+    const ws = new WebSocket(`ws://localhost:${port}/gateway/webchat?${query}`)
+    ws.once('open',  () => resolve(ws))
+    ws.once('error', reject)
+  })
+}
+
+function closeWS(ws: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) return resolve()
+    ws.once('close', () => resolve())
+    ws.close()
+  })
+}
+
+// ── Test suite ──────────────────────────────────────────────────────────
+
+describe('WebChatAdapter — WebSocket protocol', () => {
+  let httpServer: Server
+  let adapter: WebChatAdapter
+  let port: number
+
+  beforeEach(async () => {
+    adapter    = new WebChatAdapter()
+    httpServer = createServer()
+    await adapter.initialize('cfg-1', httpServer)
+
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        const addr = httpServer.address() as { port: number }
+        port = addr.port
+        resolve()
+      })
+    })
+  })
+
+  afterEach(async () => {
+    await adapter.dispose()
+    await new Promise<void>((res) => httpServer.close(() => res()))
+  })
+
+  // ── Conexión ──────────────────────────────────────────────────────────
+
+  it('conectar sin sessionId → recibe error MISSING_SESSION_ID y se cierra con 1008', async () => {
+    const ws = await connectWS(port, {}) // sin sessionId
+    const frame = await waitForFrame(ws, (f) => f['type'] === 'error')
+    expect(frame['code']).toBe('MISSING_SESSION_ID')
+
+    const closeCode = await new Promise<number>((resolve) => {
+      ws.once('close', (code) => resolve(code))
+    })
+    expect(closeCode).toBe(1008)
+  })
+
+  it('conectar con sessionId válido → primer frame es { type: connected, sessionId }', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-001' })
+    const frame = await waitForFrame(ws, (f) => f['type'] === 'connected')
+    expect(frame['sessionId']).toBe('sess-001')
+    await closeWS(ws)
+  })
+
+  it('múltiples clientes con el mismo sessionId → ambos reciben el mensaje de send()', async () => {
+    const ws1 = await connectWS(port, { sessionId: 'sess-multi' })
+    const ws2 = await connectWS(port, { sessionId: 'sess-multi' })
+
+    // Consumir frames 'connected'
+    await waitForFrame(ws1, (f) => f['type'] === 'connected')
+    await waitForFrame(ws2, (f) => f['type'] === 'connected')
+
+    const [p1, p2] = [
+      waitForFrame(ws1, (f) => f['type'] === 'message'),
+      waitForFrame(ws2, (f) => f['type'] === 'message'),
+    ]
+
+    await adapter.send({ externalId: 'sess-multi', text: 'broadcast' })
+
+    const [f1, f2] = await Promise.all([p1, p2])
+    expect(f1['text']).toBe('broadcast')
+    expect(f2['text']).toBe('broadcast')
+
+    await closeWS(ws1)
+    await closeWS(ws2)
+  })
+
+  // ── Mensajes ──────────────────────────────────────────────────────────
+
+  it('enviar { type: message, text: "hola" } → messageHandler llamado con texto correcto', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-msg' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    let received: import('../channel-adapter.interface.js').IncomingMessage | null = null
+    adapter.onMessage(async (msg) => { received = msg })
+
+    ws.send(JSON.stringify({ type: 'message', text: 'hola' }))
+
+    await vi.waitFor(() => expect(received).not.toBeNull(), { timeout: 1000 })
+    expect(received!.text).toBe('hola')
+    expect(received!.externalId).toBe('sess-msg')
+
+    await closeWS(ws)
+  })
+
+  it('enviar { type: message, text: "" } → recibe error EMPTY_MESSAGE, messageHandler NO llamado', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-empty' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    let called = false
+    adapter.onMessage(async () => { called = true })
+
+    ws.send(JSON.stringify({ type: 'message', text: '' }))
+
+    const frame = await waitForFrame(ws, (f) => f['type'] === 'error')
+    expect(frame['code']).toBe('EMPTY_MESSAGE')
+    expect(called).toBe(false)
+
+    await closeWS(ws)
+  })
+
+  it('enviar JSON malformado → recibe error INVALID_JSON', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-json' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    ws.send('not-valid-json{')
+
+    const frame = await waitForFrame(ws, (f) => f['type'] === 'error')
+    expect(frame['code']).toBe('INVALID_JSON')
+
+    await closeWS(ws)
+  })
+
+  it('enviar { type: ping } → recibe { type: pong }', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-ping' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    ws.send(JSON.stringify({ type: 'ping' }))
+
+    const frame = await waitForFrame(ws, (f) => f['type'] === 'pong')
+    expect(frame['type']).toBe('pong')
+
+    await closeWS(ws)
+  })
+
+  // ── send() / respuestas ───────────────────────────────────────────────
+
+  it('adapter.send() con cliente conectado → cliente recibe { type: message }', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-send' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    const pending = waitForFrame(ws, (f) => f['type'] === 'message')
+    await adapter.send({ externalId: 'sess-send', text: 'hola bot' })
+
+    const frame = await pending
+    expect(frame['text']).toBe('hola bot')
+
+    await closeWS(ws)
+  })
+
+  it('adapter.send() sin cliente conectado → no lanza, llama upsert en DB', async () => {
+    const { prisma } = await import('../../../../api/src/modules/core/db/prisma.service')
+    const upsertSpy = vi.spyOn((prisma as any).gatewaySession, 'upsert')
+
+    await expect(
+      adapter.send({ externalId: 'sess-offline', text: 'guardado' }),
+    ).resolves.not.toThrow()
+
+    expect(upsertSpy).toHaveBeenCalled()
+  })
+
+  // ── sendTyping() ──────────────────────────────────────────────────────
+
+  it('sendTyping(sessionId, "start") → cliente recibe { type: typing, status: "start" }', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-typing' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    const pending = waitForFrame(ws, (f) => f['type'] === 'typing')
+    adapter.sendTyping('sess-typing', 'start')
+
+    const frame = await pending
+    expect(frame['status']).toBe('start')
+
+    await closeWS(ws)
+  })
+
+  // ── Desconexión / limpieza ────────────────────────────────────────────
+
+  it('al cerrar WebSocket cliente → getStats().totalConnections decrementa', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-disconnect' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    expect(adapter.getStats().totalConnections).toBe(1)
+
+    await closeWS(ws)
+
+    // Pequeña espera para que el evento close se procese
+    await new Promise((r) => setTimeout(r, 50))
+    expect(adapter.getStats().totalConnections).toBe(0)
+  })
+
+  it('dispose() → cierra todas las conexiones con código 1001', async () => {
+    const ws = await connectWS(port, { sessionId: 'sess-dispose' })
+    await waitForFrame(ws, (f) => f['type'] === 'connected')
+
+    const closeCode = new Promise<number>((resolve) => {
+      ws.once('close', (code) => resolve(code))
+    })
+
+    await adapter.dispose()
+
+    expect(await closeCode).toBe(1001)
+  })
+})

--- a/apps/gateway/src/channels/webchat.adapter.ts
+++ b/apps/gateway/src/channels/webchat.adapter.ts
@@ -1,164 +1,404 @@
 /**
- * webchat.adapter.ts — Adaptador WebChat (SSE + HTTP)
+ * webchat.adapter.ts — Adaptador WebChat (WebSocket nativo con `ws`)
  *
- * Expone dos endpoints que el frontend puede consumir:
- *   POST /gateway/webchat/:sessionId/message  → mensaje entrante
- *   GET  /gateway/webchat/:sessionId/stream   → SSE de respuestas
+ * Protocolo:
+ *   ws[s]://<host>/gateway/webchat?sessionId=<uuid>&agentId=<uuid>
  *
- * El servidor Fastify/Express del gateway monta las rutas usando
- * WebChatAdapter.getRouter().
+ * Flujo de mensajes cliente → servidor (JSON frame):
+ *   { type: 'message', text: string, metadata?: Record<string, unknown> }
+ *   { type: 'ping' }                  ← keepalive del cliente
+ *   { type: 'history_request' }       ← solicita historial de la sesión
  *
- * Inspirado en Flowise ChatFlow y n8n WebhookNode.
+ * Flujo servidor → cliente (JSON frame):
+ *   { type: 'message', text, richContent?, metadata?, ts }
+ *   { type: 'typing', status: 'start' | 'stop' }
+ *   { type: 'pong' }
+ *   { type: 'history', messages: HistoryEntry[] }
+ *   { type: 'error', code, message }
+ *   { type: 'connected', sessionId }  ← primer frame al conectar
  */
 
-import { Router, type Request, type Response } from 'express';
-import { prisma } from '../../../api/src/modules/core/db/prisma.service';
+import { WebSocketServer, WebSocket, type RawData } from 'ws'
+import type { IncomingMessage as HttpIncomingMessage, Server } from 'http'
+import { prisma } from '../../../api/src/modules/core/db/prisma.service'
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const db = prisma as any;
+const db = prisma as any
+
+// ── Tipos de frame ──────────────────────────────────────────────────────
+
+type ClientFrame =
+  | { type: 'message'; text: string; metadata?: Record<string, unknown> }
+  | { type: 'ping' }
+  | { type: 'history_request' }
+
+type ServerFrame =
+  | { type: 'connected'; sessionId: string }
+  | { type: 'message'; text: string; richContent?: unknown; metadata?: Record<string, unknown>; ts: string }
+  | { type: 'typing'; status: 'start' | 'stop' }
+  | { type: 'pong' }
+  | { type: 'history'; messages: HistoryEntry[] }
+  | { type: 'error'; code: string; message: string }
+
+interface HistoryEntry {
+  role: 'user' | 'assistant'
+  content: string
+  ts?: string
+}
+
+// ── Conexión activa ─────────────────────────────────────────────────────
+
+interface ActiveConnection {
+  ws:          WebSocket
+  sessionId:   string
+  agentId:     string
+  connectedAt: number
+}
+
+// ── WebChatAdapter ──────────────────────────────────────────────────────
 
 export class WebChatAdapter extends BaseChannelAdapter {
-  readonly channel = 'webchat';
+  readonly channel = 'webchat'
 
-  // SSE clients: sessionId → list of Response streams
-  private readonly sseClients = new Map<string, Response[]>();
+  // WebSocketServer — se adjunta al httpServer en initialize()
+  private wss: WebSocketServer | null = null
 
-  // ── Lifecycle ────────────────────────────────────────────────────────────
+  // sessionId → lista de conexiones activas (multi-tab support)
+  private readonly connections = new Map<string, ActiveConnection[]>()
 
-  async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
+  // ── Lifecycle ─────────────────────────────────────────────────────────
+
+  /**
+   * initialize() adjunta un WebSocketServer al httpServer de Fastify/Express.
+   *
+   * @param channelConfigId  ID del ChannelConfig en DB
+   * @param httpServer       http.Server de la app — se pasa como segundo arg
+   *                         desde gateway.service.ts o server.ts al instanciar
+   *                         el adaptador. Ej:
+   *                           adapter.initialize(configId, app.server)
+   */
+  async initialize(
+    channelConfigId: string,
+    httpServer?: Server,
+  ): Promise<void> {
+    this.channelConfigId = channelConfigId
+
     const config = await db.channelConfig.findUnique({
       where: { id: channelConfigId },
-    });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-    this.credentials = config.credentials as Record<string, unknown>;
-    console.info(`[webchat] Initialized for config ${channelConfigId}`);
+    })
+    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`)
+
+    this.credentials = config.credentials as Record<string, unknown>
+
+    // Crear WebSocketServer adjunto al httpServer existente.
+    // path: '/gateway/webchat' → filtra solo esta ruta.
+    this.wss = new WebSocketServer({
+      server: httpServer,
+      path:   '/gateway/webchat',
+    })
+
+    this.wss.on('connection', (ws: WebSocket, req: HttpIncomingMessage) => {
+      this.handleConnection(ws, req)
+    })
+
+    this.wss.on('error', (err: Error) => {
+      console.error('[webchat] WebSocketServer error:', err.message)
+    })
+
+    console.info(`[webchat] WebSocketServer attached — path /gateway/webchat`)
   }
 
   async dispose(): Promise<void> {
-    // Cerrar todos los streams SSE activos
-    for (const [sessionId, clients] of this.sseClients) {
-      clients.forEach((res) => res.end());
-      console.info(`[webchat] Closed ${clients.length} SSE streams for session ${sessionId}`);
+    // Cerrar todas las conexiones activas con código 1001 (Going Away)
+    for (const [sessionId, conns] of this.connections) {
+      for (const conn of conns) {
+        conn.ws.close(1001, 'Server shutting down')
+      }
+      console.info(`[webchat] Closed ${conns.length} WS for session ${sessionId}`)
     }
-    this.sseClients.clear();
+    this.connections.clear()
+
+    await new Promise<void>((resolve, reject) => {
+      this.wss?.close((err) => (err ? reject(err) : resolve()))
+    })
+    this.wss = null
+    console.info('[webchat] WebSocketServer closed')
   }
 
-  // ── Send ─────────────────────────────────────────────────────────────────
+  // ── send() — enviar respuesta al cliente ──────────────────────────────
 
   async send(message: OutgoingMessage): Promise<void> {
-    const clients = this.sseClients.get(message.externalId) ?? [];
-    const payload = JSON.stringify({
-      type: 'message',
-      text: message.text,
-      richContent: message.richContent ?? null,
-      metadata: message.metadata ?? {},
-      ts: new Date().toISOString(),
-    });
+    const conns = this.connections.get(message.externalId) ?? []
 
-    if (clients.length === 0) {
-      // Guardar en DB para que el cliente la recupere en el próximo poll
-      await db.gatewaySession.update({
-        where: {
-          channelConfigId_externalId: {
-            channelConfigId: this.channelConfigId,
-            externalId: message.externalId,
-          },
-        },
-        data: {
-          contextWindow: {
-            push: { role: 'assistant', content: message.text },
-          } as any,
-          lastActivityAt: new Date(),
-        },
-      });
-      return;
+    const frame: ServerFrame = {
+      type:        'message',
+      text:         message.text,
+      richContent:  message.richContent ?? undefined,
+      metadata:     message.metadata ?? {},
+      ts:           new Date().toISOString(),
+    }
+    const payload = JSON.stringify(frame)
+
+    if (conns.length === 0) {
+      // Sin conexión activa → persistir en contextWindow para recuperar al reconectar
+      await this.persistMessage(message.externalId, 'assistant', message.text)
+      return
     }
 
-    // Enviar por SSE a todos los clientes activos de esta sesión
-    clients.forEach((res) => {
-      res.write(`data: ${payload}\n\n`);
-    });
+    const dead: ActiveConnection[] = []
+    for (const conn of conns) {
+      if (conn.ws.readyState === WebSocket.OPEN) {
+        conn.ws.send(payload)
+      } else {
+        dead.push(conn)
+      }
+    }
+
+    // Limpiar conexiones muertas
+    if (dead.length > 0) {
+      const alive = conns.filter((c) => !dead.includes(c))
+      if (alive.length > 0) {
+        this.connections.set(message.externalId, alive)
+      } else {
+        this.connections.delete(message.externalId)
+      }
+    }
   }
 
-  // ── Express Router ───────────────────────────────────────────────────────
+  // ── sendTyping() — helper para typing indicator ───────────────────────
 
-  getRouter(): Router {
-    const router = Router();
+  sendTyping(sessionId: string, status: 'start' | 'stop'): void {
+    const conns = this.connections.get(sessionId) ?? []
+    const frame = JSON.stringify({ type: 'typing', status } satisfies ServerFrame)
+    for (const conn of conns) {
+      if (conn.ws.readyState === WebSocket.OPEN) {
+        conn.ws.send(frame)
+      }
+    }
+  }
 
-    // POST /webchat/:sessionId/message — mensaje entrante del usuario
-    router.post('/:sessionId/message', async (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-      const { text, metadata } = req.body as {
-        text: string;
-        metadata?: Record<string, unknown>;
-      };
+  // ── handleConnection() ────────────────────────────────────────────────
 
-      if (!text?.trim()) {
-        res.status(400).json({ ok: false, error: 'text is required' });
-        return;
+  private handleConnection(ws: WebSocket, req: HttpIncomingMessage): void {
+    // Parsear query string: ?sessionId=...&agentId=...
+    const url       = new URL(req.url ?? '/', `ws://localhost`)
+    const sessionId = url.searchParams.get('sessionId') ?? ''
+    const agentId   = url.searchParams.get('agentId')   ?? ''
+
+    if (!sessionId) {
+      this.sendFrame(ws, {
+        type:    'error',
+        code:    'MISSING_SESSION_ID',
+        message: 'sessionId query param is required',
+      })
+      ws.close(1008, 'Missing sessionId')
+      return
+    }
+
+    const conn: ActiveConnection = {
+      ws,
+      sessionId,
+      agentId,
+      connectedAt: Date.now(),
+    }
+
+    // Registrar conexión
+    if (!this.connections.has(sessionId)) {
+      this.connections.set(sessionId, [])
+    }
+    this.connections.get(sessionId)!.push(conn)
+
+    console.info(
+      `[webchat] Connected: session=${sessionId} agent=${agentId} ` +
+      `total_conns=${this.connections.get(sessionId)!.length}`,
+    )
+
+    // Frame de bienvenida
+    this.sendFrame(ws, { type: 'connected', sessionId })
+
+    // Handlers de eventos
+    ws.on('message', (raw: RawData) => {
+      this.handleMessage(conn, raw).catch((err: Error) => {
+        console.error(`[webchat] handleMessage error session=${sessionId}:`, err.message)
+        this.sendFrame(ws, {
+          type:    'error',
+          code:    'INTERNAL_ERROR',
+          message: 'Failed to process message',
+        })
+      })
+    })
+
+    ws.on('close', (code: number, reason: Buffer) => {
+      this.removeConnection(sessionId, ws)
+      console.info(
+        `[webchat] Disconnected: session=${sessionId} code=${code} ` +
+        `reason=${reason.toString() || 'none'}`,
+      )
+    })
+
+    ws.on('error', (err: Error) => {
+      console.error(`[webchat] WS error session=${sessionId}:`, err.message)
+      this.removeConnection(sessionId, ws)
+    })
+  }
+
+  // ── handleMessage() ───────────────────────────────────────────────────
+
+  private async handleMessage(
+    conn: ActiveConnection,
+    raw:  RawData,
+  ): Promise<void> {
+    let frame: ClientFrame
+
+    try {
+      frame = JSON.parse(raw.toString()) as ClientFrame
+    } catch {
+      this.sendFrame(conn.ws, {
+        type:    'error',
+        code:    'INVALID_JSON',
+        message: 'Message must be valid JSON',
+      })
+      return
+    }
+
+    switch (frame.type) {
+      case 'ping':
+        this.sendFrame(conn.ws, { type: 'pong' })
+        break
+
+      case 'history_request':
+        await this.sendHistory(conn)
+        break
+
+      case 'message': {
+        const text = frame.text?.trim()
+        if (!text) {
+          this.sendFrame(conn.ws, {
+            type:    'error',
+            code:    'EMPTY_MESSAGE',
+            message: 'text cannot be empty',
+          })
+          return
+        }
+
+        // Persistir mensaje del usuario
+        await this.persistMessage(conn.sessionId, 'user', text)
+
+        const msg: IncomingMessage = {
+          externalId:  conn.sessionId,
+          senderId:    conn.sessionId,
+          text,
+          type:        'text',
+          metadata:    {
+            ...frame.metadata,
+            agentId: conn.agentId || undefined,
+            channel: 'webchat',
+          },
+          receivedAt: this.makeTimestamp(),
+        }
+
+        await this.emit(msg)
+        break
       }
 
-      const msg: IncomingMessage = {
-        externalId: sessionId,
-        senderId: sessionId,
-        text: text.trim(),
-        type: 'text',
-        metadata,
-        receivedAt: this.makeTimestamp(),
-      };
-
-      await this.emit(msg);
-      res.json({ ok: true });
-    });
-
-    // GET /webchat/:sessionId/stream — SSE stream de respuestas
-    router.get('/:sessionId/stream', (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-
-      res.setHeader('Content-Type', 'text/event-stream');
-      res.setHeader('Cache-Control', 'no-cache');
-      res.setHeader('Connection', 'keep-alive');
-      res.setHeader('X-Accel-Buffering', 'no');
-      res.flushHeaders();
-
-      if (!this.sseClients.has(sessionId)) {
-        this.sseClients.set(sessionId, []);
+      default: {
+        // TypeScript exhaustive check helper
+        const _never: never = frame
+        void _never
+        this.sendFrame(conn.ws, {
+          type:    'error',
+          code:    'UNKNOWN_FRAME_TYPE',
+          message: 'Unknown frame type',
+        })
       }
-      this.sseClients.get(sessionId)!.push(res);
+    }
+  }
 
-      // Heartbeat para mantener la conexión viva
-      const heartbeat = setInterval(() => {
-        res.write(': heartbeat\n\n');
-      }, 25_000);
+  // ── Helpers ────────────────────────────────────────────────────────────
 
-      req.on('close', () => {
-        clearInterval(heartbeat);
-        const clients = this.sseClients.get(sessionId) ?? [];
-        const idx = clients.indexOf(res);
-        if (idx !== -1) clients.splice(idx, 1);
-      });
-    });
+  private sendFrame(ws: WebSocket, frame: ServerFrame): void {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(frame))
+    }
+  }
 
-    // GET /webchat/:sessionId/history — historial para HTTP polling
-    router.get('/:sessionId/history', async (req: Request, res: Response) => {
-      const { sessionId } = req.params;
+  private removeConnection(sessionId: string, ws: WebSocket): void {
+    const conns = this.connections.get(sessionId)
+    if (!conns) return
+    const filtered = conns.filter((c) => c.ws !== ws)
+    if (filtered.length > 0) {
+      this.connections.set(sessionId, filtered)
+    } else {
+      this.connections.delete(sessionId)
+    }
+  }
+
+  private async sendHistory(conn: ActiveConnection): Promise<void> {
+    try {
       const session = await db.gatewaySession.findFirst({
         where: {
           channelConfigId: this.channelConfigId,
-          externalId: sessionId,
+          externalId:      conn.sessionId,
         },
-      });
-      res.json({
-        ok: true,
-        history: (session?.contextWindow as unknown[]) ?? [],
-      });
-    });
+      })
+      const messages = (session?.contextWindow as HistoryEntry[]) ?? []
+      this.sendFrame(conn.ws, { type: 'history', messages })
+    } catch (err) {
+      console.error('[webchat] sendHistory error:', (err as Error).message)
+      this.sendFrame(conn.ws, {
+        type:    'error',
+        code:    'HISTORY_ERROR',
+        message: 'Failed to retrieve history',
+      })
+    }
+  }
 
-    return router;
+  private async persistMessage(
+    sessionId: string,
+    role:      'user' | 'assistant',
+    content:   string,
+  ): Promise<void> {
+    try {
+      await db.gatewaySession.upsert({
+        where: {
+          channelConfigId_externalId: {
+            channelConfigId: this.channelConfigId,
+            externalId:      sessionId,
+          },
+        },
+        update: {
+          contextWindow: {
+            push: { role, content, ts: new Date().toISOString() },
+          } as any,
+          lastActivityAt: new Date(),
+        },
+        create: {
+          channelConfigId: this.channelConfigId,
+          externalId:      sessionId,
+          contextWindow:   [{ role, content, ts: new Date().toISOString() }] as any,
+          lastActivityAt:  new Date(),
+        },
+      })
+    } catch (err) {
+      // No bloquear el flujo principal si la persistencia falla
+      console.warn('[webchat] persistMessage failed:', (err as Error).message)
+    }
+  }
+
+  // ── Métricas (opcional, para observabilidad) ──────────────────────────
+
+  getStats(): { activeSessions: number; totalConnections: number } {
+    let totalConnections = 0
+    for (const conns of this.connections.values()) {
+      totalConnections += conns.length
+    }
+    return {
+      activeSessions:   this.connections.size,
+      totalConnections,
+    }
   }
 }


### PR DESCRIPTION
- Replace SSE + Express Router with native WebSocket (ws ^8.18.0)
- WebSocketServer attaches to http.Server on path /gateway/webchat
- Protocol: ?sessionId=&agentId= query params on WS upgrade
- Client frames: message | ping | history_request
- Server frames: connected | message | typing | pong | history | error
- Multi-tab support: sessionId → ActiveConnection[] map
- send() falls back to DB persistMessage() when no clients connected
- sendTyping() helper for typing indicators
- dispose() closes all connections with code 1001
- getStats() for observability (activeSessions, totalConnections)
- Add ws@^8.18.0 to dependencies, @types/ws@^8.5.13 to devDependencies
- Add ≥10 vitest integration tests covering all protocol cases

Closes #F3a-03

1. apps/gateway/src/channels/webchat.adapter.ts ← Reemplazado completo

SSE + Express Router eliminado por completo

WebSocketServer nativo de ws, adjunto al http.Server en initialize(channelConfigId, httpServer?)

Protocolo full-duplex: ws://host/gateway/webchat?sessionId=<uuid>&agentId=<uuid>

Frames cliente: message | ping | history_request

Frames servidor: connected | message | typing | pong | history | error

Multi-tab: sessionId → ActiveConnection[] con limpieza automática de conexiones muertas

send() con fallback silencioso a persistMessage() cuando no hay cliente conectado

sendTyping() helper para indicadores de escritura

dispose() cierra todo con código 1001

getStats() para observabilidad

2. apps/gateway/src/channels/__tests__/webchat.adapter.test.ts ← Nuevo (12 tests)

Todos los casos del criterio de cierre cubiertos: conexión sin sessionId, frame connected, multi-tab broadcast, message/ping/empty/invalid JSON, send() con y sin cliente, sendTyping(), desconexión y dispose()

3. apps/gateway/package.json ← Actualizado

"ws": "^8.18.0" añadido a dependencies

"@types/ws": "^8.5.13" añadido a devDependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket-based real-time chat under /gateway/webchat for faster, bidirectional messaging
  * Support for multiple concurrent connections per session (multi-tab)
  * Message persistence when no client is connected and server-side chat history retrieval
  * Connection health (ping/pong), input validation with clear error codes, typing indicators
  * Connection stats and graceful shutdown of active connections

* **Tests**
  * Added end-to-end integration tests covering connection flows, messaging, history, errors, and persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->