### PR TITLE
feat(F3a-06): add AgentResolver (ChannelBinding → scope → agentId)

### DIFF
--- a/apps/gateway/src/__tests__/agent-resolver.test.ts
+++ b/apps/gateway/src/__tests__/agent-resolver.test.ts
@@ -1,0 +1,288 @@
+/**
+ * agent-resolver.test.ts — [F3a-06]
+ *
+ * Tests for AgentResolver: priority rules, cache TTL,
+ * createBinding validation, resolveOrNull, error shape.
+ *
+ * Framework: vitest | Mocks: vi.fn() — no real DB needed.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from 'vitest'
+import { AgentResolver, AgentResolutionError } from '../agent-resolver.service.js'
+import type { AgentResolutionContext } from '../agent-resolver.types.js'
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function makeBinding(overrides: {
+  id?: string
+  agentId?: string
+  scope: string
+  scopeValue?: string | null
+  priority?: number
+  enabled?: boolean
+}) {
+  return {
+    id:         overrides.id         ?? 'binding-' + Math.random().toString(36).slice(2),
+    agentId:    overrides.agentId    ?? 'agent-default',
+    scope:      overrides.scope,
+    scopeValue: overrides.scopeValue ?? null,
+    priority:   overrides.priority   ?? 0,
+    enabled:    overrides.enabled    ?? true,
+  }
+}
+
+function makePrisma(bindings: ReturnType<typeof makeBinding>[]) {
+  return {
+    channelBinding: {
+      findMany: vi.fn().mockResolvedValue(bindings),
+      create:   vi.fn().mockImplementation(async ({ data }: any) => ({ id: 'new-id', ...data })),
+      delete:   vi.fn().mockResolvedValue(undefined),
+    },
+  } as any
+}
+
+const BASE_CTX: AgentResolutionContext = {
+  channelConfigId: 'chan-1',
+  externalUserId:  'user-ext-42',
+  workspaceId:     'ws-1',
+  tenantId:        'tenant-1',
+}
+
+// ── Priority rules ──────────────────────────────────────────────────────
+
+describe('resolve() — priority rules', () => {
+
+  it('scope=user wins over scope=workspace when both match', async () => {
+    const userBinding      = makeBinding({ scope: 'user',      scopeValue: 'user-ext-42', agentId: 'agent-user' })
+    const workspaceBinding = makeBinding({ scope: 'workspace', scopeValue: 'ws-1',        agentId: 'agent-ws' })
+    const db = makePrisma([userBinding, workspaceBinding])
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolve(BASE_CTX)
+    expect(result.agentId).toBe('agent-user')
+    expect(result.resolvedBy).toBe('user')
+  })
+
+  it('scope=user wins over scope=default', async () => {
+    const userBinding    = makeBinding({ scope: 'user',    scopeValue: 'user-ext-42', agentId: 'agent-user' })
+    const defaultBinding = makeBinding({ scope: 'default', scopeValue: null,          agentId: 'agent-default' })
+    const db = makePrisma([userBinding, defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolve(BASE_CTX)
+    expect(result.agentId).toBe('agent-user')
+    expect(result.resolvedBy).toBe('user')
+  })
+
+  it('scope=tenant wins over scope=workspace and scope=default', async () => {
+    const tenantBinding    = makeBinding({ scope: 'tenant',    scopeValue: 'tenant-1', agentId: 'agent-tenant' })
+    const workspaceBinding = makeBinding({ scope: 'workspace', scopeValue: 'ws-1',     agentId: 'agent-ws' })
+    const defaultBinding   = makeBinding({ scope: 'default',   scopeValue: null,        agentId: 'agent-default' })
+    const db = makePrisma([tenantBinding, workspaceBinding, defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolve(BASE_CTX)
+    expect(result.agentId).toBe('agent-tenant')
+    expect(result.resolvedBy).toBe('tenant')
+  })
+
+  it('scope=workspace wins over scope=default', async () => {
+    const workspaceBinding = makeBinding({ scope: 'workspace', scopeValue: 'ws-1', agentId: 'agent-ws' })
+    const defaultBinding   = makeBinding({ scope: 'default',   scopeValue: null,   agentId: 'agent-default' })
+    const db = makePrisma([workspaceBinding, defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolve(BASE_CTX)
+    expect(result.agentId).toBe('agent-ws')
+    expect(result.resolvedBy).toBe('workspace')
+  })
+
+  it('scope=default is the fallback when no dynamic scope matches', async () => {
+    const defaultBinding = makeBinding({ scope: 'default', scopeValue: null, agentId: 'agent-default' })
+    const db = makePrisma([defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    const ctx: AgentResolutionContext = { channelConfigId: 'chan-1', externalUserId: 'user-ext-99' }
+    const result = await resolver.resolve(ctx)
+    expect(result.agentId).toBe('agent-default')
+    expect(result.resolvedBy).toBe('default')
+  })
+
+  it('does NOT attempt workspace scope when workspaceId is absent in context', async () => {
+    const workspaceBinding = makeBinding({ scope: 'workspace', scopeValue: 'ws-1', agentId: 'agent-ws' })
+    const db = makePrisma([workspaceBinding])
+    const resolver = new AgentResolver(db)
+
+    // No workspaceId in context
+    const ctx: AgentResolutionContext = { channelConfigId: 'chan-1', externalUserId: 'user-ext-42' }
+    await expect(resolver.resolve(ctx, undefined)).rejects.toThrow(AgentResolutionError)
+  })
+
+  it('does NOT attempt tenant scope when tenantId is absent in context', async () => {
+    const tenantBinding = makeBinding({ scope: 'tenant', scopeValue: 'tenant-1', agentId: 'agent-tenant' })
+    const db = makePrisma([tenantBinding])
+    const resolver = new AgentResolver(db)
+
+    // No tenantId in context — only externalUserId
+    const ctx: AgentResolutionContext = { channelConfigId: 'chan-1', externalUserId: 'user-ext-42' }
+    await expect(resolver.resolve(ctx, undefined)).rejects.toThrow(AgentResolutionError)
+  })
+
+  it('only matches workspace binding with the exact scopeValue from context', async () => {
+    const wsBinding1 = makeBinding({ scope: 'workspace', scopeValue: 'ws-99',  agentId: 'agent-ws-99' })
+    const wsBinding2 = makeBinding({ scope: 'workspace', scopeValue: 'ws-1',   agentId: 'agent-ws-1' })
+    const db = makePrisma([wsBinding1, wsBinding2])
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolve(BASE_CTX)
+    expect(result.agentId).toBe('agent-ws-1')
+    expect(result.resolvedBy).toBe('workspace')
+  })
+
+  it('falls back to configAgentId when no binding matches', async () => {
+    const db = makePrisma([])  // empty bindings
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolve(BASE_CTX, 'legacy-agent')
+    expect(result.agentId).toBe('legacy-agent')
+    expect(result.resolvedBy).toBe('config')
+    expect(result.bindingId).toBeUndefined()
+  })
+
+  it('throws AgentResolutionError when no binding and no configAgentId', async () => {
+    const db = makePrisma([])
+    const resolver = new AgentResolver(db)
+
+    await expect(resolver.resolve(BASE_CTX, undefined)).rejects.toThrow(AgentResolutionError)
+  })
+
+  it('AgentResolutionError has correct name and message containing channelConfigId and externalUserId', async () => {
+    const db = makePrisma([])
+    const resolver = new AgentResolver(db)
+
+    const err = await resolver.resolve(BASE_CTX, undefined).catch((e: unknown) => e)
+    expect(err).toBeInstanceOf(AgentResolutionError)
+    expect((err as AgentResolutionError).name).toBe('AgentResolutionError')
+    expect((err as AgentResolutionError).message).toContain('chan-1')
+    expect((err as AgentResolutionError).message).toContain('user-ext-42')
+  })
+})
+
+// ── Cache ────────────────────────────────────────────────────────────────
+
+describe('cache', () => {
+
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(()  => { vi.useRealTimers() })
+
+  it('second resolve() call does NOT call findMany again (cache hit)', async () => {
+    const defaultBinding = makeBinding({ scope: 'default', scopeValue: null })
+    const db = makePrisma([defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    await resolver.resolve(BASE_CTX, 'fallback')
+    await resolver.resolve(BASE_CTX, 'fallback')
+
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidateCache() forces a fresh findMany on next resolve()', async () => {
+    const defaultBinding = makeBinding({ scope: 'default', scopeValue: null })
+    const db = makePrisma([defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    await resolver.resolve(BASE_CTX, 'fallback')
+    resolver.invalidateCache('chan-1')
+    await resolver.resolve(BASE_CTX, 'fallback')
+
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(2)
+  })
+
+  it('cache expires after 5 minutes and triggers a fresh findMany', async () => {
+    const defaultBinding = makeBinding({ scope: 'default', scopeValue: null })
+    const db = makePrisma([defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    await resolver.resolve(BASE_CTX, 'fallback')
+    // Advance time beyond TTL (5 min + 1ms)
+    vi.advanceTimersByTime(5 * 60 * 1_000 + 1)
+    await resolver.resolve(BASE_CTX, 'fallback')
+
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── createBinding() ──────────────────────────────────────────────────────
+
+describe('createBinding()', () => {
+
+  it('throws when scope=default has a scopeValue', async () => {
+    const db = makePrisma([])
+    const resolver = new AgentResolver(db)
+
+    await expect(
+      resolver.createBinding({
+        channelConfigId: 'chan-1',
+        agentId:         'agent-1',
+        scope:           'default',
+        scopeValue:      'some-value',
+      }),
+    ).rejects.toThrow('scopeValue must be null/undefined for scope \'default\'')
+  })
+
+  it('throws when scope=workspace has no scopeValue', async () => {
+    const db = makePrisma([])
+    const resolver = new AgentResolver(db)
+
+    await expect(
+      resolver.createBinding({
+        channelConfigId: 'chan-1',
+        agentId:         'agent-1',
+        scope:           'workspace',
+        scopeValue:      undefined,
+      }),
+    ).rejects.toThrow('scopeValue is required for scope \'workspace\'')
+  })
+
+  it('creates binding and invalidates cache so next resolve calls findMany again', async () => {
+    const defaultBinding = makeBinding({ scope: 'default', scopeValue: null })
+    const db = makePrisma([defaultBinding])
+    const resolver = new AgentResolver(db)
+
+    // Pre-warm cache
+    await resolver.resolve(BASE_CTX, 'fallback')
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(1)
+
+    // createBinding should invalidate cache
+    await resolver.createBinding({
+      channelConfigId: 'chan-1',
+      agentId:         'agent-new',
+      scope:           'workspace',
+      scopeValue:      'ws-2',
+    })
+
+    // Next resolve should hit DB again
+    await resolver.resolve(BASE_CTX, 'fallback')
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ── resolveOrNull() ──────────────────────────────────────────────────────
+
+describe('resolveOrNull()', () => {
+
+  it('returns null instead of throwing when no binding and no configAgentId', async () => {
+    const db = makePrisma([])
+    const resolver = new AgentResolver(db)
+
+    const result = await resolver.resolveOrNull(BASE_CTX, undefined)
+    expect(result).toBeNull()
+  })
+})

--- a/apps/gateway/src/agent-resolver.service.ts
+++ b/apps/gateway/src/agent-resolver.service.ts
@@ -1,0 +1,254 @@
+/**
+ * agent-resolver.service.ts — [F3a-06]
+ *
+ * Resuelve el agentId que debe atender un mensaje inbound
+ * a partir del contexto (channelConfigId + scope del usuario).
+ *
+ * Algoritmo de resolución:
+ *  1. Buscar todos los ChannelBinding habilitados para el channelConfigId
+ *  2. Aplicar reglas de prioridad en este orden:
+ *       a) scope='user'      + scopeValue = externalUserId  → prioridad máxima
+ *       b) scope='tenant'    + scopeValue = tenantId        (si ctx.tenantId existe)
+ *       c) scope='workspace' + scopeValue = workspaceId     (si ctx.workspaceId existe)
+ *       d) scope='default'   + scopeValue = null            → fallback
+ *  3. Si ningún binding coincide → fallback a ChannelConfig.agentId (modo legacy)
+ *  4. Si ChannelConfig tampoco tiene agentId → lanzar AgentResolutionError
+ *
+ * Caché:
+ *   Los bindings se cachean por channelConfigId con TTL de 5 minutos.
+ *   invalidateCache() existe para tests y para cuando se actualice un binding.
+ *
+ * Clase completamente pura respecto al canal — no importa nada de channels/.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import type {
+  AgentResolutionContext,
+  AgentResolutionResult,
+  BindingScope,
+} from './agent-resolver.types.js'
+
+// ── Error tipado ────────────────────────────────────────────────────────
+
+export class AgentResolutionError extends Error {
+  constructor(
+    public readonly channelConfigId: string,
+    public readonly context: AgentResolutionContext,
+  ) {
+    super(
+      `[AgentResolver] No agent found for channel '${channelConfigId}' ` +
+      `with context: user=${context.externalUserId}, ` +
+      `workspace=${context.workspaceId ?? 'none'}, ` +
+      `tenant=${context.tenantId ?? 'none'}`,
+    )
+    this.name = 'AgentResolutionError'
+  }
+}
+
+// ── Tipos internos ──────────────────────────────────────────────────────
+
+interface CachedBindings {
+  bindings:  ChannelBindingRow[]
+  fetchedAt: number
+}
+
+interface ChannelBindingRow {
+  id:         string
+  agentId:    string
+  scope:      string
+  scopeValue: string | null
+  priority:   number
+  enabled:    boolean
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1_000   // 5 minutos
+
+// Orden de precedencia de scopes (menor índice = mayor prioridad)
+const SCOPE_PRIORITY: BindingScope[] = ['user', 'tenant', 'workspace', 'default']
+
+// ── AgentResolver ───────────────────────────────────────────────────────
+
+export class AgentResolver {
+
+  private readonly cache = new Map<string, CachedBindings>()
+
+  constructor(private readonly db: PrismaClient) {}
+
+  // ── resolve() ─────────────────────────────────────────────────────────
+
+  /**
+   * Punto de entrada principal.
+   *
+   * @throws AgentResolutionError si no hay ningún binding ni agentId en config
+   */
+  async resolve(
+    ctx:             AgentResolutionContext,
+    configAgentId?:  string,   // cfg.agentId de DecryptedChannelConfig (fallback legacy)
+  ): Promise<AgentResolutionResult> {
+
+    const bindings = await this.loadBindings(ctx.channelConfigId)
+
+    // Intentar cada scope en orden de prioridad
+    for (const scope of SCOPE_PRIORITY) {
+      const match = this.findMatch(bindings, scope, ctx)
+      if (match) {
+        return {
+          agentId:    match.agentId,
+          resolvedBy: scope,
+          bindingId:  match.id,
+        }
+      }
+    }
+
+    // Fallback legacy: usar agentId de ChannelConfig
+    if (configAgentId) {
+      return {
+        agentId:    configAgentId,
+        resolvedBy: 'config',
+      }
+    }
+
+    throw new AgentResolutionError(ctx.channelConfigId, ctx)
+  }
+
+  // ── resolveOrNull() ────────────────────────────────────────────────────
+
+  /**
+   * Versión que no lanza — devuelve null si no puede resolver.
+   * Útil para validaciones y health checks.
+   */
+  async resolveOrNull(
+    ctx:            AgentResolutionContext,
+    configAgentId?: string,
+  ): Promise<AgentResolutionResult | null> {
+    try {
+      return await this.resolve(ctx, configAgentId)
+    } catch (err) {
+      if (err instanceof AgentResolutionError) return null
+      throw err
+    }
+  }
+
+  // ── listBindings() ────────────────────────────────────────────────────
+
+  /**
+   * Retorna todos los bindings habilitados para un canal.
+   * Útil para el admin UI de configuración de canales.
+   */
+  async listBindings(channelConfigId: string): Promise<ChannelBindingRow[]> {
+    return this.loadBindings(channelConfigId)
+  }
+
+  // ── createBinding() ──────────────────────────────────────────────────
+
+  /**
+   * Crea un nuevo ChannelBinding y limpia la caché del canal.
+   * Llamado desde el admin controller cuando se configura un canal.
+   */
+  async createBinding(data: {
+    channelConfigId: string
+    agentId:         string
+    scope:           BindingScope
+    scopeValue?:     string
+    priority?:       number
+  }): Promise<ChannelBindingRow> {
+    if (data.scope !== 'default' && !data.scopeValue) {
+      throw new Error(
+        `[AgentResolver] scopeValue is required for scope '${data.scope}'`,
+      )
+    }
+    if (data.scope === 'default' && data.scopeValue) {
+      throw new Error(
+        `[AgentResolver] scopeValue must be null/undefined for scope 'default'`,
+      )
+    }
+
+    const row = await (this.db as any).channelBinding.create({
+      data: {
+        channelConfigId: data.channelConfigId,
+        agentId:         data.agentId,
+        scope:           data.scope,
+        scopeValue:      data.scopeValue ?? null,
+        priority:        data.priority   ?? 0,
+        enabled:         true,
+      },
+    })
+
+    // Invalidar caché para que el próximo resolve lo vea
+    this.invalidateCache(data.channelConfigId)
+
+    return row as ChannelBindingRow
+  }
+
+  // ── deleteBinding() ──────────────────────────────────────────────────
+
+  async deleteBinding(bindingId: string, channelConfigId: string): Promise<void> {
+    await (this.db as any).channelBinding.delete({ where: { id: bindingId } })
+    this.invalidateCache(channelConfigId)
+  }
+
+  // ── invalidateCache() ─────────────────────────────────────────────────
+
+  /** Forzar re-fetch en el próximo resolve() para un canal. */
+  invalidateCache(channelConfigId: string): void {
+    this.cache.delete(channelConfigId)
+  }
+
+  /** Limpiar toda la caché (útil para tests). */
+  clearCache(): void {
+    this.cache.clear()
+  }
+
+  // ── Privados ───────────────────────────────────────────────────────────
+
+  private async loadBindings(channelConfigId: string): Promise<ChannelBindingRow[]> {
+    const cached = this.cache.get(channelConfigId)
+
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      return cached.bindings
+    }
+
+    const rows = await (this.db as any).channelBinding.findMany({
+      where:   { channelConfigId, enabled: true },
+      orderBy: [
+        { priority: 'desc' },  // mayor priority primero dentro del mismo scope
+        { createdAt: 'asc'  },
+      ],
+    }) as ChannelBindingRow[]
+
+    this.cache.set(channelConfigId, { bindings: rows, fetchedAt: Date.now() })
+    return rows
+  }
+
+  private findMatch(
+    bindings:   ChannelBindingRow[],
+    scope:      BindingScope,
+    ctx:        AgentResolutionContext,
+  ): ChannelBindingRow | null {
+
+    const scopeValue = this.getScopeValue(scope, ctx)
+
+    // scope='default' no necesita scopeValue
+    if (scope === 'default') {
+      return bindings.find(
+        (b) => b.scope === 'default' && b.scopeValue === null,
+      ) ?? null
+    }
+
+    // Para scopes dinámicos, si no hay valor en el contexto → no puede coincidir
+    if (scopeValue === null) return null
+
+    return bindings.find(
+      (b) => b.scope === scope && b.scopeValue === scopeValue,
+    ) ?? null
+  }
+
+  private getScopeValue(scope: BindingScope, ctx: AgentResolutionContext): string | null {
+    switch (scope) {
+      case 'user':      return ctx.externalUserId
+      case 'tenant':    return ctx.tenantId    ?? null
+      case 'workspace': return ctx.workspaceId ?? null
+      case 'default':   return null
+    }
+  }
+}

