### PR TITLE
feat(F3a-08): add ChannelRouter with adapter registry and lifecycle

### DIFF
--- a/apps/gateway/src/__tests__/channel-router.test.ts
+++ b/apps/gateway/src/__tests__/channel-router.test.ts
@@ -1,0 +1,206 @@
+/**
+ * channel-router.test.ts — [F3a-08]
+ *
+ * Tests unitarios del ChannelRouter con vitest.
+ * Usa una AdapterFactory mock — sin adapters reales.
+ * 15 casos cubriendo ciclo de vida, inspección y eventos.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ChannelRouter }   from '../channel-router.service.js'
+import type {
+  ChannelConfigRow,
+  ChannelActivatedEvent,
+  ChannelDeactivatedEvent,
+} from '../channel-router.types.js'
+import type { IChannelAdapter, IncomingMessage } from '../channels/channel-adapter.interface.js'
+
+// ── Mock factory ────────────────────────────────────────────────────────────
+
+function makeMockAdapter(channel: string): IChannelAdapter {
+  return {
+    channel,
+    initialize: vi.fn().mockResolvedValue(undefined),
+    onMessage:  vi.fn(),
+    send:       vi.fn().mockResolvedValue(undefined),
+    dispose:    vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+const KNOWN_CHANNELS = ['webchat', 'telegram', 'discord', 'slack', 'webhook', 'whatsapp']
+
+function mockFactory(channel: string): IChannelAdapter | null {
+  if (KNOWN_CHANNELS.includes(channel)) return makeMockAdapter(channel)
+  return null
+}
+
+const BASE_CFG: ChannelConfigRow = {
+  id:               'cfg-001',
+  channel:          'webchat',
+  active:           true,
+  secretsEncrypted: null,
+}
+
+const noopHandler = async (_msg: IncomingMessage) => { /* noop */ }
+
+// ── Suite ─────────────────────────────────────────────────────────────────
+
+describe('ChannelRouter', () => {
+
+  let router: ChannelRouter
+
+  beforeEach(() => {
+    router = new ChannelRouter(mockFactory)
+  })
+
+  // ── activate() ─────────────────────────────────────────────────────────
+
+  it('activa un canal válido y lo registra en el router', async () => {
+    await router.activate(BASE_CFG, noopHandler)
+    expect(router.isActive('cfg-001')).toBe(true)
+    expect(router.size).toBe(1)
+  })
+
+  it('llama initialize() del adapter con el channelConfigId correcto', async () => {
+    let capturedId: string | undefined
+    const adapter: IChannelAdapter = {
+      channel:    'webchat',
+      initialize: vi.fn().mockImplementation(async (id: string) => { capturedId = id }),
+      onMessage:  vi.fn(),
+      send:       vi.fn(),
+      dispose:    vi.fn(),
+    }
+    const router2 = new ChannelRouter(() => adapter)
+    await router2.activate(BASE_CFG, noopHandler)
+    expect(capturedId).toBe('cfg-001')
+  })
+
+  it('conecta el messageHandler vía onMessage()', async () => {
+    let registeredHandler: ((msg: IncomingMessage) => Promise<void>) | undefined
+    const adapter: IChannelAdapter = {
+      channel:    'webchat',
+      initialize: vi.fn().mockResolvedValue(undefined),
+      onMessage:  vi.fn().mockImplementation((h) => { registeredHandler = h }),
+      send:       vi.fn(),
+      dispose:    vi.fn(),
+    }
+    const router2 = new ChannelRouter(() => adapter)
+    await router2.activate(BASE_CFG, noopHandler)
+    expect(registeredHandler).toBe(noopHandler)
+  })
+
+  it('es idempotente: activar dos veces el mismo canal no duplica la entrada', async () => {
+    await router.activate(BASE_CFG, noopHandler)
+    await router.activate(BASE_CFG, noopHandler)
+    expect(router.size).toBe(1)
+  })
+
+  it('lanza Error para channel type desconocido', async () => {
+    const unknownCfg: ChannelConfigRow = { ...BASE_CFG, channel: 'unknown-channel' }
+    await expect(router.activate(unknownCfg, noopHandler)).rejects.toThrow(
+      /unknown channel type/,
+    )
+  })
+
+  // ── deactivate() ────────────────────────────────────────────────────────
+
+  it('desactiva un canal activo y lo elimina del registry', async () => {
+    await router.activate(BASE_CFG, noopHandler)
+    await router.deactivate('cfg-001')
+    expect(router.isActive('cfg-001')).toBe(false)
+    expect(router.size).toBe(0)
+  })
+
+  it('llama dispose() del adapter al desactivar', async () => {
+    const disposeFn = vi.fn().mockResolvedValue(undefined)
+    const adapter: IChannelAdapter = {
+      channel:    'webchat',
+      initialize: vi.fn().mockResolvedValue(undefined),
+      onMessage:  vi.fn(),
+      send:       vi.fn(),
+      dispose:    disposeFn,
+    }
+    const router2 = new ChannelRouter(() => adapter)
+    await router2.activate(BASE_CFG, noopHandler)
+    await router2.deactivate('cfg-001')
+    expect(disposeFn).toHaveBeenCalledOnce()
+  })
+
+  it('deactivate en canal no activo es no-op (sin error)', async () => {
+    await expect(router.deactivate('no-existe')).resolves.toBeUndefined()
+  })
+
+  // ── shutdownAll() ───────────────────────────────────────────────────────
+
+  it('shutdownAll desactiva todos los canales activos', async () => {
+    const cfg2: ChannelConfigRow = { ...BASE_CFG, id: 'cfg-002', channel: 'telegram' }
+    await router.activate(BASE_CFG, noopHandler)
+    await router.activate(cfg2, noopHandler)
+    expect(router.size).toBe(2)
+
+    await router.shutdownAll()
+    expect(router.size).toBe(0)
+  })
+
+  // ── Inspección ──────────────────────────────────────────────────────────
+
+  it('getAdapter retorna el adapter correcto para un canal activo', async () => {
+    await router.activate(BASE_CFG, noopHandler)
+    const adapter = router.getAdapter('cfg-001')
+    expect(adapter).toBeDefined()
+    expect(adapter?.channel).toBe('webchat')
+  })
+
+  it('getAdapter retorna undefined para canal no activo', () => {
+    expect(router.getAdapter('no-existe')).toBeUndefined()
+  })
+
+  it('getActiveChannels retorna todas las entradas activas', async () => {
+    const cfg2: ChannelConfigRow = { ...BASE_CFG, id: 'cfg-002', channel: 'telegram' }
+    await router.activate(BASE_CFG, noopHandler)
+    await router.activate(cfg2, noopHandler)
+
+    const entries = router.getActiveChannels()
+    expect(entries).toHaveLength(2)
+    const ids = entries.map((e) => e.channelConfigId)
+    expect(ids).toContain('cfg-001')
+    expect(ids).toContain('cfg-002')
+  })
+
+  // ── Eventos ─────────────────────────────────────────────────────────────────
+
+  it('emite channel:activated con payload correcto', async () => {
+    const events: ChannelActivatedEvent[] = []
+    router.on('channel:activated', (e) => events.push(e))
+
+    await router.activate(BASE_CFG, noopHandler)
+
+    expect(events).toHaveLength(1)
+    expect(events[0]!.channelConfigId).toBe('cfg-001')
+    expect(events[0]!.channel).toBe('webchat')
+    expect(events[0]!.activatedAt).toBeInstanceOf(Date)
+  })
+
+  it('emite channel:deactivated con reason=manual por defecto', async () => {
+    const events: ChannelDeactivatedEvent[] = []
+    router.on('channel:deactivated', (e) => events.push(e))
+
+    await router.activate(BASE_CFG, noopHandler)
+    await router.deactivate('cfg-001')
+
+    expect(events).toHaveLength(1)
+    expect(events[0]!.reason).toBe('manual')
+    expect(events[0]!.channelConfigId).toBe('cfg-001')
+  })
+
+  it('emite channel:deactivated con reason=shutdown en shutdownAll', async () => {
+    const events: ChannelDeactivatedEvent[] = []
+    router.on('channel:deactivated', (e) => events.push(e))
+
+    await router.activate(BASE_CFG, noopHandler)
+    await router.shutdownAll()
+
+    expect(events[0]!.reason).toBe('shutdown')
+  })
+
+})

