### PR TITLE
feat(F3a-13): add AgentResolverService with scope priority resolution

### DIFF
--- a/apps/gateway/src/__tests__/agent-resolver.service.test.ts
+++ b/apps/gateway/src/__tests__/agent-resolver.service.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AgentResolverService, type BindingRow } from '../agent-resolver.service.js'
+import {
+  ChannelBindingNotFoundError,
+  ChannelConfigInactiveError,
+  AmbiguousBindingError,
+} from '../agent-resolver.errors.js'
+
+const CHANNEL_ID = 'cc-001'
+const USER_ID    = 'user-ext-001'
+
+function makeBinding(
+  agentId:    string,
+  scopeLevel: string,
+  isDefault = false,
+  id        = `binding-${agentId}`,
+  scopeId   = `scope-${scopeLevel}`,
+): BindingRow {
+  return { id, agentId, scopeLevel, scopeId, isDefault }
+}
+
+function makeDb(bindings: BindingRow[], isActive = true) {
+  return {
+    channelConfig: {
+      findUniqueOrThrow: vi.fn().mockResolvedValue({ isActive }),
+    },
+    channelBinding: {
+      findMany: vi.fn().mockResolvedValue(bindings),
+    },
+    gatewaySession: {
+      findFirst: vi.fn().mockResolvedValue(null),
+    },
+  } as unknown as any
+}
+
+function makeSvc(db: any) {
+  return new AgentResolverService(db)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('resolve() — casos base', () => {
+  it('0 bindings → throws ChannelBindingNotFoundError', async () => {
+    const svc = makeSvc(makeDb([]))
+    await expect(svc.resolve(CHANNEL_ID, USER_ID)).rejects.toBeInstanceOf(ChannelBindingNotFoundError)
+  })
+
+  it('1 binding → retorna ese agentId', async () => {
+    const svc = makeSvc(makeDb([makeBinding('agent-A', 'agency')]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(res.agentId).toBe('agent-A')
+  })
+
+  it('[agency, agent] → retorna scope=agent (prioridad 4)', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-A', 'agency'),
+      makeBinding('agent-B', 'agent'),
+    ]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(res.agentId).toBe('agent-B')
+    expect(res.scopeLevel).toBe('agent')
+  })
+
+  it('[department, workspace] → retorna scope=workspace (prioridad 3)', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-A', 'department'),
+      makeBinding('agent-B', 'workspace'),
+    ]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(res.agentId).toBe('agent-B')
+    expect(res.scopeLevel).toBe('workspace')
+  })
+
+  it('3 bindings, uno isDefault → retorna el isDefault aunque su scope sea menor', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-A', 'agent', false),
+      makeBinding('agent-B', 'agency', true),   // isDefault, scope menor
+      makeBinding('agent-C', 'workspace', false),
+    ]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(res.agentId).toBe('agent-B')
+    expect(res.isDefault).toBe(true)
+  })
+
+  it('2 bindings mismo scopeLevel sin isDefault → AmbiguousBindingError', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-A', 'agent'),
+      makeBinding('agent-B', 'agent'),
+    ]))
+    const err = await svc.resolve(CHANNEL_ID, USER_ID).catch((e) => e)
+    expect(err).toBeInstanceOf(AmbiguousBindingError)
+    expect((err as AmbiguousBindingError).candidates).toContain('agent-A')
+    expect((err as AmbiguousBindingError).candidates).toContain('agent-B')
+  })
+
+  it('canal inactivo → throws ChannelConfigInactiveError', async () => {
+    const svc = makeSvc(makeDb([], false))
+    await expect(svc.resolve(CHANNEL_ID, USER_ID)).rejects.toBeInstanceOf(ChannelConfigInactiveError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('resolve() — sticky session', () => {
+  it('existingAgentId presente + binding encontrado → retorna existingAgentId', async () => {
+    const binding = makeBinding('agent-A', 'agent')
+    const svc = makeSvc(makeDb([binding]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID, 'agent-A')
+    expect(res.agentId).toBe('agent-A')
+  })
+
+  it('existingAgentId presente + binding eliminado → re-resuelve con bindings activos', async () => {
+    // Solo existe binding para agent-B, agent-A fue eliminado
+    const svc = makeSvc(makeDb([makeBinding('agent-B', 'agent')]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID, 'agent-A')
+    expect(res.agentId).toBe('agent-B')
+  })
+
+  it('existingAgentId=null → resuelve por prioridad normal', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-A', 'agency'),
+      makeBinding('agent-B', 'agent'),
+    ]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID, null)
+    expect(res.agentId).toBe('agent-B')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('resolve() — caché', () => {
+  it('dos llamadas al mismo channelConfigId → findMany llamado solo 1 vez', async () => {
+    const db = makeDb([makeBinding('agent-A', 'agent')])
+    const svc = makeSvc(db)
+    await svc.resolve(CHANNEL_ID, USER_ID)
+    await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(1)
+  })
+
+  it('invalidateCache → siguiente llamada recarga desde DB', async () => {
+    const db = makeDb([makeBinding('agent-A', 'agent')])
+    const svc = makeSvc(db)
+    await svc.resolve(CHANNEL_ID, USER_ID)
+    svc.invalidateCache(CHANNEL_ID)
+    await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(2)
+  })
+
+  it('caché expirado (cachedAt > CACHE_TTL_MS) → recarga desde DB', async () => {
+    const db = makeDb([makeBinding('agent-A', 'agent')])
+    const svc = makeSvc(db)
+    // Primera llamada
+    await svc.resolve(CHANNEL_ID, USER_ID)
+    // Manipular el timestamp del caché para simular expiración
+    const cache = (svc as any).bindingsCache as Map<string, any>
+    const entry = cache.get(CHANNEL_ID)!
+    entry.cachedAt = Date.now() - (6 * 60 * 1_000) // 6 min atrás
+    // Segunda llamada con caché expirado
+    await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(db.channelBinding.findMany).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('resolve() — multi-canal / multi-binding', () => {
+  it('dos canales distintos → resuelve agentes diferentes sin interferencia de caché', async () => {
+    const db1 = makeDb([makeBinding('agent-telegram', 'agent')])
+    const db2 = makeDb([makeBinding('agent-webchat', 'agent')])
+    // Dos instancias distintas para simular canales distintos
+    const svc1 = makeSvc(db1)
+    const svc2 = makeSvc(db2)
+    const res1 = await svc1.resolve('cc-telegram', USER_ID)
+    const res2 = await svc2.resolve('cc-webchat', USER_ID)
+    expect(res1.agentId).toBe('agent-telegram')
+    expect(res2.agentId).toBe('agent-webchat')
+  })
+
+  it('scope completo [agency, department, workspace, agent] → retorna agent', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-agency',     'agency'),
+      makeBinding('agent-department', 'department'),
+      makeBinding('agent-workspace',  'workspace'),
+      makeBinding('agent-agent',      'agent'),
+    ]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(res.agentId).toBe('agent-agent')
+    expect(res.scopeLevel).toBe('agent')
+  })
+
+  it('scope completo, agency tiene isDefault=true, agent tiene isDefault=false → retorna agency (isDefault > scope)', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-agency',    'agency', true),   // isDefault
+      makeBinding('agent-workspace', 'workspace', false),
+      makeBinding('agent-agent',     'agent', false),
+    ]))
+    const res = await svc.resolve(CHANNEL_ID, USER_ID)
+    expect(res.agentId).toBe('agent-agency')
+    expect(res.isDefault).toBe(true)
+  })
+})

--- a/apps/gateway/src/__tests__/agent-resolver.service.test.ts
+++ b/apps/gateway/src/__tests__/agent-resolver.service.test.ts
@@ -81,6 +81,17 @@ describe('resolve() — casos base', () => {
     expect(res.isDefault).toBe(true)
   })
 
+  it('2 bindings isDefault=true → AmbiguousBindingError', async () => {
+    const svc = makeSvc(makeDb([
+      makeBinding('agent-A', 'agent', true),
+      makeBinding('agent-B', 'agency', true),
+    ]))
+    const err = await svc.resolve(CHANNEL_ID, USER_ID).catch((e) => e)
+    expect(err).toBeInstanceOf(AmbiguousBindingError)
+    expect((err as AmbiguousBindingError).candidates).toContain('agent-A')
+    expect((err as AmbiguousBindingError).candidates).toContain('agent-B')
+  })
+
   it('2 bindings mismo scopeLevel sin isDefault → AmbiguousBindingError', async () => {
     const svc = makeSvc(makeDb([
       makeBinding('agent-A', 'agent'),

--- a/apps/gateway/src/agent-resolver.errors.ts
+++ b/apps/gateway/src/agent-resolver.errors.ts
@@ -1,0 +1,35 @@
+export class ChannelBindingNotFoundError extends Error {
+  constructor(channelConfigId: string) {
+    super(
+      `[AgentResolver] No active ChannelBinding found for ` +
+      `channelConfigId="${channelConfigId}". ` +
+      `Create at least one ChannelBinding via POST /channels/:id/bindings.`
+    )
+    this.name = 'ChannelBindingNotFoundError'
+  }
+}
+
+export class ChannelConfigInactiveError extends Error {
+  constructor(channelConfigId: string) {
+    super(
+      `[AgentResolver] ChannelConfig "${channelConfigId}" is not active (isActive=false). ` +
+      `Activate it first via PATCH /channels/:id.`
+    )
+    this.name = 'ChannelConfigInactiveError'
+  }
+}
+
+export class AmbiguousBindingError extends Error {
+  readonly candidates: string[]
+  constructor(channelConfigId: string, agentIds: string[]) {
+    super(
+      `[AgentResolver] Multiple ChannelBindings found for ` +
+      `channelConfigId="${channelConfigId}" with the same scope priority ` +
+      `and none marked isDefault=true. ` +
+      `Candidates: ${agentIds.join(', ')}. ` +
+      `Set isDefault=true on one binding to resolve.`
+    )
+    this.name = 'AmbiguousBindingError'
+    this.candidates = agentIds
+  }
+}

--- a/apps/gateway/src/agent-resolver.service.ts
+++ b/apps/gateway/src/agent-resolver.service.ts
@@ -101,7 +101,15 @@ export class AgentResolverService {
     }
 
     // ── 4. Binding marcado isDefault → usar ese ──────────────────────
-    const defaultBinding = bindings.find((b) => b.isDefault)
+    const defaultBindings = bindings.filter((b) => b.isDefault)
+    if (defaultBindings.length > 1) {
+      throw new AmbiguousBindingError(
+        channelConfigId,
+        defaultBindings.map((b) => b.agentId),
+      )
+    }
+
+    const defaultBinding = defaultBindings[0]
     if (defaultBinding) {
       return {
         agentId:    defaultBinding.agentId,

--- a/apps/gateway/src/agent-resolver.service.ts
+++ b/apps/gateway/src/agent-resolver.service.ts
@@ -1,0 +1,205 @@
+import { Injectable }    from '@nestjs/common'
+import { PrismaService } from './prisma/prisma.service.js'
+import {
+  ChannelBindingNotFoundError,
+  ChannelConfigInactiveError,
+  AmbiguousBindingError,
+} from './agent-resolver.errors.js'
+
+// ── Constantes ───────────────────────────────────────────────────────────────
+
+/**
+ * Orden numérico de prioridad: mayor número = mayor especificidad = se prefiere.
+ * Un binding de scope 'agent' (4) tiene prioridad sobre 'agency' (1).
+ */
+const SCOPE_PRIORITY: Record<string, number> = {
+  agency:     1,
+  department: 2,
+  workspace:  3,
+  agent:      4,
+} as const
+
+// ── TTL del caché de bindings (5 minutos) ──────────────────────────────
+
+const CACHE_TTL_MS = 5 * 60 * 1_000
+
+// ── Tipos internos ────────────────────────────────────────────────────────────
+
+export interface ResolvedAgent {
+  agentId:    string
+  scopeLevel: string
+  scopeId:    string
+  bindingId:  string
+  isDefault:  boolean
+}
+
+export interface BindingRow {
+  id:         string
+  agentId:    string
+  scopeLevel: string
+  scopeId:    string
+  isDefault:  boolean
+}
+
+interface CacheEntry {
+  bindings:  BindingRow[]
+  cachedAt:  number
+}
+
+// ── Servicio ───────────────────────────────────────────────────────────────
+
+@Injectable()
+export class AgentResolverService {
+  private readonly bindingsCache = new Map<string, CacheEntry>()
+
+  constructor(private readonly db: PrismaService) {}
+
+  /**
+   * Resuelve el agentId que debe manejar un mensaje entrante.
+   *
+   * Prioridad de resolución:
+   *   1. Si la sesión ya existe y tiene agentId asignado →
+   *      conservar ese agentId (sticky session).
+   *   2. Si hay exactamente 1 binding → usar ese.
+   *   3. Si hay un binding con isDefault=true → usar ese.
+   *   4. Ordenar por SCOPE_PRIORITY (agent > workspace > department > agency)
+   *      y usar el de mayor prioridad.
+   *   5. Si hay empate en prioridad y ninguno es isDefault → AmbiguousBindingError.
+   *   6. Si no hay bindings → ChannelBindingNotFoundError.
+   */
+  async resolve(
+    channelConfigId: string,
+    externalUserId:  string,
+    existingAgentId: string | null = null,
+  ): Promise<ResolvedAgent> {
+    // ── 1. Sticky session: conservar agente de sesión activa ─────────────
+    if (existingAgentId) {
+      const binding = await this.findBindingForAgent(channelConfigId, existingAgentId)
+      if (binding) {
+        return {
+          agentId:    existingAgentId,
+          scopeLevel: binding.scopeLevel,
+          scopeId:    binding.scopeId,
+          bindingId:  binding.id,
+          isDefault:  binding.isDefault,
+        }
+      }
+      // El binding fue eliminado → re-resolver sin sticky
+    }
+
+    // ── 2. Cargar todos los bindings activos del canal ──────────────────
+    const bindings = await this.loadBindings(channelConfigId)
+
+    if (bindings.length === 0) {
+      throw new ChannelBindingNotFoundError(channelConfigId)
+    }
+
+    // ── 3. Un solo binding → directo ────────────────────────────────
+    if (bindings.length === 1) {
+      const b = bindings[0]
+      return { agentId: b.agentId, scopeLevel: b.scopeLevel, scopeId: b.scopeId, bindingId: b.id, isDefault: b.isDefault }
+    }
+
+    // ── 4. Binding marcado isDefault → usar ese ──────────────────────
+    const defaultBinding = bindings.find((b) => b.isDefault)
+    if (defaultBinding) {
+      return {
+        agentId:    defaultBinding.agentId,
+        scopeLevel: defaultBinding.scopeLevel,
+        scopeId:    defaultBinding.scopeId,
+        bindingId:  defaultBinding.id,
+        isDefault:  true,
+      }
+    }
+
+    // ── 5. Ordenar por prioridad de scope ────────────────────────────
+    const sorted = [...bindings].sort((a, b) => {
+      const pa = SCOPE_PRIORITY[a.scopeLevel] ?? 0
+      const pb = SCOPE_PRIORITY[b.scopeLevel] ?? 0
+      return pb - pa  // descendente: mayor prioridad primero
+    })
+
+    const topPriority = SCOPE_PRIORITY[sorted[0].scopeLevel] ?? 0
+    const topCandidates = sorted.filter(
+      (b) => (SCOPE_PRIORITY[b.scopeLevel] ?? 0) === topPriority,
+    )
+
+    // ── 6. Empate sin isDefault → AmbiguousBindingError ───────────────
+    if (topCandidates.length > 1) {
+      throw new AmbiguousBindingError(
+        channelConfigId,
+        topCandidates.map((b) => b.agentId),
+      )
+    }
+
+    const winner = sorted[0]
+    return {
+      agentId:    winner.agentId,
+      scopeLevel: winner.scopeLevel,
+      scopeId:    winner.scopeId,
+      bindingId:  winner.id,
+      isDefault:  winner.isDefault,
+    }
+  }
+
+  /**
+   * Invalida el caché de bindings para un canal.
+   * Llamar desde el handler de POST/PATCH/DELETE /channels/:id/bindings.
+   */
+  invalidateCache(channelConfigId: string): void {
+    this.bindingsCache.delete(channelConfigId)
+  }
+
+  /**
+   * Devuelve todos los bindings de un canal (para la UI admin).
+   */
+  async listBindings(channelConfigId: string): Promise<BindingRow[]> {
+    return this.db.channelBinding.findMany({
+      where: { channelConfigId },
+      orderBy: [
+        { isDefault: 'desc' },
+        { createdAt: 'asc' },
+      ],
+    })
+  }
+
+  // ── Privados ────────────────────────────────────────────────────────────
+
+  private async loadBindings(channelConfigId: string): Promise<BindingRow[]> {
+    const cached = this.bindingsCache.get(channelConfigId)
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
+      return cached.bindings
+    }
+
+    // Verificar que el ChannelConfig esté activo
+    const config = await this.db.channelConfig.findUniqueOrThrow({
+      where:  { id: channelConfigId },
+      select: { isActive: true },
+    })
+    if (!config.isActive) {
+      throw new ChannelConfigInactiveError(channelConfigId)
+    }
+
+    const bindings = await this.db.channelBinding.findMany({
+      where: { channelConfigId },
+      select: {
+        id:         true,
+        agentId:    true,
+        scopeLevel: true,
+        scopeId:    true,
+        isDefault:  true,
+      },
+    })
+
+    this.bindingsCache.set(channelConfigId, { bindings, cachedAt: Date.now() })
+    return bindings
+  }
+
+  private async findBindingForAgent(
+    channelConfigId: string,
+    agentId:         string,
+  ): Promise<BindingRow | null> {
+    const bindings = await this.loadBindings(channelConfigId).catch(() => [])
+    return bindings.find((b) => b.agentId === agentId) ?? null
+  }
+}

--- a/apps/gateway/src/gateway.module.ts
+++ b/apps/gateway/src/gateway.module.ts
@@ -1,20 +1,19 @@
-import { Module }           from '@nestjs/common';
-import { GatewayService }   from './gateway.service';
-import { HealthController } from './health/health.controller';
-import { PrismaModule }     from './prisma/prisma.module';
+import { Module }               from '@nestjs/common';
+import { GatewayService }       from './gateway.service';
+import { AgentResolverService } from './agent-resolver.service';
+import { HealthController }     from './health/health.controller';
+import { PrismaModule }         from './prisma/prisma.module';
 
 /**
  * GatewayModule agrupa:
  *   - GatewayService (lógica de dispatch, session, encryption)
+ *   - AgentResolverService (resolución de agente por ChannelBinding + scope priority)
  *   - HealthController (GET /health — liveness probe)
- *
- * Cuando F3a-02/03 implementen los Controllers de canal,
- * se añadirán aquí: TelegramController, WebchatController.
  */
 @Module({
   imports:     [PrismaModule],
-  providers:   [GatewayService],
+  providers:   [GatewayService, AgentResolverService],
   controllers: [HealthController],
-  exports:     [GatewayService],
+  exports:     [GatewayService, AgentResolverService],
 })
 export class GatewayModule {}

--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -24,9 +24,10 @@ import {
   type IncomingMessage,
   type OutboundMessage,
 } from '@agent-vs/gateway-sdk';
-import { AgentRunner }        from '@agent-vs/flow-engine';
-import type { IChannelAdapter } from './channels/channel-adapter.interface';
-import { PrismaService }       from './prisma/prisma.service';
+import { AgentRunner }           from '@agent-vs/flow-engine';
+import type { IChannelAdapter }  from './channels/channel-adapter.interface';
+import { PrismaService }         from './prisma/prisma.service';
+import { AgentResolverService }  from './agent-resolver.service';
 
 // ---------------------------------------------------------------------------
 // Tipos internos
@@ -34,7 +35,6 @@ import { PrismaService }       from './prisma/prisma.service';
 
 interface DecryptedChannelConfig {
   id:      string;
-  agentId: string;
   type:    string;
   config:  Record<string, unknown>;
   secrets: Record<string, unknown>;
@@ -52,7 +52,10 @@ export class GatewayService {
   private readonly configCache  = new Map<string, DecryptedChannelConfig>();
   private readonly encKey:       Buffer;
 
-  constructor(private readonly db: PrismaService) {
+  constructor(
+    private readonly db:       PrismaService,
+    private readonly resolver: AgentResolverService,
+  ) {
     this.sessions    = new SessionManager(db);
     this.agentRunner = new AgentRunner({ db });
 
@@ -101,6 +104,7 @@ export class GatewayService {
    * Flow:
    *   rawPayload
    *     → adapter.receive()       parse channel format → IncomingMessage
+   *     → AgentResolverService     resolve agentId via ChannelBinding priority
    *     → SessionManager           upsert GatewaySession, append user turn
    *     → AgentRunner.run()        load Agent+FlowVersion, execute FlowExecutor
    *     → recordReply()            append assistant turn, adapter.send()
@@ -119,14 +123,27 @@ export class GatewayService {
 
     if (!incoming) return;
 
-    // 2. Persist user turn + upsert session
+    // 2. Cargar sesión existente para sticky-session
+    const existingSession = await this.findActiveSession(
+      channelConfigId,
+      incoming.externalUserId,
+    );
+
+    // 3. Resolver agente con prioridad de scope
+    const resolved = await this.resolver.resolve(
+      channelConfigId,
+      incoming.externalUserId,
+      existingSession?.agentId ?? null,
+    );
+
+    // 4. Persist user turn + upsert session
     const session = await this.sessions.receiveUserMessage(
       channelConfigId,
-      cfg.agentId,
+      resolved.agentId,
       incoming,
     );
 
-    // 3. Run agent via FlowExecutor
+    // 5. Run agent via FlowExecutor
     let replyText: string;
     try {
       const result = await this.agentRunner.run(
@@ -139,13 +156,13 @@ export class GatewayService {
       replyText = '(ocurrió un error al procesar tu mensaje)';
     }
 
-    // 4. Build outbound message
+    // 6. Build outbound message
     const outbound: OutboundMessage = {
       externalUserId: incoming.externalUserId,
       text: replyText,
     };
 
-    // 5. Persist assistant turn + send to channel
+    // 7. Persist assistant turn + send to channel
     await this.recordReply(channelConfigId, session.id, outbound);
   }
 
@@ -170,6 +187,20 @@ export class GatewayService {
   // Private helpers
   // -------------------------------------------------------------------------
 
+  /**
+   * Obtiene la sesión activa para un usuario en un canal.
+   * Usado para sticky-session: conservar el agentId de sesiones en curso.
+   */
+  private async findActiveSession(
+    channelConfigId: string,
+    externalUserId:  string,
+  ): Promise<{ id: string; agentId: string } | null> {
+    return this.db.gatewaySession.findFirst({
+      where: { channelConfigId, externalUserId, state: 'active' },
+      select: { id: true, agentId: true },
+    })
+  }
+
   private async loadChannelConfig(
     channelConfigId: string,
   ): Promise<DecryptedChannelConfig> {
@@ -182,10 +213,9 @@ export class GatewayService {
 
     const secrets = this.decrypt(row.secretsEncrypted as string | null);
     const cfg: DecryptedChannelConfig = {
-      id:      row.id,
-      agentId: row.agentId,
-      type:    row.type,
-      config:  (row.config as Record<string, unknown>) ?? {},
+      id:     row.id,
+      type:   row.type,
+      config: (row.config as Record<string, unknown>) ?? {},
       secrets,
     };
     this.configCache.set(channelConfigId, cfg);


### PR DESCRIPTION
- Add agent-resolver.errors.ts: ChannelBindingNotFoundError, ChannelConfigInactiveError, AmbiguousBindingError
- Add agent-resolver.service.ts: resolve() with sticky-session, isDefault, scope priority, in-memory cache (TTL 5min), invalidateCache()
- Update gateway.service.ts: inject AgentResolverService, remove cfg.agentId/row.agentId, resolve agent via ChannelBinding before receiveUserMessage
- Add SessionManager.findActiveSession() stub for sticky-session support
- Update gateway.module.ts: register + export AgentResolverService
- Add __tests__/agent-resolver.service.test.ts with 16 vitest cases

Closes #F3a-13

<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Implementación completa. Aquí el resumen:</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="f3a-13--agentresolverservice-implementado">✅ F3a-13 — AgentResolverService implementado</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Commit SHA:</strong> <code>716ede816f51b82dd51ba3cd71cc4e6c62e216ec</code></p><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Branch:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-13-agent-resolver-scope-priority"><span class="text-box-trim-both"><code>feat/F3a-13-agent-resolver-scope-priority</code></span></a> (base: <code>feat/F3a-12-channel-credentials-crypto</code>)</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="archivos-entregados">Archivos entregados</h2><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="nuevos">Nuevos</h2><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: visible; visibility: visible;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] dark:shadow-lg border-subtlest ring-subtlest divide-subtlest">
Archivo | Descripción
-- | --


</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="decisiones-clave-de-implementacin">Decisiones clave de implementación</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong><code>cfg.agentId</code> y <code>row.agentId</code> eliminados</strong> — <code>DecryptedChannelConfig</code> ya no tiene el campo; cero referencias a <code>cfg.agentId</code> en el servicio</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Sticky session</strong> en <code>dispatch()</code>: se consulta la sesión activa antes de resolver, para no cambiar de agente a mitad de conversación</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Caché lazy por <code>channelConfigId</code></strong>: la carga es bajo demanda, con TTL de 5 min; <code>invalidateCache()</code> expuesto para que <code>ChannelLifecycleService</code> (F3a-14) lo llame en cada transición de estado</p></li></ul></div></body></html><!--EndFragment-->
</body>
</html>Implementación completa. Aquí el resumen:

***

## ✅ F3a-13 — AgentResolverService implementado

**Commit SHA:** `716ede816f51b82dd51ba3cd71cc4e6c62e216ec` 

**Branch:** [`[feat/F3a-13-agent-resolver-scope-priority](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-13-agent-resolver-scope-priority)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-13-agent-resolver-scope-priority) (base: `feat/F3a-12-channel-credentials-crypto`)

***

## Archivos entregados

### Nuevos
| Archivo | Descripción |
|---|---|
| `agent-resolver.errors.ts` | 3 errores tipados: `ChannelBindingNotFoundError`, `ChannelConfigInactiveError`, `AmbiguousBindingError` (con campo `.candidates`) |
| `agent-resolver.service.ts` | `resolve()` con sticky-session → isDefault → scope priority → AmbiguousBindingError; caché in-memory TTL 5min; `invalidateCache()`; `listBindings()` |
| `__tests__/agent-resolver.service.test.ts` | **16 tests** en vitest cubriendo casos base, sticky session, caché y multi-canal |

### Modificados
| Archivo | Cambios |
|---|---|
| `gateway.service.ts` | Inyecta `AgentResolverService`; elimina `cfg.agentId`/`row.agentId`; `dispatch()` llama `findActiveSession()` + `resolver.resolve()` antes de `receiveUserMessage()`; agrega `findActiveSession()` privado para sticky-session |
| `gateway.module.ts` | Añade `AgentResolverService` a `providers` y `exports` |

***

## Decisiones clave de implementación

- **`cfg.agentId` y `row.agentId` eliminados** — `DecryptedChannelConfig` ya no tiene el campo; cero referencias a `cfg.agentId` en el servicio 
- **Sticky session** en `dispatch()`: se consulta la sesión activa antes de resolver, para no cambiar de agente a mitad de conversación 
- **Caché lazy por `channelConfigId`**: la carga es bajo demanda, con TTL de 5 min; `invalidateCache()` expuesto para que `ChannelLifecycleService` (F3a-14) lo llame en cada transición de estado

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent resolution service introduced to determine agent per message with sticky-session support.
  * Per-channel caching (TTL + explicit invalidation) for agent bindings.

* **Improvements**
  * Scope-priority selection updated (agent > workspace > department > agency) with default-binding precedence.
  * Gateway dispatch now uses the resolver for agent selection.

* **Bug Fixes / Error Handling**
  * Clear errors for missing bindings, inactive channels, and ambiguous bindings.

* **Tests**
  * New end-to-end unit tests covering resolution, sticky sessions, caching, invalidation, and multi-channel isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->