### PR TITLE
feat(F3a-07): add MessageDispatcher with timeout, retry and metrics

### DIFF
--- a/apps/gateway/src/__tests__/message-dispatcher.test.ts
+++ b/apps/gateway/src/__tests__/message-dispatcher.test.ts
@@ -1,0 +1,270 @@
+/**
+ * message-dispatcher.test.ts — [F3a-07]
+ *
+ * Tests unitarios del MessageDispatcher con vitest.
+ * Usa un mock de IAgentExecutor — sin BD, sin FlowEngine.
+ * 16 casos cubriendo success, retry, timeout, agent_error, events.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MessageDispatcher, TimeoutError }       from '../message-dispatcher.service.js'
+import type {
+  IAgentExecutor,
+  DispatchInput,
+  DispatchSuccessEvent,
+  DispatchErrorEvent,
+} from '../message-dispatcher.types.js'
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeExecutor(impl: IAgentExecutor['run']): IAgentExecutor {
+  return { run: impl }
+}
+
+const BASE_INPUT: DispatchInput = {
+  agentId:         'agent-001',
+  history:         [{ role: 'user', content: 'Hola' }] as any,
+  sessionId:       'sess-abc',
+  channelConfigId: 'cfg-xyz',
+  externalUserId:  'user-123',
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────
+
+describe('MessageDispatcher', () => {
+
+  // ── Éxito en el primer intento ──────────────────────────────────────────
+
+  it('retorna DispatchSuccess con reply correcto en el primer intento', async () => {
+    const executor = makeExecutor(async () => ({ reply: 'Hola humano' }))
+    const dispatcher = new MessageDispatcher(executor)
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.reply).toBe('Hola humano')
+      expect(result.attempts).toBe(1)
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('reemplaza reply vacío por "(sin respuesta)"', async () => {
+    const executor = makeExecutor(async () => ({ reply: '' }))
+    const dispatcher = new MessageDispatcher(executor)
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.reply).toBe('(sin respuesta)')
+  })
+
+  it('reemplaza reply con solo espacios por "(sin respuesta)"', async () => {
+    const executor = makeExecutor(async () => ({ reply: '   ' }))
+    const dispatcher = new MessageDispatcher(executor)
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.reply).toBe('(sin respuesta)')
+  })
+
+  // ── Reintento en error transitorio ──────────────────────────────────────
+
+  it('reintenta en error transitorio y retorna éxito en el segundo intento', async () => {
+    let calls = 0
+    const executor = makeExecutor(async () => {
+      calls++
+      if (calls === 1) throw new Error('network error')
+      return { reply: 'Recuperado' }
+    })
+    const dispatcher = new MessageDispatcher(executor, { retryDelayMs: 0 })
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.attempts).toBe(2)
+      expect(result.reply).toBe('Recuperado')
+    }
+  })
+
+  it('retorna DispatchFailure con kind=transient si todos los intentos fallan por red', async () => {
+    const executor = makeExecutor(async () => { throw new Error('econnreset') })
+    const dispatcher = new MessageDispatcher(executor, { retryDelayMs: 0 })
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errorKind).toBe('transient')
+      expect(result.attempts).toBe(2)
+    }
+  })
+
+  // ── Timeout ─────────────────────────────────────────────────────────────
+
+  it('retorna DispatchFailure con kind=timeout cuando el agente excede timeoutMs', async () => {
+    vi.useFakeTimers()
+
+    const executor = makeExecutor(() => new Promise(() => { /* never resolves */ }))
+    const dispatcher = new MessageDispatcher(executor, {
+      timeoutMs:    100,
+      maxAttempts:  1,
+      retryDelayMs: 0,
+    })
+
+    const dispatchPromise = dispatcher.dispatch(BASE_INPUT)
+    vi.advanceTimersByTime(200)
+    const result = await dispatchPromise
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errorKind).toBe('timeout')
+
+    vi.useRealTimers()
+  })
+
+  it('NO reintenta en timeout (timeout no es transitorio)', async () => {
+    vi.useFakeTimers()
+
+    let calls = 0
+    const executor = makeExecutor(() => {
+      calls++
+      return new Promise(() => { /* never */ })
+    })
+    const dispatcher = new MessageDispatcher(executor, {
+      timeoutMs:    100,
+      maxAttempts:  2,
+      retryDelayMs: 0,
+    })
+
+    const dispatchPromise = dispatcher.dispatch(BASE_INPUT)
+    vi.advanceTimersByTime(500)
+    await dispatchPromise
+
+    // timeout NO es reintentable — solo 1 intento
+    expect(calls).toBe(1)
+
+    vi.useRealTimers()
+  })
+
+  // ── Error de agente (no reintentable) ────────────────────────────────────
+
+  it('retorna kind=agent_error para errores 4xx y NO reintenta', async () => {
+    let calls = 0
+    const executor = makeExecutor(async () => {
+      calls++
+      throw new Error('agent not found')
+    })
+    const dispatcher = new MessageDispatcher(executor, { retryDelayMs: 0 })
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errorKind).toBe('agent_error')
+    expect(calls).toBe(1) // sin reintento
+  })
+
+  it('retorna kind=agent_error para error con "invalid agent"', async () => {
+    const executor = makeExecutor(async () => { throw new Error('Invalid agent configuration') })
+    const dispatcher = new MessageDispatcher(executor, { retryDelayMs: 0 })
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errorKind).toBe('agent_error')
+  })
+
+  // ── maxAttempts = 1 (sin reintento) ──────────────────────────────────────
+
+  it('con maxAttempts=1 no reintenta aunque el error sea transitorio', async () => {
+    let calls = 0
+    const executor = makeExecutor(async () => {
+      calls++
+      throw new Error('network error')
+    })
+    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1, retryDelayMs: 0 })
+    await dispatcher.dispatch(BASE_INPUT)
+
+    expect(calls).toBe(1)
+  })
+
+  // ── Eventos de métricas ──────────────────────────────────────────────────
+
+  it('emite dispatch:success con el payload correcto en éxito', async () => {
+    const executor = makeExecutor(async () => ({ reply: 'OK' }))
+    const dispatcher = new MessageDispatcher(executor)
+
+    const events: DispatchSuccessEvent[] = []
+    dispatcher.on('dispatch:success', (e) => events.push(e))
+
+    await dispatcher.dispatch(BASE_INPUT)
+
+    expect(events).toHaveLength(1)
+    expect(events[0]!.sessionId).toBe(BASE_INPUT.sessionId)
+    expect(events[0]!.agentId).toBe(BASE_INPUT.agentId)
+    expect(events[0]!.channelConfigId).toBe(BASE_INPUT.channelConfigId)
+    expect(events[0]!.attempts).toBe(1)
+  })
+
+  it('emite dispatch:error con errorKind correcto en fallo', async () => {
+    const executor = makeExecutor(async () => { throw new Error('econnrefused') })
+    const dispatcher = new MessageDispatcher(executor, { retryDelayMs: 0 })
+
+    const errorEvents: DispatchErrorEvent[] = []
+    dispatcher.on('dispatch:error', (e) => errorEvents.push(e))
+
+    await dispatcher.dispatch(BASE_INPUT)
+
+    expect(errorEvents).toHaveLength(1)
+    expect(errorEvents[0]!.errorKind).toBe('transient')
+    expect(errorEvents[0]!.sessionId).toBe(BASE_INPUT.sessionId)
+  })
+
+  it('emite dispatch:success una sola vez incluso en reintento exitoso', async () => {
+    let calls = 0
+    const executor = makeExecutor(async () => {
+      if (++calls === 1) throw new Error('503 overloaded')
+      return { reply: 'OK en intento 2' }
+    })
+    const dispatcher = new MessageDispatcher(executor, { retryDelayMs: 0 })
+
+    const successEvents: DispatchSuccessEvent[] = []
+    const errorEvents:   DispatchErrorEvent[]   = []
+    dispatcher.on('dispatch:success', (e) => successEvents.push(e))
+    dispatcher.on('dispatch:error',   (e) => errorEvents.push(e))
+
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(true)
+    expect(successEvents).toHaveLength(1)   // un solo evento de éxito
+    expect(errorEvents).toHaveLength(0)     // sin evento de error
+    if (result.ok) expect(result.attempts).toBe(2)
+  })
+
+  // ── Campos de resultado ──────────────────────────────────────────────────
+
+  it('durationMs es siempre un número >= 0', async () => {
+    const executor = makeExecutor(async () => ({ reply: 'fast' }))
+    const dispatcher = new MessageDispatcher(executor)
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(0)
+    expect(typeof result.durationMs).toBe('number')
+  })
+
+  it('DispatchFailure incluye errorMessage como string no vacío', async () => {
+    const executor = makeExecutor(async () => { throw new Error('some error msg') })
+    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1, retryDelayMs: 0 })
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(typeof result.errorMessage).toBe('string')
+      expect(result.errorMessage.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('clasifica error desconocido (no Error instance) como unknown', async () => {
+    const executor = makeExecutor(async () => { throw 'string error' })
+    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1, retryDelayMs: 0 })
+    const result = await dispatcher.dispatch(BASE_INPUT)
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.errorKind).toBe('unknown')
+  })
+
+})