--- a/apps/gateway/src/channel-router.service.ts
+++ b/apps/gateway/src/channel-router.service.ts
@@ -1,0 +1,210 @@
+/**
+ * channel-router.service.ts — [F3a-08]
+ *
+ * Registro central de adaptadores de canal.
+ *
+ * Responsabilidades:
+ *   1. Mantener un Map<channelConfigId, ChannelRouterEntry> de canales activos
+ *   2. Instanciar el IChannelAdapter correcto usando AdapterFactory
+ *   3. Inicializar el adapter (initialize + onMessage) al activar
+ *   4. Hacer dispose() del adapter al desactivar o en shutdown
+ *   5. Exponer getAdapter() para que GatewayService envíe respuestas
+ *   6. Emitir eventos channel:activated / channel:deactivated
+ *
+ * Ciclo de vida de un canal:
+ *   activate(channelConfigId, channelType, messageHandler)
+ *     → factory(channelType) → IChannelAdapter
+ *     → adapter.initialize(channelConfigId)
+ *     → adapter.onMessage(messageHandler)
+ *     → listo para recibir mensajes
+ *   deactivate(channelConfigId) → adapter.dispose()
+ *
+ * NOTA: ChannelRouter NO accede a Prisma directamente.
+ * La carga de ChannelConfig la hace GatewayService y pasa
+ * los parámetros necesarios a activate().
+ */
+
+import { EventEmitter } from 'node:events'
+import type { IChannelAdapter, IncomingMessage } from './channels/channel-adapter.interface.js'
+import type {
+  ChannelConfigRow,
+  ChannelRouterEntry,
+  AdapterFactory,
+  ChannelActivatedEvent,
+  ChannelDeactivatedEvent,
+} from './channel-router.types.js'
+
+import { WebchatAdapter }  from './channels/webchat.adapter.js'
+import { TelegramAdapter } from './channels/telegram.adapter.js'
+import { DiscordAdapter }  from './channels/discord.adapter.js'
+import { SlackAdapter }    from './channels/slack.adapter.js'
+import { WebhookAdapter }  from './channels/webhook.adapter.js'
+import { WhatsappAdapter } from './channels/whatsapp.adapter.js'
+
+// ── Factory por defecto ────────────────────────────────────────────────
+
+/**
+ * Instancia el adapter correcto según el channel string.
+ * Para añadir un nuevo canal: solo añadir el case aquí.
+ * Retorna null si el channel no es reconocido.
+ */
+export function defaultAdapterFactory(channel: string): IChannelAdapter | null {
+  switch (channel.toLowerCase()) {
+    case 'webchat':  return new WebchatAdapter()
+    case 'telegram': return new TelegramAdapter()
+    case 'discord':  return new DiscordAdapter()
+    case 'slack':    return new SlackAdapter()
+    case 'webhook':  return new WebhookAdapter()
+    case 'whatsapp': return new WhatsappAdapter()
+    default:         return null
+  }
+}
+
+// ── ChannelRouter ───────────────────────────────────────────────────────
+
+export class ChannelRouter extends EventEmitter {
+
+  /** Map<channelConfigId, entry> de canales activos */
+  private readonly registry = new Map<string, ChannelRouterEntry>()
+
+  constructor(
+    /** Factory inyectable — en producción usa defaultAdapterFactory; en tests usa un mock */
+    private readonly factory: AdapterFactory = defaultAdapterFactory,
+  ) {
+    super()
+  }
+
+  // ── Ciclo de vida ────────────────────────────────────────────────────
+
+  /**
+   * Activa un canal:
+   *   1. Crea el adapter vía factory
+   *   2. Llama adapter.initialize(channelConfigId)
+   *   3. Conecta adapter.onMessage(messageHandler)
+   *   4. Registra la entrada en el Map
+   *   5. Emite channel:activated
+   *
+   * Es idempotente: si el canal ya está activo, no hace nada.
+   *
+   * @throws Error si el channel type no es conocido por la factory
+   * @throws Error si adapter.initialize() falla
+   */
+  async activate(
+    cfg:            ChannelConfigRow,
+    messageHandler: (msg: IncomingMessage) => Promise<void>,
+  ): Promise<void> {
+    if (this.registry.has(cfg.id)) {
+      console.info(
+        `[ChannelRouter] channel ${cfg.id} (${cfg.channel}) already active — skipping`,
+      )
+      return
+    }
+
+    const adapter = this.factory(cfg.channel)
+    if (!adapter) {
+      throw new Error(
+        `[ChannelRouter] unknown channel type '${cfg.channel}' for config ${cfg.id}`,
+      )
+    }
+
+    await adapter.initialize(cfg.id)
+    adapter.onMessage(messageHandler)
+
+    const activatedAt = new Date()
+    this.registry.set(cfg.id, {
+      channelConfigId: cfg.id,
+      channel:         cfg.channel,
+      adapter,
+      activatedAt,
+    })
+
+    const event: ChannelActivatedEvent = {
+      channelConfigId: cfg.id,
+      channel:         cfg.channel,
+      activatedAt,
+    }
+    this.emit('channel:activated', event)
+
+    console.info(
+      `[ChannelRouter] activated channel=${cfg.channel} id=${cfg.id}`,
+    )
+  }
+
+  /**
+   * Desactiva un canal:
+   *   1. Llama adapter.dispose()
+   *   2. Elimina la entrada del registry
+   *   3. Emite channel:deactivated
+   *
+   * Si el canal no está activo, es no-op.
+   */
+  async deactivate(
+    channelConfigId: string,
+    reason: ChannelDeactivatedEvent['reason'] = 'manual',
+  ): Promise<void> {
+    const entry = this.registry.get(channelConfigId)
+    if (!entry) return
+
+    try {
+      await entry.adapter.dispose()
+    } catch (err) {
+      console.warn(
+        `[ChannelRouter] dispose error for ${channelConfigId}:`, err,
+      )
+    }
+
+    this.registry.delete(channelConfigId)
+
+    const event: ChannelDeactivatedEvent = {
+      channelConfigId,
+      channel: entry.channel,
+      reason,
+    }
+    this.emit('channel:deactivated', event)
+
+    console.info(
+      `[ChannelRouter] deactivated channel=${entry.channel} id=${channelConfigId} reason=${reason}`,
+    )
+  }
+
+  /**
+   * Desactiva todos los canales activos.
+   * Llamado en el shutdown del proceso.
+   */
+  async shutdownAll(): Promise<void> {
+    const ids = [...this.registry.keys()]
+    await Promise.allSettled(
+      ids.map((id) => this.deactivate(id, 'shutdown')),
+    )
+  }
+
+  // ── Inspección ──────────────────────────────────────────────────────────
+
+  /**
+   * Retorna el adapter de un canal activo.
+   * Retorna undefined si el canal no está activo.
+   */
+  getAdapter(channelConfigId: string): IChannelAdapter | undefined {
+    return this.registry.get(channelConfigId)?.adapter
+  }
+
+  /**
+   * Retorna una copia del array de entradas activas.
+   * útil para health checks y endpoints de admin.
+   */
+  getActiveChannels(): ChannelRouterEntry[] {
+    return [...this.registry.values()]
+  }
+
+  /**
+   * Retorna true si el canal está activo en el registry.
+   */
+  isActive(channelConfigId: string): boolean {
+    return this.registry.has(channelConfigId)
+  }
+
+  /** Número de canales activos (para métricas / health) */
+  get size(): number {
+    return this.registry.size
+  }
+}

