### PR TITLE
Feat/f3a 12 channel credentials crypto

### DIFF
--- a/apps/api/src/modules/channels/dto/create-channel-config.dto.ts
+++ b/apps/api/src/modules/channels/dto/create-channel-config.dto.ts
@@ -1,0 +1,108 @@
+/**
+ * DTO para POST /channels — crea un nuevo ChannelConfig.
+ *
+ * Flujo en el handler:
+ *   1. Zod valida el body completo (type + credentials + config)
+ *   2. parseCredentials(type, credentials) valida estructura por canal
+ *   3. encryptSecrets(credentials) → secretsEncrypted
+ *   4. prisma.channelConfig.create({ data: { type, name, config, secretsEncrypted, ... } })
+ *   5. La respuesta NUNCA incluye credentials ni secretsEncrypted
+ */
+
+import { z }           from 'zod'
+import { ChannelType } from '@prisma/client'
+import {
+  TelegramCredentialsSchema,
+  WhatsAppCredentialsSchema,
+  DiscordCredentialsSchema,
+  TeamsCredentialsSchema,
+  SlackCredentialsSchema,
+  WebhookCredentialsSchema,
+  WebchatCredentialsSchema,
+} from '@lss/crypto'
+
+// ── Schemas de config (no-sensible) por canal ──────────────────────────
+
+const TelegramConfigSchema = z.object({
+  parseMode:        z.enum(['Markdown', 'HTML', 'MarkdownV2']).default('Markdown'),
+  maxMessageLength: z.number().int().min(1).max(4096).default(4096),
+  webhookPath:      z.string().optional(),
+}).default({})
+
+const WhatsAppConfigSchema = z.object({
+  webhookPath: z.string().optional(),
+  apiVersion:  z.string().default('v18.0'),
+}).default({})
+
+const DiscordConfigSchema = z.object({
+  interactionsPath: z.string().optional(),
+  commandPrefix:    z.string().max(5).default('!'),
+}).default({})
+
+const TeamsConfigSchema = z.object({
+  webhookPath: z.string().optional(),
+}).default({})
+
+const SlackConfigSchema = z.object({
+  eventsPath: z.string().optional(),
+  slashPath:  z.string().optional(),
+}).default({})
+
+const WebhookConfigSchema = z.object({
+  path:   z.string().min(1).default('/webhook'),
+  method: z.enum(['POST', 'GET']).default('POST'),
+}).default({})
+
+const WebchatConfigSchema = z.object({
+  allowedOrigins:   z.array(z.string().url()).default([]),
+  sessionTimeoutMs: z.number().int().positive().default(1_800_000),
+}).default({})
+
+// ── Discriminated union completa ────────────────────────────────────────
+
+export const CreateChannelConfigSchema = z.discriminatedUnion('type', [
+  z.object({
+    type:        z.literal(ChannelType.telegram),
+    name:        z.string().min(1).max(128),
+    credentials: TelegramCredentialsSchema,
+    config:      TelegramConfigSchema,
+  }),
+  z.object({
+    type:        z.literal(ChannelType.whatsapp),
+    name:        z.string().min(1).max(128),
+    credentials: WhatsAppCredentialsSchema,
+    config:      WhatsAppConfigSchema,
+  }),
+  z.object({
+    type:        z.literal(ChannelType.discord),
+    name:        z.string().min(1).max(128),
+    credentials: DiscordCredentialsSchema,
+    config:      DiscordConfigSchema,
+  }),
+  z.object({
+    type:        z.literal(ChannelType.teams),
+    name:        z.string().min(1).max(128),
+    credentials: TeamsCredentialsSchema,
+    config:      TeamsConfigSchema,
+  }),
+  z.object({
+    type:        z.literal(ChannelType.slack),
+    name:        z.string().min(1).max(128),
+    credentials: SlackCredentialsSchema,
+    config:      SlackConfigSchema,
+  }),
+  z.object({
+    type:        z.literal(ChannelType.webhook),
+    name:        z.string().min(1).max(128),
+    credentials: WebhookCredentialsSchema,
+    config:      WebhookConfigSchema,
+  }),
+  z.object({
+    type:        z.literal(ChannelType.webchat),
+    name:        z.string().min(1).max(128),
+    credentials: WebchatCredentialsSchema,
+    config:      WebchatConfigSchema,
+  }),
+])
+
+export type CreateChannelConfigDto = z.infer<typeof CreateChannelConfigSchema>