--- a/apps/gateway/src/message-dispatcher.service.ts
+++ b/apps/gateway/src/message-dispatcher.service.ts
@@ -1,0 +1,239 @@
+/**
+ * message-dispatcher.service.ts — [F3a-07]
+ *
+ * Encapsula la llamada al AgentExecutor (AgentRunner) con:
+ *   - Timeout por intento (default 30s)
+ *   - Reintento automático en errores transitorios (max 2 intentos)
+ *   - EventEmitter para métricas observables
+ *   - DispatchResult tipado — NUNCA lanza al caller
+ *   - Logging estructurado con duración y número de intentos
+ *
+ * Clasificación de errores:
+ *   - timeout:     AbortError o Promise.race ganó la señal de timeout
+ *   - agent_error: el AgentRunner lanzó un error con status 4xx (no reintentable)
+ *   - transient:   error de red, 5xx, o desconocido — se reintenta
+ *   - unknown:     cualquier otro tipo de error no clasificado
+ *
+ * Uso:
+ *   const dispatcher = new MessageDispatcher(agentRunner, { timeoutMs: 20_000 })
+ *   const result = await dispatcher.dispatch(input)
+ *   if (result.ok) { ... result.reply ... }
+ *   else { ... result.errorKind ... }
+ *
+ * Métricas:
+ *   dispatcher.on('dispatch:success', (e: DispatchSuccessEvent) => ...)
+ *   dispatcher.on('dispatch:error',   (e: DispatchErrorEvent)   => ...)
+ */
+
+import { EventEmitter }                    from 'node:events'
+import type {
+  IAgentExecutor,
+  DispatchInput,
+  DispatchResult,
+  DispatchErrorKind,
+  MessageDispatcherOptions,
+  DispatchSuccessEvent,
+  DispatchErrorEvent,
+} from './message-dispatcher.types.js'
+
+// ── Constantes por defecto ────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS    = 30_000
+const DEFAULT_MAX_ATTEMPTS  = 2
+const DEFAULT_RETRY_DELAY   = 1_000
+
+// ── Clase principal ───────────────────────────────────────────────────────
+
+export class MessageDispatcher extends EventEmitter {
+  private readonly executor:     IAgentExecutor
+  private readonly timeoutMs:    number
+  private readonly maxAttempts:  number
+  private readonly retryDelayMs: number
+
+  constructor(
+    executor: IAgentExecutor,
+    options:  MessageDispatcherOptions = {},
+  ) {
+    super()
+    this.executor     = executor
+    this.timeoutMs    = options.timeoutMs    ?? DEFAULT_TIMEOUT_MS
+    this.maxAttempts  = options.maxAttempts  ?? DEFAULT_MAX_ATTEMPTS
+    this.retryDelayMs = options.retryDelayMs ?? DEFAULT_RETRY_DELAY
+  }
+
+  // ── Método principal ────────────────────────────────────────────────────
+
+  /**
+   * Despacha el historial de conversación al agente y retorna un DispatchResult.
+   * NUNCA lanza — todos los errores quedan encapsulados en DispatchFailure.
+   */
+  async dispatch(input: DispatchInput): Promise<DispatchResult> {
+    const startMs = Date.now()
+    let   attempt = 0
+    let   lastErrorKind:    DispatchErrorKind = 'unknown'
+    let   lastErrorMessage: string            = ''
+
+    while (attempt < this.maxAttempts) {
+      attempt++
+
+      try {
+        const reply = await this.runWithTimeout(input.agentId, input.history)
+        const durationMs = Date.now() - startMs
+        const replyText  = reply.trim().length > 0 ? reply : '(sin respuesta)'
+
+        const successEvent: DispatchSuccessEvent = {
+          sessionId:       input.sessionId,
+          agentId:         input.agentId,
+          channelConfigId: input.channelConfigId,
+          durationMs,
+          attempts:        attempt,
+        }
+        this.emit('dispatch:success', successEvent)
+
+        console.log(
+          `[MessageDispatcher] ok sessionId=${input.sessionId}` +
+          ` agentId=${input.agentId} attempts=${attempt} durationMs=${durationMs}`,
+        )
+
+        return {
+          ok:         true,
+          reply:      replyText,
+          durationMs,
+          attempts:   attempt,
+        }
+
+      } catch (err: unknown) {
+        const { kind, message } = classifyError(err)
+        lastErrorKind    = kind
+        lastErrorMessage = message
+
+        const isRetryable = kind === 'transient' || kind === 'unknown'
+        const hasRetry    = attempt < this.maxAttempts
+
+        console.warn(
+          `[MessageDispatcher] attempt=${attempt}/${this.maxAttempts}` +
+          ` kind=${kind} retryable=${isRetryable && hasRetry}` +
+          ` sessionId=${input.sessionId} error=${message}`,
+        )
+
+        if (!isRetryable || !hasRetry) break
+
+        // Delay antes del reintento
+        await sleep(this.retryDelayMs)
+      }
+    }
+
+    // Todos los intentos fallaron
+    const durationMs = Date.now() - startMs
+
+    const errorEvent: DispatchErrorEvent = {
+      sessionId:       input.sessionId,
+      agentId:         input.agentId,
+      channelConfigId: input.channelConfigId,
+      errorKind:       lastErrorKind,
+      errorMessage:    lastErrorMessage,
+      durationMs,
+      attempts:        attempt,
+    }
+    this.emit('dispatch:error', errorEvent)
+
+    console.error(
+      `[MessageDispatcher] failed sessionId=${input.sessionId}` +
+      ` agentId=${input.agentId} kind=${lastErrorKind}` +
+      ` attempts=${attempt} durationMs=${durationMs}`,
+    )
+
+    return {
+      ok:           false,
+      errorKind:    lastErrorKind,
+      errorMessage: lastErrorMessage,
+      durationMs,
+      attempts:     attempt,
+    }
+  }
+
+  // ── Ejecución con timeout ────────────────────────────────────────────────
+
+  private async runWithTimeout(
+    agentId: string,
+    history: import('@agent-vs/gateway-sdk').SessionTurn[],
+  ): Promise<string> {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new TimeoutError(`AgentRunner exceeded ${this.timeoutMs}ms`))
+      }, this.timeoutMs)
+    })
+
+    try {
+      const result = await Promise.race([
+        this.executor.run(agentId, history),
+        timeoutPromise,
+      ])
+      return result.reply ?? ''
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
+  }
+}
+
+// ── Errores internos ──────────────────────────────────────────────────────
+
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
+
+// ── Clasificación de errores ──────────────────────────────────────────────
+
+function classifyError(err: unknown): { kind: DispatchErrorKind; message: string } {
+  if (err instanceof TimeoutError) {
+    return { kind: 'timeout', message: err.message }
+  }
+
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase()
+
+    // Errores 4xx de negocio — no reintentables
+    if (
+      msg.includes('400') ||
+      msg.includes('401') ||
+      msg.includes('403') ||
+      msg.includes('404') ||
+      msg.includes('agent not found') ||
+      msg.includes('invalid agent') ||
+      msg.includes('not found')
+    ) {
+      return { kind: 'agent_error', message: err.message }
+    }
+
+    // Errores de red / LLM / 5xx — reintentables
+    if (
+      msg.includes('network') ||
+      msg.includes('econnrefused') ||
+      msg.includes('econnreset') ||
+      msg.includes('fetch') ||
+      msg.includes('timeout') ||
+      msg.includes('503') ||
+      msg.includes('502') ||
+      msg.includes('500') ||
+      msg.includes('rate limit') ||
+      msg.includes('overloaded')
+    ) {
+      return { kind: 'transient', message: err.message }
+    }
+
+    return { kind: 'unknown', message: err.message }
+  }
+
+  return { kind: 'unknown', message: String(err) }
+}
+
+// ── Utilidades ────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/apps/gateway/src/message-dispatcher.types.ts
+++ b/apps/gateway/src/message-dispatcher.types.ts
@@ -1,0 +1,105 @@
+/**
+ * message-dispatcher.types.ts — [F3a-07]
+ *
+ * Tipos públicos del MessageDispatcher:
+ *   - IAgentExecutor: abstracción del AgentRunner para inyección/testing
+ *   - DispatchInput: contexto completo de un mensaje entrante
+ *   - DispatchResult: union type ok/failure — el caller NUNCA recibe un throw
+ *   - MessageDispatcherOptions: timeout, reintentos, delay
+ *   - DispatchSuccessEvent / DispatchErrorEvent: payloads de métricas
+ */
+
+import type { SessionTurn } from '@agent-vs/gateway-sdk'
+
+// ── Abstracción del ejecutor de agente ────────────────────────────────────
+
+/**
+ * Interfaz mínima que MessageDispatcher necesita del AgentRunner.
+ * AgentRunner de @agent-vs/flow-engine implementa esta interfaz.
+ */
+export interface IAgentExecutor {
+  run(agentId: string, history: SessionTurn[]): Promise<{ reply: string }>
+}
+
+// ── Input del dispatch ────────────────────────────────────────────────────
+
+export interface DispatchInput {
+  agentId:         string
+  history:         SessionTurn[]
+  /** Para logging y métricas */
+  sessionId:       string
+  /** Para logging */
+  channelConfigId: string
+  /** Para logging */
+  externalUserId:  string
+}
+
+// ── Resultado del dispatch ────────────────────────────────────────────────
+
+export type DispatchResult =
+  | DispatchSuccess
+  | DispatchFailure
+
+export interface DispatchSuccess {
+  ok:         true
+  reply:      string
+  durationMs: number
+  /** Número de intentos realizados (1 = éxito directo, 2 = éxito en reintento) */
+  attempts:   number
+}
+
+export interface DispatchFailure {
+  ok:           false
+  /** Tipo de error para que el caller decida el mensaje al usuario */
+  errorKind:    DispatchErrorKind
+  /** Mensaje técnico para logs */
+  errorMessage: string
+  durationMs:   number
+  attempts:     number
+}
+
+export type DispatchErrorKind =
+  | 'timeout'      // AgentRunner tardó más de timeoutMs
+  | 'agent_error'  // AgentRunner lanzó un error de negocio (no reintentable)
+  | 'transient'    // Error de red/LLM reintentado sin éxito
+  | 'unknown'      // Error no clasificado
+
+// ── Opciones del dispatcher ───────────────────────────────────────────────
+
+export interface MessageDispatcherOptions {
+  /**
+   * Tiempo máximo de espera por intento en ms.
+   * @default 30_000
+   */
+  timeoutMs?: number
+  /**
+   * Número máximo de intentos (1 = sin reintento).
+   * @default 2
+   */
+  maxAttempts?: number
+  /**
+   * Delay entre intentos en ms.
+   * @default 1_000
+   */
+  retryDelayMs?: number
+}
+
+// ── Eventos de métricas ───────────────────────────────────────────────────
+
+export interface DispatchSuccessEvent {
+  sessionId:       string
+  agentId:         string
+  channelConfigId: string
+  durationMs:      number
+  attempts:        number
+}
+
+export interface DispatchErrorEvent {
+  sessionId:       string
+  agentId:         string
+  channelConfigId: string
+  errorKind:       DispatchErrorKind
+  errorMessage:    string
+  durationMs:      number
+  attempts:        number
+}