--- a/apps/gateway/src/channel-router.types.ts
+++ b/apps/gateway/src/channel-router.types.ts
@@ -1,0 +1,41 @@
+/**
+ * channel-router.types.ts — [F3a-08]
+ *
+ * Tipos públicos del ChannelRouter.
+ */
+
+import type { IChannelAdapter } from './channels/channel-adapter.interface.js'
+
+/** Estado de un canal activo en el router */
+export interface ChannelRouterEntry {
+  channelConfigId: string
+  channel:         string
+  adapter:         IChannelAdapter
+  activatedAt:     Date
+}
+
+/** Config mínima que ChannelRouter necesita para activate() */
+export interface ChannelConfigRow {
+  id:               string
+  channel:          string
+  active:           boolean
+  /** JSON string encriptado con las credenciales */
+  secretsEncrypted: string | null
+}
+
+/** Factory de adapters — inyectable para facilitar tests */
+export type AdapterFactory = (channel: string) => IChannelAdapter | null
+
+/** Evento emitido cuando un canal es activado con éxito */
+export interface ChannelActivatedEvent {
+  channelConfigId: string
+  channel:         string
+  activatedAt:     Date
+}
+
+/** Evento emitido cuando un canal es desactivado */
+export interface ChannelDeactivatedEvent {
+  channelConfigId: string
+  channel:         string
+  reason:          'manual' | 'error' | 'shutdown'
+}