--- a/apps/api/src/modules/channels/dto/update-channel-config.dto.ts
+++ b/apps/api/src/modules/channels/dto/update-channel-config.dto.ts
@@ -1,0 +1,42 @@
+/**
+ * DTO para PATCH /channels/:id — actualización parcial.
+ *
+ * Regla: si se envía credentials, DEBE ser completo para ese canal.
+ * No se permiten patches parciales de credentials (seguridad: evitar
+ * reemplazar solo el botToken dejando el webhookSecret del canal anterior).
+ *
+ * Si credentials no se envía, secretsEncrypted no se toca.
+ */
+
+import { z }           from 'zod'
+import { ChannelType } from '@prisma/client'
+import {
+  TelegramCredentialsSchema,
+  WhatsAppCredentialsSchema,
+  DiscordCredentialsSchema,
+  TeamsCredentialsSchema,
+  SlackCredentialsSchema,
+  WebhookCredentialsSchema,
+  WebchatCredentialsSchema,
+} from '@lss/crypto'
+
+export const UpdateChannelConfigSchema = z.object({
+  name:     z.string().min(1).max(128).optional(),
+  isActive: z.boolean().optional(),
+  config:   z.record(z.unknown()).optional(),
+  /**
+   * Para actualizar credenciales: enviar el tipo explícito + credentials completas.
+   * Si credentials se envía, type es obligatorio para saber qué schema usar.
+   */
+  credentials: z.union([
+    z.object({ type: z.literal(ChannelType.telegram), data: TelegramCredentialsSchema }),
+    z.object({ type: z.literal(ChannelType.whatsapp), data: WhatsAppCredentialsSchema }),
+    z.object({ type: z.literal(ChannelType.discord),  data: DiscordCredentialsSchema }),
+    z.object({ type: z.literal(ChannelType.teams),    data: TeamsCredentialsSchema }),
+    z.object({ type: z.literal(ChannelType.slack),    data: SlackCredentialsSchema }),
+    z.object({ type: z.literal(ChannelType.webhook),  data: WebhookCredentialsSchema }),
+    z.object({ type: z.literal(ChannelType.webchat),  data: WebchatCredentialsSchema }),
+  ]).optional(),
+})
+
+export type UpdateChannelConfigDto = z.infer<typeof UpdateChannelConfigSchema>