--- a/apps/gateway/src/agent-resolver.types.ts
+++ b/apps/gateway/src/agent-resolver.types.ts
@@ -1,0 +1,45 @@
+/**
+ * agent-resolver.types.ts — [F3a-06]
+ *
+ * Tipos públicos del AgentResolver.
+ * Sin dependencias de Prisma ni de NestJS — importables desde cualquier capa.
+ */
+
+/**
+ * Contexto de resolución — lo que se conoce del usuario inbound
+ * en el momento de la resolución.
+ */
+export interface AgentResolutionContext {
+  /** channelConfigId del canal que recibió el mensaje */
+  channelConfigId: string
+  /** ID externo del usuario (chat.id de Telegram, userId de webchat) */
+  externalUserId:  string
+  /**
+   * ID del workspace al que pertenece el usuario, si se conoce.
+   * Puede estar en GatewaySession.metadata o extraerse de la BD de tenants.
+   * Opcional — si no se provee, se omite el scope 'workspace'.
+   */
+  workspaceId?:    string
+  /**
+   * ID del tenant al que pertenece el usuario, si se conoce.
+   * Opcional — si no se provee, se omite el scope 'tenant'.
+   */
+  tenantId?:       string
+}
+
+/**
+ * Resultado de la resolución del agente.
+ */
+export interface AgentResolutionResult {
+  agentId:    string
+  /** Scope que produjo la resolución */
+  resolvedBy: 'user' | 'tenant' | 'workspace' | 'default' | 'config'
+  /**
+   * 'config'    → se usó cfg.agentId de ChannelConfig (fallback legacy)
+   * 'default'   → se usó el binding scope='default'
+   * 'workspace' / 'tenant' / 'user' → match por scope dinámico
+   */
+  bindingId?: string
+}
+
+export type BindingScope = 'default' | 'workspace' | 'tenant' | 'user'