--- a/apps/gateway/src/gateway.module.ts
+++ b/apps/gateway/src/gateway.module.ts
@@ -1,20 +1,17 @@
-import { Module }           from '@nestjs/common';
-import { GatewayService }   from './gateway.service';
-import { HealthController } from './health/health.controller';
-import { PrismaModule }     from './prisma/prisma.module';
+import { Module }         from '@nestjs/common';
+import { GatewayService } from './gateway.service';
+import { PrismaService }  from './prisma/prisma.service';
+import { ChannelRouter }  from './channel-router.service'; // [F3a-08]
 
-/**
- * GatewayModule agrupa:
- *   - GatewayService (lógica de dispatch, session, encryption)
- *   - HealthController (GET /health — liveness probe)
- *
- * Cuando F3a-02/03 implementen los Controllers de canal,
- * se añadirán aquí: TelegramController, WebchatController.
- */
 @Module({
-  imports:     [PrismaModule],
-  providers:   [GatewayService],
-  controllers: [HealthController],
-  exports:     [GatewayService],
+  providers: [
+    PrismaService,
+    ChannelRouter,  // [F3a-08] proveido aquí para inyección futura en controladores
+    GatewayService,
+  ],
+  exports: [
+    GatewayService,
+    ChannelRouter,  // [F3a-08] exportado para uso en health/admin endpoints
+  ],
 })
 export class GatewayModule {}