--- a/apps/gateway/src/channel-credentials.loader.ts
+++ b/apps/gateway/src/channel-credentials.loader.ts
@@ -1,0 +1,77 @@
+/**
+ * Descifra las credenciales de un ChannelConfig en runtime.
+ * Usado por los adapters al inicializarse (TelegramAdapter, etc.)
+ *
+ * Incluye caché en memoria para no descifrar en cada mensaje.
+ * El caché se invalida cuando el ChannelConfig es actualizado
+ * (llamar invalidateCredentialsCache(channelConfigId) desde el handler PATCH).
+ */
+
+import type { PrismaClient }                        from '@prisma/client'
+import { ChannelType }                              from '@prisma/client'
+import { decryptSecrets, parseCredentials }         from '@lss/crypto'
+import type { CredentialsByType }                   from '@lss/crypto'
+
+type CacheEntry = { data: Record<string, unknown>; cachedAt: number }
+const CACHE_TTL_MS = 5 * 60 * 1_000  // 5 minutos
+
+const credentialsCache = new Map<string, CacheEntry>()
+
+/**
+ * Carga y descifra las credenciales de un ChannelConfig.
+ * Tipado genérico: el caller pasa el ChannelType esperado y obtiene
+ * el tipo correcto de credenciales.
+ *
+ * @example
+ *   const creds = await loadCredentials(db, configId, ChannelType.telegram)
+ *   creds.botToken  // string — tipado correcto
+ */
+export async function loadCredentials<T extends ChannelType>(
+  db:              PrismaClient,
+  channelConfigId: string,
+  expectedType:    T,
+): Promise<CredentialsByType[T]> {
+  // 1. Revisar caché
+  const cached = credentialsCache.get(channelConfigId)
+  if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+    return parseCredentials(expectedType, cached.data)
+  }
+
+  // 2. Cargar desde DB
+  const config = await db.channelConfig.findUniqueOrThrow({
+    where:  { id: channelConfigId },
+    select: { secretsEncrypted: true, type: true },
+  })
+
+  if (config.type !== expectedType) {
+    throw new Error(
+      `[credentials] Channel ${channelConfigId} has type ${config.type}, ` +
+      `but expected ${expectedType}`
+    )
+  }
+
+  // 3. Descifrar
+  const raw = decryptSecrets(config.secretsEncrypted)
+
+  // 4. Guardar en caché
+  credentialsCache.set(channelConfigId, { data: raw, cachedAt: Date.now() })
+
+  // 5. Validar con Zod (lanza si el ciphertext está corrompido o migrado mal)
+  return parseCredentials(expectedType, raw)
+}
+
+/**
+ * Invalida la entrada de caché para un canal.
+ * Llamar tras actualizar credenciales via PATCH /channels/:id.
+ */
+export function invalidateCredentialsCache(channelConfigId: string): void {
+  credentialsCache.delete(channelConfigId)
+}
+
+/**
+ * Limpia todo el caché.
+ * Usar solo en tests o tras rotación masiva de clave.
+ */
+export function clearCredentialsCache(): void {
+  credentialsCache.clear()
+}

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@lss/crypto",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types":  "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test":  "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.23.8",
+    "@prisma/client": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/crypto/src/__tests__/channel-secrets.test.ts
+++ b/packages/crypto/src/__tests__/channel-secrets.test.ts
@@ -1,0 +1,90 @@
+import { randomBytes } from 'node:crypto'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { encryptSecrets, decryptSecrets, rotateEncryption } from '../channel-secrets.js'
+
+const validKey = () => Buffer.from(randomBytes(32)).toString('base64')
+
+describe('encryptSecrets / decryptSecrets', () => {
+  let testKey: string
+
+  beforeAll(() => {
+    testKey = validKey()
+    process.env.CHANNEL_SECRET = testKey
+  })
+
+  afterAll(() => {
+    delete process.env.CHANNEL_SECRET
+  })
+
+  it('encryptSecrets({}) returns a non-empty base64 string', () => {
+    const result = encryptSecrets({})
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+    // valid base64
+    expect(() => Buffer.from(result, 'base64')).not.toThrow()
+  })
+
+  it('round-trip: decryptSecrets(encryptSecrets(obj)) deep-equals obj', () => {
+    const obj = { botToken: '123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij', webhookSecret: 'abc123xyz' }
+    const encrypted = encryptSecrets(obj)
+    const decrypted = decryptSecrets(encrypted)
+    expect(decrypted).toEqual(obj)
+  })
+
+  it('two calls to encryptSecrets with same obj produce different ciphertexts (random IV)', () => {
+    const obj = { botToken: '123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij' }
+    const a = encryptSecrets(obj)
+    const b = encryptSecrets(obj)
+    expect(a).not.toBe(b)
+  })
+
+  it('decryptSecrets with tampered ciphertext throws with [crypto] Failed to decrypt', () => {
+    const encrypted = encryptSecrets({ key: 'value' })
+    const buf = Buffer.from(encrypted, 'base64')
+    // Flip last byte
+    buf[buf.length - 1] ^= 0x01
+    const tampered = buf.toString('base64')
+    expect(() => decryptSecrets(tampered)).toThrow('[crypto] Failed to decrypt secrets')
+  })
+
+  it('decryptSecrets with too-short base64 string throws "too short"', () => {
+    // 12 IV + 16 tag = 28 bytes minimum with 1 byte payload = 29. Give only 10.
+    const short = Buffer.alloc(10).toString('base64')
+    expect(() => decryptSecrets(short)).toThrow('too short')
+  })
+
+  it('throws when CHANNEL_SECRET is not set', () => {
+    const orig = process.env.CHANNEL_SECRET
+    delete process.env.CHANNEL_SECRET
+    try {
+      expect(() => encryptSecrets({ x: 1 })).toThrow('CHANNEL_SECRET env var is not set')
+    } finally {
+      process.env.CHANNEL_SECRET = orig
+    }
+  })
+
+  it('throws when CHANNEL_SECRET decodes to wrong byte length', () => {
+    const orig = process.env.CHANNEL_SECRET
+    // 31 bytes → base64
+    process.env.CHANNEL_SECRET = Buffer.from(randomBytes(31)).toString('base64')
+    try {
+      expect(() => encryptSecrets({ x: 1 })).toThrow('must decode to exactly 32 bytes')
+    } finally {
+      process.env.CHANNEL_SECRET = orig
+    }
+  })
+
+  it('rotateEncryption: encrypt with key A, rotate to key B, decrypt with key B gives original', () => {
+    const keyA = validKey()
+    const keyB = validKey()
+    const origEnv = process.env.CHANNEL_SECRET
+    process.env.CHANNEL_SECRET = keyA
+    const original = { botToken: '111111111:AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIa' }
+    const encryptedWithA = encryptSecrets(original)
+    const rotated = rotateEncryption(encryptedWithA, keyA, keyB)
+    process.env.CHANNEL_SECRET = keyB
+    const decrypted = decryptSecrets(rotated)
+    expect(decrypted).toEqual(original)
+    process.env.CHANNEL_SECRET = origEnv
+  })
+})