### PR DESCRIPTION
- Add message-dispatcher.types.ts: IAgentExecutor, DispatchInput, DispatchResult, DispatchSuccess, DispatchFailure, DispatchErrorKind, MessageDispatcherOptions, DispatchSuccessEvent, DispatchErrorEvent
- Add message-dispatcher.service.ts: MessageDispatcher class with timeout per attempt (default 30s), up to 2 attempts with delay, transient vs non-retryable error classification, EventEmitter events dispatch:success / dispatch:error, structured logging with durationMs
- Add __tests__/message-dispatcher.test.ts: 16 vitest tests covering success on first attempt, retry on transient error, timeout detection, non-retryable agent_error, maxAttempts=1 disables retry, event emission, durationMs and attempts fields, empty reply fallback
- Modify gateway.service.ts: replace inline agentRunner.run() block with messageDispatcher.dispatch(), handle DispatchResult ok/failure branches, map errorKind to user-facing reply string

Closes #50

## ✅ F3a-07 implementado

**Commit SHA: `3f143c38f0e7e044c7696e35aac20b3f711e3c90`** 

Rama: [`[feat/F3a-07-message-dispatcher](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-07-message-dispatcher)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-07-message-dispatcher)

***

### Archivos entregados en el commit

**`apps/gateway/src/message-dispatcher.types.ts`** ← Nuevo
- `IAgentExecutor` — interfaz mínima que abstrae `AgentRunner` para ser testeable sin instanciar FlowEngine
- `DispatchInput` — contexto completo: `agentId`, `history`, `sessionId`, `channelConfigId`, `externalUserId`
- `DispatchResult = DispatchSuccess | DispatchFailure` — union type; el caller **nunca** recibe un `throw`
- `DispatchErrorKind`: `timeout | agent_error | transient | unknown`
- `MessageDispatcherOptions` con `timeoutMs`, `maxAttempts`, `retryDelayMs`
- `DispatchSuccessEvent` / `DispatchErrorEvent` para observabilidad

**`apps/gateway/src/message-dispatcher.service.ts`** ← Nuevo
- Clase `MessageDispatcher extends EventEmitter` — sin decoradores NestJS, plain class
- `dispatch()`: loop de hasta `maxAttempts` (default 2), nunca lanza, siempre retorna `DispatchResult`
- `runWithTimeout()`: `Promise.race` entre el executor y un `setTimeout` → lanza `TimeoutError`
- Clasificación de errores: `4xx/agent not found` → `agent_error` (no reintentable); `network/5xx/rate-limit` → `transient` (reintentable); `TimeoutError` → `timeout` (no reintentable)
- Eventos `dispatch:success` / `dispatch:error` emitidos con payload completo para métricas
- Logging estructurado con `durationMs`, `attempts`, `sessionId`

**`apps/gateway/src/__tests__/message-dispatcher.test.ts`** ← Nuevo
- **16 tests** con `vitest` + `vi.useFakeTimers()` para el caso de timeout
- Cubre: éxito directo, reply vacío → `"(sin respuesta)"`, retry exitoso en intento 2, `transient` agota intentos, timeout detectado, timeout no reintenta, `agent_error` no reintenta, `maxAttempts=1` desactiva retry, eventos `dispatch:success`/`dispatch:error`, evento único en retry exitoso, `durationMs >= 0`, `errorMessage` no vacío, error no-`Error` → `unknown`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message dispatcher service with automatic retry capability for transient failures and per-attempt timeout protection.
  * Error classification with four error types and detailed error messaging.
  * Event emission for dispatch outcomes with duration and attempt count metrics.
  * Configurable timeout and retry behavior.

* **Tests**
  * Added comprehensive test suite covering success/failure paths, retry behavior, timeout handling, and event emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->