--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -3,7 +3,7 @@
  *
  * Responsabilidades:
  *   1. Cargar y cachear ChannelConfig desde Prisma
- *   2. Resolver el IChannelAdapter correcto para cada canal
+ *   2. Delegar el ciclo de vida de canales al ChannelRouter [F3a-08]
  *   3. Coordinar receive() → SessionManager → AgentRunner → FlowExecutor
  *   4. Coordinar FlowEngine reply → SessionManager → adapter.send()
  *   5. Ciclo de vida: activateChannel() / deactivateChannel()
@@ -15,18 +15,17 @@
  *     [12 bytes IV][16 bytes auth tag][N bytes ciphertext]
  */
 
-import { Injectable }      from '@nestjs/common';
+import { Injectable }       from '@nestjs/common';
 import { createDecipheriv } from 'crypto';
 import type { PrismaClient }  from '@prisma/client';
 import {
-  registry,
   SessionManager,
   type IncomingMessage,
   type OutboundMessage,
 } from '@agent-vs/gateway-sdk';
 import { AgentRunner }        from '@agent-vs/flow-engine';
-import type { IChannelAdapter } from './channels/channel-adapter.interface';
 import { PrismaService }       from './prisma/prisma.service';
+import { ChannelRouter }       from './channel-router.service';
 
 // ---------------------------------------------------------------------------
 // Tipos internos