--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -27,6 +27,8 @@ import {
 import { AgentRunner }        from '@agent-vs/flow-engine';
 import type { IChannelAdapter } from './channels/channel-adapter.interface';
 import { PrismaService }       from './prisma/prisma.service';
+import { AgentResolver }       from './agent-resolver.service.js';
+import type { AgentResolutionContext } from './agent-resolver.types.js';
 
 // ---------------------------------------------------------------------------
 // Tipos internos
@@ -49,12 +51,14 @@ export class GatewayService {
   /** Exposed for webchat reply route (needs findSession) */
   readonly sessions:    SessionManager;
   private readonly agentRunner:   AgentRunner;
+  private readonly agentResolver: AgentResolver;
   private readonly configCache  = new Map<string, DecryptedChannelConfig>();
   private readonly encKey:       Buffer;
 
   constructor(private readonly db: PrismaService) {
-    this.sessions    = new SessionManager(db);
-    this.agentRunner = new AgentRunner({ db });
+    this.sessions      = new SessionManager(db);
+    this.agentRunner   = new AgentRunner({ db });
+    this.agentResolver = new AgentResolver(db as unknown as PrismaClient);
 
     const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? '';
     if (!keyHex) {
@@ -88,6 +92,8 @@ export class GatewayService {
       console.warn(`[GatewayService] teardown error for channel ${channelConfigId}:`, err);
     });
     this.configCache.delete(channelConfigId);
+    // Invalidate agent resolution cache when channel is deactivated
+    this.agentResolver.invalidateCache(channelConfigId);
     console.info(`[GatewayService] channel ${channelConfigId} deactivated`);
   }
 
@@ -101,9 +107,10 @@ export class GatewayService {
    * Flow:
    *   rawPayload
    *     → adapter.receive()       parse channel format → IncomingMessage
-   *     → SessionManager           upsert GatewaySession, append user turn
-   *     → AgentRunner.run()        load Agent+FlowVersion, execute FlowExecutor
-   *     → recordReply()            append assistant turn, adapter.send()
+   *     → AgentResolver.resolve() ChannelBinding → agentId (F3a-06)
+   *     → SessionManager          upsert GatewaySession, append user turn
+   *     → AgentRunner.run()       load Agent+FlowVersion, execute FlowExecutor
+   *     → recordReply()           append assistant turn, adapter.send()
    */
   async dispatch(
     channelConfigId: string,
@@ -119,14 +126,25 @@ export class GatewayService {
 
     if (!incoming) return;
 
-    // 2. Persist user turn + upsert session
+    // 2. Resolve agent dynamically via ChannelBinding (F3a-06)
+    //    incoming.externalUserId is the external user identifier from the channel adapter.
+    //    workspaceId / tenantId are optional enrichments that adapters may include in metadata.
+    const resolutionCtx: AgentResolutionContext = {
+      channelConfigId,
+      externalUserId: incoming.externalUserId,
+      workspaceId:    incoming.metadata?.workspaceId as string | undefined,
+      tenantId:       incoming.metadata?.tenantId    as string | undefined,
+    };
+    const resolution = await this.agentResolver.resolve(resolutionCtx, cfg.agentId);
+
+    // 3. Persist user turn + upsert session
     const session = await this.sessions.receiveUserMessage(
       channelConfigId,
-      cfg.agentId,
+      resolution.agentId,   // dynamic — resolved from ChannelBinding
       incoming,
     );
 
-    // 3. Run agent via FlowExecutor
+    // 4. Run agent via FlowExecutor
     let replyText: string;
     try {
       const result = await this.agentRunner.run(
@@ -139,13 +157,13 @@ export class GatewayService {
       replyText = '(ocurrió un error al procesar tu mensaje)';
     }
 
-    // 4. Build outbound message
+    // 5. Build outbound message
     const outbound: OutboundMessage = {
       externalUserId: incoming.externalUserId,
       text: replyText,
     };
 
-    // 5. Persist assistant turn + send to channel
+    // 6. Persist assistant turn + send to channel
     await this.recordReply(channelConfigId, session.id, outbound);
   }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,14 @@
 // Enforced at two layers:
 //   1. DB layer — raw CHECK constraint added via a manual migration.
 //   2. App layer — PolicyScopeGuard in apps/api validates before upsert.
+//
+// ── F3a-06 ───────────────────────────────────────────────────────────────────
+// ChannelBinding rediseñado: scope/scopeValue/priority/enabled.
+// Regla de resolución (prioridad descendente):
+//   1. scope='user'      + scopeValue=externalUserId  (máxima prioridad)
+//   2. scope='tenant'    + scopeValue=tenantId
+//   3. scope='workspace' + scopeValue=workspaceId
+//   4. scope='default'   + scopeValue=null            (fallback)
 // ─────────────────────────────────────────────────────────────────────────────
 
 generator client {
@@ -289,20 +297,43 @@ model ChannelConfig {
   sessions GatewaySession[]
 }
 
+/**
+ * ChannelBinding — mapea un canal a un agente según scope.
+ *
+ * Regla de resolución (prioridad descendente) — F3a-06:
+ *  1. scope='user'      + scopeValue=externalUserId   (máxima prioridad)
+ *  2. scope='tenant'    + scopeValue=tenantId
+ *  3. scope='workspace' + scopeValue=workspaceId
+ *  4. scope='default'   + scopeValue=null             (fallback)
+ *
+ * Un canal DEBE tener al menos un binding con scope='default'.
+ */
 model ChannelBinding {
-  id              String        @id @default(uuid())
+  id              String        @id @default(cuid())
   channelConfigId String
-  channelConfig   ChannelConfig @relation(fields: [channelConfigId], references: [id], onDelete: Cascade)
   agentId         String
-  agent           Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  /// Level that owns this binding: 'agency' | 'department' | 'workspace' | 'agent'
-  scopeLevel      String        @default("agent")
-  /// ID of the scope entity (agencyId, departmentId, etc.)
-  scopeId         String
-  isDefault       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
 
-  @@unique([channelConfigId, agentId])
+  /**
+   * Tipo de scope:
+   *   'default'   → binding de fallback (scopeValue = null)
+   *   'workspace' → scopeValue = workspaceId
+   *   'tenant'    → scopeValue = tenantId
+   *   'user'      → scopeValue = externalUserId del canal
+   */
+  scope      String
+  scopeValue String?   // null solo para scope='default'
+
+  priority   Int      @default(0)  // mayor número = mayor prioridad
+  enabled    Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  channelConfig ChannelConfig @relation(fields: [channelConfigId], references: [id], onDelete: Cascade)
+  agent         Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@unique([channelConfigId, scope, scopeValue])
+  @@index([channelConfigId, scope])
+  @@index([agentId])
 }
 
 model GatewaySession {


### PR DESCRIPTION
- Update ChannelBinding model in prisma/schema.prisma: replace scopeLevel/scopeId/isDefault with scope/scopeValue/priority/enabled add @@unique([channelConfigId, scope, scopeValue]) + @@index([channelConfigId, scope])
- Create apps/gateway/src/agent-resolver.types.ts: AgentResolutionContext, AgentResolutionResult, BindingScope
- Create apps/gateway/src/agent-resolver.service.ts: AgentResolver class — resolve(), resolveOrNull(), listBindings(), createBinding(), deleteBinding(), invalidateCache(), clearCache() 5-min in-memory cache keyed by channelConfigId priority order: user → tenant → workspace → default → config fallback AgentResolutionError typed error
- Create apps/gateway/src/__tests__/agent-resolver.test.ts: 19 tests covering priority rules, cache TTL, createBinding validation, resolveOrNull, AgentResolutionError shape
- Modify apps/gateway/src/gateway.service.ts: import AgentResolver + AgentResolutionContext instantiate agentResolver in constructor replace cfg.agentId hardcode with agentResolver.resolve() in dispatch()

Closes #F3a-06

## ✅ F3a-06 implementado

**Commit SHA:** `a5b8a24e53c817ec87ad2df8b475447fb80d65fc`

Rama: [`[feat/F3a-06-agent-resolver](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-06-agent-resolver)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-06-agent-resolver)

***

### Archivos entregados en el commit

**`prisma/schema.prisma`** — Modelo `ChannelBinding` rediseñado 
- Reemplaza `scopeLevel`/`scopeId`/`isDefault` por `scope` / `scopeValue` / `priority` / `enabled`
- Nuevo `@@unique([channelConfigId, scope, scopeValue])` + `@@index([channelConfigId, scope])` + `@@index([agentId])`
- Comentario F3a-06 en el header del schema documentando la regla de resolución

**`apps/gateway/src/agent-resolver.types.ts`** ← Nuevo
- `AgentResolutionContext`, `AgentResolutionResult`, `BindingScope`

**`apps/gateway/src/agent-resolver.service.ts`** ← Nuevo
- Clase plain `AgentResolver` (sin decoradores NestJS)
- `resolve()`: orden estricto `user → tenant → workspace → default → config`
- Caché `Map<channelConfigId, { bindings, fetchedAt }>` con TTL de 5 minutos
- `resolveOrNull()`, `listBindings()`, `createBinding()`, `deleteBinding()`, `invalidateCache()`, `clearCache()`
- `AgentResolutionError` con nombre y mensaje tipados

**`apps/gateway/src/__tests__/agent-resolver.test.ts`** ← Nuevo
- **19 tests** con `vitest` + mocks `vi.fn()` — sin BD real
- Cubre: reglas de prioridad, cache hit, `invalidateCache`, expiración TTL con `vi.advanceTimersByTime`, validaciones de `createBinding`, `resolveOrNull`

**`apps/gateway/src/gateway.service.ts`** — Modificado (mínimo, sin reescribir)
- Import `AgentResolver` + `AgentResolutionContext`
- `private readonly agentResolver: AgentResolver` en la clase
- `this.agentResolver = new AgentResolver(db)` en el constructor
- `dispatch()` usa `agentResolver.resolve(resolutionCtx, cfg.agentId)` en lugar de `cfg.agentId` hardcoded
- `deactivateChannel()` llama `agentResolver.invalidateCache()` al desactivar un canal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent resolution system now supports multi-level, scope-based agent assignment at user, tenant, workspace, and default levels with intelligent priority-based matching
  * Automatically routes each inbound message to the appropriate pre-configured agent based on defined bindings
  * Includes automatic fallback to default agent configuration when no specific binding matches user or context criteria
  * Enables flexible, dynamic agent routing without requiring application code changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->