### PR TITLE
feat(F3a-11): add ChannelType enum and BotStatus to ChannelConfig

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,18 +270,44 @@ model RunStep {
   @@index([agentId, startedAt])
 }
 
+enum ChannelType {
+  telegram
+  whatsapp
+  webchat
+  discord
+  teams
+  slack
+  webhook
+}
+
+/// Estado operacional del adaptador del canal.
+/// Actualizado por ChannelAdapterManager tras cada cambio de estado.
+enum BotStatus {
+  initializing
+  online
+  offline
+  error
+  rate_limited
+  webhook_error
+}
+
 // ─── Gateway / Channels ──────────────────────────────────────────────────────
 
 model ChannelConfig {
   id               String  @id @default(uuid())
-  /// 'telegram' | 'whatsapp' | 'webchat' | 'slack' | 'discord' | 'webhook'
-  type             String
+  type             ChannelType
   name             String
   /// AES-256-GCM encrypted secrets (CHANNEL_SECRET env key)
-  secretsEncrypted String   @db.Text
+  secretsEncrypted String      @db.Text
   /// Non-sensitive config: { webhookPath, parseMode, allowedOrigins, ... }
   config           Json
-  isActive         Boolean  @default(false)
+  isActive         Boolean     @default(false)
+  /// Estado operacional del bot/webhook — actualizado por el adapter manager.
+  botStatus        BotStatus   @default(initializing)
+  /// Detalle del último error o aviso (stack trace, mensaje Telegram API, etc.)
+  statusDetail     String?     @db.Text
+  /// Timestamp del último cambio de botStatus.
+  statusUpdatedAt  DateTime?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 


### PR DESCRIPTION
- add ChannelType and BotStatus enums to Prisma schema
- convert ChannelConfig.type from String to ChannelType
- add botStatus, statusDetail, and statusUpdatedAt fields

Closes #F3a-11

Hice la implementación en GitHub sobre la rama `feat/F3a-11-channel-type-bot-status-enums` y dejé el cambio commiteado y pusheado. 

## Cambio aplicado

Actualicé `prisma/schema.prisma` para añadir los enums `ChannelType` y `BotStatus` antes del bloque de Gateway/Channels, y cambié `ChannelConfig.type` de `String` a `ChannelType`. 

También añadí en `ChannelConfig` los campos `botStatus`, `statusDetail` y `statusUpdatedAt`, manteniendo el resto del modelo intacto como pediste. 

## Alcance real

En este turno solo pude aplicar y empujar el cambio del schema en GitHub; no ejecuté la migración Prisma, no regeneré cliente, ni actualicé aún usos en TypeScript, DTOs, seeds o tests obligatorios. 

Eso significa que el repositorio ya tiene el cambio base del schema, pero todavía no queda cerrada toda la tarea F3a-11 según tu criterio de cierre. 

## Commit

Commit number: `0abd04fc219a7b97287324a26638c6678a0d94fe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced bot operational state tracking with detailed status information and timestamps
  * Improved channel configuration validation for more reliable system behavior
  * Added error and warning detail logging capabilities for better diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->