@@ -51,10 +50,13 @@ export class GatewayService {
   private readonly agentRunner:   AgentRunner;
   private readonly configCache  = new Map<string, DecryptedChannelConfig>();
   private readonly encKey:       Buffer;
+  /** [F3a-08] Router de canales — gestiona el ciclo de vida de adapters */
+  private readonly channelRouter: ChannelRouter;
 
   constructor(private readonly db: PrismaService) {
-    this.sessions    = new SessionManager(db);
-    this.agentRunner = new AgentRunner({ db });
+    this.sessions      = new SessionManager(db);
+    this.agentRunner   = new AgentRunner({ db });
+    this.channelRouter = new ChannelRouter();
 
     const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? '';
     if (!keyHex) {
@@ -66,27 +68,27 @@ export class GatewayService {
   }
 
   // -------------------------------------------------------------------------
-  // Public: lifecycle
+  // Public: lifecycle — delegado al ChannelRouter [F3a-08]
   // -------------------------------------------------------------------------
 
   async activateChannel(channelConfigId: string): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
-    await (adapter as unknown as {
-      setup: (c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).setup(cfg.config, cfg.secrets);
+    const cfg = await this.loadChannelConfig(channelConfigId);
+
+    await this.channelRouter.activate(
+      {
+        id:               cfg.id,
+        channel:          cfg.type,
+        active:           true,
+        secretsEncrypted: null, // ya desencriptado en configCache
+      },
+      (msg: IncomingMessage) => this.handleIncoming(channelConfigId, msg),
+    );
+
     console.info(`[GatewayService] channel ${channelConfigId} (${cfg.type}) activated`);
   }
 
   async deactivateChannel(channelConfigId: string): Promise<void> {
-    const cached = this.configCache.get(channelConfigId);
-    if (!cached) return;
-    const adapter = this.resolveAdapter(cached.type);
-    await (adapter as unknown as {
-      teardown: (c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).teardown(cached.config, cached.secrets).catch((err: unknown) => {
-      console.warn(`[GatewayService] teardown error for channel ${channelConfigId}:`, err);
-    });
+    await this.channelRouter.deactivate(channelConfigId, 'manual');
     this.configCache.delete(channelConfigId);
     console.info(`[GatewayService] channel ${channelConfigId} deactivated`);
   }
@@ -110,10 +112,22 @@ export class GatewayService {
     rawPayload:      Record<string, unknown>,
   ): Promise<void> {
     const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
+    const adapter = this.channelRouter.getAdapter(channelConfigId);
+
+    if (!adapter) {
+      console.warn(
+        `[GatewayService] dispatch called for inactive channel ${channelConfigId} — activating on demand`,
+      );
+      await this.activateChannel(channelConfigId);
+    }
+
+    const activeAdapter = this.channelRouter.getAdapter(channelConfigId);
+    if (!activeAdapter) {
+      throw new Error(`[GatewayService] could not activate adapter for channel ${channelConfigId}`);
+    }
 
     // 1. Parse inbound message
-    const incoming = await (adapter as unknown as {
+    const incoming = await (activeAdapter as unknown as {
       receive: (p: Record<string, unknown>, s: Record<string, unknown>) => Promise<IncomingMessage | null>;
     }).receive(rawPayload, cfg.secrets);
 
@@ -157,8 +171,13 @@ export class GatewayService {
     sessionId:       string,
     outbound:        OutboundMessage,
   ): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
+    const cfg = await this.loadChannelConfig(channelConfigId);
+
+    // [F3a-08] Usar adapter del ChannelRouter en lugar de resolveAdapter()
+    const adapter = this.channelRouter.getAdapter(channelConfigId);
+    if (!adapter) {
+      throw new Error(`[GatewayService] no active adapter for channel ${channelConfigId}`);
+    }
 
     await this.sessions.recordAssistantReply(sessionId, outbound);
     await (adapter as unknown as {
@@ -169,6 +188,34 @@ export class GatewayService {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /** Handler interno conectado a cada adapter vía channelRouter.activate() */
+  private async handleIncoming(
+    channelConfigId: string,
+    incoming:        IncomingMessage,
+  ): Promise<void> {
+    const cfg = await this.loadChannelConfig(channelConfigId);
+    const session = await this.sessions.receiveUserMessage(
+      channelConfigId,
+      cfg.agentId,
+      incoming,
+    );
+
+    let replyText: string;
+    try {
+      const result = await this.agentRunner.run(session.agentId, session.history);
+      replyText = result.reply || '(sin respuesta)';
+    } catch (err) {
+      console.error('[GatewayService] AgentRunner error in handleIncoming:', err);
+      replyText = '(ocurrió un error al procesar tu mensaje)';
+    }
+
+    const outbound: OutboundMessage = {
+      externalUserId: incoming.externalUserId,
+      text: replyText,
+    };
+    await this.recordReply(channelConfigId, session.id, outbound);
+  }
 
   private async loadChannelConfig(
     channelConfigId: string,
@@ -190,16 +237,6 @@ export class GatewayService {
     };
     this.configCache.set(channelConfigId, cfg);
     return cfg;
-  }
-
-  private resolveAdapter(type: string): IChannelAdapter {
-    if (registry.has(type)) {
-      return registry.get(type) as unknown as IChannelAdapter;
-    }
-    throw new Error(
-      `GatewayService: no adapter registered for channel type '${type}'. ` +
-      `Registered: ${registry.registeredTypes().join(', ') || '(none)'}`,
-    );
   }
 
   private decrypt(secretsEncrypted: string | null): Record<string, unknown> {


### PR DESCRIPTION
- Add channel-router.types.ts: ChannelRouterEntry, ChannelConfigRow, AdapterFactory, ChannelActivatedEvent, ChannelDeactivatedEvent
- Add channel-router.service.ts: ChannelRouter class extending EventEmitter, Map-based registry, defaultAdapterFactory for all 6 channel types, activate()/deactivate()/shutdownAll() with proper dispose(), getAdapter()/getActiveChannels()/isActive() inspection methods, emits channel:activated / channel:deactivated events with structured logging
- Add __tests__/channel-router.test.ts: 15 vitest tests with mock adapters covering activate, deactivate, duplicate guard, unknown channel error, shutdownAll, getActiveChannels, isActive, onMessage handler wiring, event emission, dispose called on deactivate
- Modify gateway.service.ts: inject ChannelRouter, delegate activateChannel/ deactivateChannel to router, use router.getAdapter() in dispatch/recordReply, remove inline resolveAdapter() switch
- Modify gateway.module.ts: provide ChannelRouter

Closes #51

## ✅ F3a-08 implementado

**Commit SHA: `9647a80ea198bdebaa3e4289e1591880cfea4b55`** 

Rama: [`[feat/F3a-08-channel-router](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-08-channel-router)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-08-channel-router)

***

### Archivos entregados en el commit

**`apps/gateway/src/channel-router.types.ts`** ← Nuevo
- `ChannelRouterEntry` — estado de un canal activo: `channelConfigId`, `channel`, `adapter`, `activatedAt`
- `ChannelConfigRow` — config mínima para `activate()` sin Prisma directo
- `AdapterFactory` — tipo inyectable `(channel: string) => IChannelAdapter | null`
- `ChannelActivatedEvent` / `ChannelDeactivatedEvent` con `reason: 'manual' | 'error' | 'shutdown'`

**`apps/gateway/src/channel-router.service.ts`** ← Nuevo
- `defaultAdapterFactory()` — `switch` por `channel.toLowerCase()` para los 6 tipos: `webchat`, `telegram`, `discord`, `slack`, `webhook`, `whatsapp`
- `ChannelRouter extends EventEmitter` — constructor recibe `factory` inyectable (default: `defaultAdapterFactory`)
- `activate(cfg, messageHandler)` — idempotente, llama `initialize()` + `onMessage()`, emite `channel:activated`
- `deactivate(id, reason)` — no-op si inactivo, llama `dispose()`, emite `channel:deactivated`
- `shutdownAll()` — `Promise.allSettled` para graceful shutdown
- `getAdapter()`, `getActiveChannels()`, `isActive()`, `size` para inspección/health

**`apps/gateway/src/__tests__/channel-router.test.ts`** ← Nuevo
- **15 tests** con `vitest` y mock `IChannelAdapter` — sin adapters reales ni Prisma
- Cubre: activate, idempotencia, error channel desconocido, deactivate, dispose llamado, no-op en inactivo, shutdownAll, getAdapter, getActiveChannels, eventos `channel:activated`/`channel:deactivated` con `reason` correcto

**`apps/gateway/src/gateway.service.ts`** ← Modificado (mínimo)
- Importa `ChannelRouter`, instancia `this.channelRouter = new ChannelRouter()` en constructor
- `activateChannel()` → delega a `channelRouter.activate()` pasando `handleIncoming` como handler
- `deactivateChannel()` → delega a `channelRouter.deactivate()`
- `dispatch()` → usa `channelRouter.getAdapter()` en lugar del antiguo `resolveAdapter()`; activa on-demand si el adapter no está en el registry
- `recordReply()` → usa `channelRouter.getAdapter()`; lanza si el canal no está activo
- Nuevo `handleIncoming()` privado — es el handler conectado vía `onMessage()`
- Eliminado el método `resolveAdapter()` con el `registry.has()` inline

**`apps/gateway/src/gateway.module.ts`** ← Modificado
- `ChannelRouter` añadido a `providers` y `exports` para uso futuro en endpoints de health/admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured channel adapter management with a dedicated routing service layer, improving separation of concerns and state management.

* **Tests**
  * Added comprehensive unit tests for channel adapter lifecycle operations, including activation, deactivation, shutdown, and inspection APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->