--- a/packages/crypto/src/__tests__/credentials-schema.test.ts
+++ b/packages/crypto/src/__tests__/credentials-schema.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { ChannelType } from '@prisma/client'
+import {
+  TelegramCredentialsSchema,
+  WhatsAppCredentialsSchema,
+  DiscordCredentialsSchema,
+  TeamsCredentialsSchema,
+  SlackCredentialsSchema,
+  CREDENTIALS_SCHEMA_BY_TYPE,
+  parseCredentials,
+  safeParseCredentials,
+} from '../credentials-schema.js'
+import { CreateChannelConfigSchema } from '../../../apps/api/src/modules/channels/dto/create-channel-config.dto.js'
+
+const VALID_TELEGRAM_TOKEN = '123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij'
+
+describe('TelegramCredentialsSchema', () => {
+  it('parses valid bot token', () => {
+    expect(() =>
+      TelegramCredentialsSchema.parse({ botToken: VALID_TELEGRAM_TOKEN })
+    ).not.toThrow()
+  })
+
+  it('rejects short token', () => {
+    expect(() =>
+      TelegramCredentialsSchema.parse({ botToken: 'short' })
+    ).toThrow()
+  })
+
+  it('rejects token without colon separator (regex)', () => {
+    expect(() =>
+      TelegramCredentialsSchema.parse({ botToken: 'nodots_and_no_colon_____________________' })
+    ).toThrow()
+  })
+})
+
+describe('WhatsAppCredentialsSchema', () => {
+  const base = {
+    accessToken:        'longaccesstoken_here_12345',
+    phoneNumberId:      '12345678901',
+    wabaId:             '98765432109',
+    webhookVerifyToken: 'verify_me_please',
+  }
+
+  it('parses valid full payload', () => {
+    expect(() => WhatsAppCredentialsSchema.parse(base)).not.toThrow()
+  })
+
+  it('rejects missing accessToken', () => {
+    const { accessToken: _, ...rest } = base
+    expect(() => WhatsAppCredentialsSchema.parse(rest)).toThrow()
+  })
+
+  it('rejects missing webhookVerifyToken', () => {
+    const { webhookVerifyToken: _, ...rest } = base
+    expect(() => WhatsAppCredentialsSchema.parse(rest)).toThrow()
+  })
+})
+
+describe('DiscordCredentialsSchema', () => {
+  it('rejects publicKey with length != 64', () => {
+    expect(() =>
+      DiscordCredentialsSchema.parse({
+        botToken:      'x'.repeat(50),
+        publicKey:     'x'.repeat(63),
+        applicationId: '1234567890',
+      })
+    ).toThrow()
+  })
+
+  it('accepts publicKey with exactly 64 chars', () => {
+    expect(() =>
+      DiscordCredentialsSchema.parse({
+        botToken:      'x'.repeat(50),
+        publicKey:     'a'.repeat(64),
+        applicationId: '1234567890',
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('TeamsCredentialsSchema', () => {
+  it('rejects non-uuid appId', () => {
+    expect(() =>
+      TeamsCredentialsSchema.parse({
+        appId:       'not-a-uuid',
+        appPassword: 'secret1234',
+      })
+    ).toThrow()
+  })
+
+  it('accepts valid uuid appId', () => {
+    expect(() =>
+      TeamsCredentialsSchema.parse({
+        appId:       '550e8400-e29b-41d4-a716-446655440000',
+        appPassword: 'secret1234',
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('SlackCredentialsSchema', () => {
+  const validSigning = 'x'.repeat(20)
+
+  it('accepts valid xoxb- token', () => {
+    expect(() =>
+      SlackCredentialsSchema.parse({ botToken: 'xoxb-abc123', signingSecret: validSigning })
+    ).not.toThrow()
+  })
+
+  it('rejects token not starting with xoxb-', () => {
+    expect(() =>
+      SlackCredentialsSchema.parse({ botToken: 'xoxa-abc123', signingSecret: validSigning })
+    ).toThrow()
+  })
+})
+
+describe('parseCredentials / safeParseCredentials', () => {
+  it('parseCredentials(telegram, valid) returns typed object', () => {
+    const result = parseCredentials(ChannelType.telegram, { botToken: VALID_TELEGRAM_TOKEN })
+    expect(result.botToken).toBe(VALID_TELEGRAM_TOKEN)
+  })
+
+  it('parseCredentials(telegram, invalid) throws ZodError', () => {
+    expect(() => parseCredentials(ChannelType.telegram, { botToken: 'bad' })).toThrow()
+  })
+
+  it('safeParseCredentials(whatsapp, invalid) returns success=false', () => {
+    const result = safeParseCredentials(ChannelType.whatsapp, { bad: 'data' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('CREDENTIALS_SCHEMA_BY_TYPE', () => {
+  it('has exactly 7 entries (one per ChannelType value)', () => {
+    const channelTypeValues = Object.values(ChannelType)
+    const schemaKeys = Object.keys(CREDENTIALS_SCHEMA_BY_TYPE)
+    expect(schemaKeys.length).toBe(7)
+    expect(schemaKeys.sort()).toEqual(channelTypeValues.sort())
+  })
+})
+
+describe('CreateChannelConfigSchema discriminated union', () => {
+  it('rejects telegram type paired with WhatsApp credentials', () => {
+    const result = CreateChannelConfigSchema.safeParse({
+      type:        ChannelType.telegram,
+      name:        'Test',
+      credentials: {
+        accessToken:        'longaccesstoken_here_12345',
+        phoneNumberId:      '12345678901',
+        wabaId:             '98765432109',
+        webhookVerifyToken: 'verify_me_please',
+      },
+      config: {},
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/crypto/src/channel-secrets.ts
+++ b/packages/crypto/src/channel-secrets.ts
@@ -1,0 +1,125 @@
+/**
+ * AES-256-GCM encrypt/decrypt para credenciales de ChannelConfig.
+ *
+ * Formato del ciphertext (base64-encoded):
+ *   [ IV (12 bytes) | CIPHERTEXT (variable) | AUTH_TAG (16 bytes) ]
+ *
+ * La clave maestra viene de process.env.CHANNEL_SECRET.
+ * Debe ser exactamente 32 bytes (256 bits) en base64 o hex.
+ *
+ * Generar una nueva clave:
+ *   node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+
+const ALGORITHM  = 'aes-256-gcm' as const
+const IV_LENGTH  = 12   // bytes — NIST recomendación para GCM
+const TAG_LENGTH = 16   // bytes — máximo en GCM
+
+// ── Clave maestra ───────────────────────────────────────────────────────
+
+function getMasterKey(): Buffer {
+  const raw = process.env.CHANNEL_SECRET
+  if (!raw) {
+    throw new Error(
+      '[crypto] CHANNEL_SECRET env var is not set. ' +
+      "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('base64'))\""
+    )
+  }
+
+  // Aceptar base64 (44 chars) o hex (64 chars)
+  let buf: Buffer
+  if (raw.length === 64 && /^[0-9a-fA-F]+$/.test(raw)) {
+    buf = Buffer.from(raw, 'hex')
+  } else {
+    buf = Buffer.from(raw, 'base64')
+  }
+
+  if (buf.length !== 32) {
+    throw new Error(
+      `[crypto] CHANNEL_SECRET must decode to exactly 32 bytes. ` +
+      `Got ${buf.length} bytes. ` +
+      `Regenerate: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"`
+    )
+  }
+  return buf
+}
+
+// ── API pública ─────────────────────────────────────────────────────────
+
+/**
+ * Cifra un objeto JSON de credenciales.
+ * @param credentials - El objeto POJO de credenciales (ya validado con Zod)
+ * @returns string base64 apto para almacenar en ChannelConfig.secretsEncrypted
+ */
+export function encryptSecrets(credentials: Record<string, unknown>): string {
+  const key       = getMasterKey()
+  const iv        = randomBytes(IV_LENGTH)
+  const cipher    = createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH })
+  const plaintext = Buffer.from(JSON.stringify(credentials), 'utf8')
+
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()])
+  const authTag   = cipher.getAuthTag()
+
+  // Concatenar: iv || ciphertext || authTag → base64
+  return Buffer.concat([iv, encrypted, authTag]).toString('base64')
+}
+
+/**
+ * Descifra el campo secretsEncrypted de ChannelConfig.
+ * @returns El objeto de credenciales original (sin tipar — usar parseCredentials() post-decrypt)
+ * @throws Error si el ciphertext está corrupto, el tag no coincide, o la clave es incorrecta
+ */
+export function decryptSecrets(secretsEncrypted: string): Record<string, unknown> {
+  const key  = getMasterKey()
+  const buf  = Buffer.from(secretsEncrypted, 'base64')
+
+  if (buf.length < IV_LENGTH + TAG_LENGTH + 1) {
+    throw new Error('[crypto] Invalid ciphertext: too short')
+  }
+
+  const iv         = buf.subarray(0, IV_LENGTH)
+  const authTag    = buf.subarray(buf.length - TAG_LENGTH)
+  const ciphertext = buf.subarray(IV_LENGTH, buf.length - TAG_LENGTH)
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH })
+  decipher.setAuthTag(authTag)
+
+  try {
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    return JSON.parse(decrypted.toString('utf8')) as Record<string, unknown>
+  } catch (err) {
+    throw new Error(
+      '[crypto] Failed to decrypt secrets. ' +
+      'Possible causes: wrong CHANNEL_SECRET, corrupted data, or tampered ciphertext. ' +
+      `Original: ${(err as Error).message}`
+    )
+  }
+}
+
+/**
+ * Rota las credenciales: descifra con la clave actual y recifra.
+ * Usado para rotación de clave: primero cambiar CHANNEL_SECRET_OLD → NEW,
+ * luego llamar este método para reencriptar todos los registros.
+ */
+export function rotateEncryption(
+  secretsEncrypted: string,
+  oldKey:           string,
+  newKey:           string,
+): string {
+  const origEnv = process.env.CHANNEL_SECRET
+  process.env.CHANNEL_SECRET = oldKey
+  let plainObj: Record<string, unknown>
+  try {
+    plainObj = decryptSecrets(secretsEncrypted)
+  } finally {
+    process.env.CHANNEL_SECRET = origEnv
+  }
+  process.env.CHANNEL_SECRET = newKey
+  try {
+    return encryptSecrets(plainObj)
+  } finally {
+    process.env.CHANNEL_SECRET = origEnv
+  }
+}

--- a/packages/crypto/src/credentials-schema.ts
+++ b/packages/crypto/src/credentials-schema.ts
@@ -1,0 +1,138 @@
+/**
+ * Schemas Zod para las credenciales por canal.
+ *
+ * Separación de conceptos:
+ *   credentials (secretsEncrypted) → tokens, secrets, API keys
+ *   config (Json, plaintext)       → parseMode, allowedOrigins, maxMessageLength, etc.
+ *
+ * NUNCA mezclar — si un campo es un secreto, va en credentials.
+ * Si es configuración pública/no sensible, va en config.
+ */
+
+import { z } from 'zod'
+import { ChannelType } from '@prisma/client'
+
+// ── Schemas de credenciales por canal ──────────────────────────────────
+
+/** Telegram Bot API */
+export const TelegramCredentialsSchema = z.object({
+  botToken:      z.string().min(20, 'Bot token too short').regex(
+    /^\d+:[A-Za-z0-9_-]{35,}$/,
+    'Invalid Telegram bot token format (expected: <id>:<token>)'
+  ),
+  webhookSecret: z.string().min(8).max(256).optional(),
+})
+export type TelegramCredentials = z.infer<typeof TelegramCredentialsSchema>
+
+/** WhatsApp Cloud API (Meta) */
+export const WhatsAppCredentialsSchema = z.object({
+  /** Token de acceso de larga duración (permanent token) */
+  accessToken:        z.string().min(10),
+  /** Phone Number ID de la cuenta de negocio */
+  phoneNumberId:      z.string().min(5),
+  /** WhatsApp Business Account ID */
+  wabaId:             z.string().min(5),
+  /** Verify token para la verificación del webhook */
+  webhookVerifyToken: z.string().min(8).max(128),
+  /** App Secret para verificar firma HMAC-SHA256 */
+  appSecret:          z.string().min(10).optional(),
+})
+export type WhatsAppCredentials = z.infer<typeof WhatsAppCredentialsSchema>
+
+/** Discord Bot */
+export const DiscordCredentialsSchema = z.object({
+  botToken:      z.string().min(50, 'Discord bot token too short'),
+  /** Public key para verificar interacciones (slash commands) */
+  publicKey:     z.string().length(64, 'Public key must be 64 hex chars'),
+  applicationId: z.string().min(10),
+  /** Guild ID — opcional si el bot opera en múltiples guilds */
+  guildId:       z.string().min(10).optional(),
+  /** Client Secret — requerido para OAuth2 flows */
+  clientSecret:  z.string().min(20).optional(),
+})
+export type DiscordCredentials = z.infer<typeof DiscordCredentialsSchema>
+
+/** Microsoft Teams (Azure Bot Service) */
+export const TeamsCredentialsSchema = z.object({
+  /** Microsoft App ID (guid) */
+  appId:       z.string().uuid('appId must be a valid UUID'),
+  /** Microsoft App Password */
+  appPassword: z.string().min(8),
+  /** Tenant ID — 'common' para multi-tenant, guid para single */
+  tenantId:    z.string().min(4).default('common'),
+  /** Service URL base (ej: https://smba.trafficmanager.net/apis/) */
+  serviceUrl:  z.string().url().optional(),
+})
+export type TeamsCredentials = z.infer<typeof TeamsCredentialsSchema>
+
+/** Slack */
+export const SlackCredentialsSchema = z.object({
+  botToken:      z.string().regex(/^xoxb-/, 'Must start with xoxb-'),
+  signingSecret: z.string().min(20),
+  appToken:      z.string().regex(/^xapp-/).optional(),
+  /** Para Slack OAuth: Client ID/Secret */
+  clientId:      z.string().optional(),
+  clientSecret:  z.string().optional(),
+})
+export type SlackCredentials = z.infer<typeof SlackCredentialsSchema>
+
+/**
+ * Webhook genérico — acepta secret para validación HMAC opcional
+ */
+export const WebhookCredentialsSchema = z.object({
+  /** Secret para verificar HMAC-SHA256 del payload entrante */
+  signingSecret: z.string().min(8).optional(),
+  /** Bearer token para autenticar requests salientes */
+  outboundToken: z.string().min(8).optional(),
+})
+export type WebhookCredentials = z.infer<typeof WebhookCredentialsSchema>
+
+/** Webchat — sin credenciales sensibles obligatorias */
+export const WebchatCredentialsSchema = z.object({
+  /** JWT secret para autenticar sesiones de webchat */
+  jwtSecret:   z.string().min(16).optional(),
+  /** API key para integrar en sitios externos */
+  embedApiKey: z.string().min(16).optional(),
+})
+export type WebchatCredentials = z.infer<typeof WebchatCredentialsSchema>
+
+// ── Discriminated union — mapeo ChannelType → schema ───────────────────
+
+export const CREDENTIALS_SCHEMA_BY_TYPE = {
+  [ChannelType.telegram]: TelegramCredentialsSchema,
+  [ChannelType.whatsapp]: WhatsAppCredentialsSchema,
+  [ChannelType.discord]:  DiscordCredentialsSchema,
+  [ChannelType.teams]:    TeamsCredentialsSchema,
+  [ChannelType.slack]:    SlackCredentialsSchema,
+  [ChannelType.webhook]:  WebhookCredentialsSchema,
+  [ChannelType.webchat]:  WebchatCredentialsSchema,
+} as const satisfies Record<ChannelType, z.ZodObject<z.ZodRawShape>>
+
+export type CredentialsByType = {
+  [K in ChannelType]: z.infer<typeof CREDENTIALS_SCHEMA_BY_TYPE[K]>
+}
+
+/**
+ * Valida un objeto de credenciales según el ChannelType.
+ * Lanza ZodError si la validación falla.
+ */
+export function parseCredentials<T extends ChannelType>(
+  type:  T,
+  input: unknown,
+): CredentialsByType[T] {
+  return CREDENTIALS_SCHEMA_BY_TYPE[type].parse(input) as CredentialsByType[T]
+}
+
+/**
+ * Valida sin lanzar excepciones.
+ * Retorna { success, data, error }.
+ */
+export function safeParseCredentials<T extends ChannelType>(
+  type:  T,
+  input: unknown,
+): z.SafeParseReturnType<CredentialsByType[T], CredentialsByType[T]> {
+  return CREDENTIALS_SCHEMA_BY_TYPE[type].safeParse(input) as z.SafeParseReturnType<
+    CredentialsByType[T],
+    CredentialsByType[T]
+  >
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,0 +1,29 @@
+export {
+  encryptSecrets,
+  decryptSecrets,
+  rotateEncryption,
+} from './channel-secrets.js'
+
+export {
+  parseCredentials,
+  safeParseCredentials,
+  CREDENTIALS_SCHEMA_BY_TYPE,
+  TelegramCredentialsSchema,
+  WhatsAppCredentialsSchema,
+  DiscordCredentialsSchema,
+  TeamsCredentialsSchema,
+  SlackCredentialsSchema,
+  WebhookCredentialsSchema,
+  WebchatCredentialsSchema,
+} from './credentials-schema.js'
+
+export type {
+  TelegramCredentials,
+  WhatsAppCredentials,
+  DiscordCredentials,
+  TeamsCredentials,
+  SlackCredentials,
+  WebhookCredentials,
+  WebchatCredentials,
+  CredentialsByType,
+} from './credentials-schema.js'

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -270,18 +270,44 @@ model RunStep {
   @@index([agentId, startedAt])
 }
 
+enum ChannelType {
+  telegram
+  whatsapp
+  webchat
+  discord
+  teams
+  slack
+  webhook
+}
+
+/// Estado operacional del adaptador del canal.
+/// Actualizado por ChannelAdapterManager tras cada cambio de estado.
+enum BotStatus {
+  initializing
+  online
+  offline
+  error
+  rate_limited
+  webhook_error
+}
+
 // ─── Gateway / Channels ──────────────────────────────────────────────────────
 
 model ChannelConfig {
   id               String  @id @default(uuid())
-  /// 'telegram' | 'whatsapp' | 'webchat' | 'slack' | 'discord' | 'webhook'
-  type             String
+  type             ChannelType
   name             String
   /// AES-256-GCM encrypted secrets (CHANNEL_SECRET env key)
-  secretsEncrypted String   @db.Text
+  secretsEncrypted String      @db.Text
   /// Non-sensitive config: { webhookPath, parseMode, allowedOrigins, ... }
   config           Json
-  isActive         Boolean  @default(false)
+  isActive         Boolean     @default(false)
+  /// Estado operacional del bot/webhook — actualizado por el adapter manager.
+  botStatus        BotStatus   @default(initializing)
+  /// Detalle del último error o aviso (stack trace, mensaje Telegram API, etc.)
+  statusDetail     String?     @db.Text
+  /// Timestamp del último cambio de botStatus.
+  statusUpdatedAt  DateTime?
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Implementación completa en GitHub. Aquí el resumen de todo lo entregado:</p><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="f3a-12--lsscrypto-package-implementado">F3a-12 — <code>@lss/crypto</code> package implementado</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Commit SHA: <strong><code>9d9fabf7eb3e2f9897b26d2a878ed646f49b8413</code></strong></p><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Rama: <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-12-channel-credentials-crypto"><span class="text-box-trim-both"><code>feat/F3a-12-channel-credentials-crypto</code></span></a> — basada en <code>feat/F3a-11</code> (ChannelType enum ya incluido).</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-creados">Archivos creados</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong><code>packages/crypto/</code> — Package nuevo <code>@lss/crypto</code></strong></p><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised">
Archivo | Contenido
-- | --
package.json | Package @lss/crypto, type module, deps: zod + @prisma/client
tsconfig.json | ES2022, NodeNext module resolution, strict
src/channel-secrets.ts | encryptSecrets(), decryptSecrets(), rotateEncryption() — AES-256-GCM con IV aleatorio de 12 bytes, CHANNEL_SECRET desde env
src/credentials-schema.ts | Zod schemas por los 7 ChannelTypes: Telegram, WhatsApp, Discord, Teams, Slack, Webhook, Webchat + parseCredentials(), safeParseCredentials(), CREDENTIALS_SCHEMA_BY_TYPE
src/index.ts | Barrel — exports nombrados, sin default export
src/__tests__/channel-secrets.test.ts | 8 tests: round-trip, IV no-determinista, tamper detection, string corto, env ausente, clave incorrecta, rotateEncryption
src/__tests__/credentials-schema.test.ts | 13+ tests: Telegram/WhatsApp/Discord/Teams/Slack validations, parseCredentials, safeParseCredentials, CREDENTIALS_SCHEMA_BY_TYPE con 7 entradas, discriminated union

</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong><code>apps/api/src/modules/channels/dto/</code></strong></p><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>create-channel-config.dto.ts</code> — <code>CreateChannelConfigSchema</code> discriminated union por ChannelType, con schemas de config no-sensibles por canal</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>update-channel-config.dto.ts</code> — <code>UpdateChannelConfigSchema</code> con credentials opcional y completo (no patch parcial)</p></li></ul><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong><code>apps/gateway/src/channel-credentials.loader.ts</code></strong> — <code>loadCredentials&lt;T&gt;()</code> con caché TTL 5 min, <code>invalidateCredentialsCache()</code>, <code>clearCredentialsCache()</code></p></div></body></html><!--EndFragment-->
</body>
</html>Implementación completa en GitHub. Aquí el resumen de todo lo entregado:

## F3a-12 — `@lss/crypto` package implementado

Commit SHA: **`9d9fabf7eb3e2f9897b26d2a878ed646f49b8413`** 

Rama: [`[feat/F3a-12-channel-credentials-crypto](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-12-channel-credentials-crypto)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-12-channel-credentials-crypto) — basada en `feat/F3a-11` (ChannelType enum ya incluido). 

***

### Archivos creados

**`packages/crypto/` — Package nuevo `@lss/crypto`** 

| Archivo | Contenido |
|---|---|
| `package.json` | Package `@lss/crypto`, type module, deps: zod + @prisma/client |
| `tsconfig.json` | ES2022, NodeNext module resolution, strict |
| `src/channel-secrets.ts` | `encryptSecrets()`, `decryptSecrets()`, `rotateEncryption()` — AES-256-GCM con IV aleatorio de 12 bytes, CHANNEL_SECRET desde env |
| `src/credentials-schema.ts` | Zod schemas por los 7 ChannelTypes: Telegram, WhatsApp, Discord, Teams, Slack, Webhook, Webchat + `parseCredentials()`, `safeParseCredentials()`, `CREDENTIALS_SCHEMA_BY_TYPE` |
| `src/index.ts` | Barrel — exports nombrados, sin default export |
| `src/__tests__/channel-secrets.test.ts` | 8 tests: round-trip, IV no-determinista, tamper detection, string corto, env ausente, clave incorrecta, rotateEncryption |
| `src/__tests__/credentials-schema.test.ts` | 13+ tests: Telegram/WhatsApp/Discord/Teams/Slack validations, parseCredentials, safeParseCredentials, CREDENTIALS_SCHEMA_BY_TYPE con 7 entradas, discriminated union |

**`apps/api/src/modules/channels/dto/`**
- `create-channel-config.dto.ts` — `CreateChannelConfigSchema` discriminated union por ChannelType, con schemas de config no-sensibles por canal 
- `update-channel-config.dto.ts` — `UpdateChannelConfigSchema` con credentials opcional y completo (no patch parcial) 

**`apps/gateway/src/channel-credentials.loader.ts`** — `loadCredentials<T>()` con caché TTL 5 min, `invalidateCredentialsCache()`, `clearCredentialsCache()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added channel status tracking to monitor initialization and runtime state across all supported platforms.
  * Enhanced channel creation and updates with comprehensive configuration validation and type safety.
  * Implemented secure encrypted credential storage for all channel authentication data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->