### PR TITLE
feat(F3a-14): add ChannelLifecycleService provision/start/stop/restar…

### DIFF
--- a/apps/api/src/modules/channels/__tests__/channel-lifecycle.service.test.ts
+++ b/apps/api/src/modules/channels/__tests__/channel-lifecycle.service.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ChannelLifecycleService } from '../channel-lifecycle.service.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from '../channel-lifecycle.errors.js'
+
+function makeChannel(status: string, id = 'ch-001') {
+  return {
+    id,
+    name: 'TestBot',
+    type: 'telegram',
+    status,
+    isActive: status === 'active' || status === 'starting',
+    errorMessage: null,
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    config: {},
+    secretsEncrypted: null,
+  }
+}
+
+function makeDb(channel: any) {
+  return {
+    channelConfig: {
+      findUnique:         vi.fn().mockResolvedValue(channel),
+      findUniqueOrThrow:  vi.fn().mockResolvedValue(channel),
+      create:             vi.fn().mockResolvedValue({ ...channel, status: 'provisioned', isActive: false }),
+      update:             vi.fn().mockImplementation(({ data }: any) =>
+                            Promise.resolve({ ...channel, ...data })),
+      findMany:           vi.fn().mockResolvedValue([channel]),
+    },
+    channelBinding: { count: vi.fn().mockResolvedValue(0) },
+    gatewaySession: { count: vi.fn().mockResolvedValue(0) },
+  }
+}
+
+function makeGateway() {
+  return {
+    activateChannel:   vi.fn().mockResolvedValue(undefined),
+    deactivateChannel: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeResolver() {
+  return { invalidateCache: vi.fn() }
+}
+
+function makeSvc(db: any, gateway: any = makeGateway(), resolver: any = makeResolver()) {
+  return new ChannelLifecycleService(db as any, gateway as any, resolver as any)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('provision()', () => {
+  it('creates channel with status=provisioned and isActive=false', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    const result = await svc.provision({ type: 'telegram', name: 'TestBot', config: {} })
+    expect(db.channelConfig.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'provisioned', isActive: false }) })
+    )
+    expect(result.status).toBe('provisioned')
+    expect(result.isActive).toBe(false)
+  })
+
+  it('encrypts secrets when provided', async () => {
+    process.env.GATEWAY_ENCRYPTION_KEY = 'a'.repeat(64) // 32-byte key in hex
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await svc.provision({ type: 'telegram', name: 'TestBot', config: {}, secrets: { token: 'secret' } })
+    const createCall = (db.channelConfig.create as any).mock.calls[0][0]
+    expect(createCall.data.secretsEncrypted).toBeTruthy()
+    expect(createCall.data.secretsEncrypted).not.toBe('{"token":"secret"}')
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+  })
+
+  it('autoStart=true calls start() and returns active status', async () => {
+    process.env.GATEWAY_ENCRYPTION_KEY = 'b'.repeat(64)
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.provision({ type: 'telegram', name: 'TestBot', config: {}, autoStart: true })
+    expect(result.status).toBe('active')
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+  })
+
+  it('throws Error when GATEWAY_ENCRYPTION_KEY is missing and secrets provided', async () => {
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(
+      svc.provision({ type: 'telegram', name: 'TestBot', config: {}, secrets: { token: 'x' } })
+    ).rejects.toThrow('GATEWAY_ENCRYPTION_KEY is not set')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('start()', () => {
+  it('provisioned → active, isActive=true', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+    expect(result.isActive).toBe(true)
+  })
+
+  it('stopped → active', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('error → active', async () => {
+    const ch = makeChannel('error')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('active → throws ChannelAlreadyInStateError', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(ChannelAlreadyInStateError)
+  })
+
+  it('starting → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('starting')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('gateway failure → persists error status and throws WebhookRegistrationError', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const gateway = { activateChannel: vi.fn().mockRejectedValue(new Error('webhook timeout')) }
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db, gateway)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(WebhookRegistrationError)
+    const lastUpdateCall = (db.channelConfig.update as any).mock.calls.at(-1)[0]
+    expect(lastUpdateCall.data.status).toBe('error')
+    expect(lastUpdateCall.data.isActive).toBe(false)
+    expect(lastUpdateCall.data.errorMessage).toContain('webhook timeout')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('stop()', () => {
+  it('active → stopped, isActive=false', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.stop('ch-001')
+    expect(result.status).toBe('stopped')
+    expect(result.isActive).toBe(false)
+  })
+
+  it('stopped → throws ChannelAlreadyInStateError', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.stop('ch-001')).rejects.toBeInstanceOf(ChannelAlreadyInStateError)
+  })
+
+  it('provisioned → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.stop('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('gateway failure → persists error status and re-throws', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const gateway = {
+      activateChannel:   vi.fn(),
+      deactivateChannel: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db, gateway)
+    await expect(svc.stop('ch-001')).rejects.toThrow('network error')
+    const lastUpdateCall = (db.channelConfig.update as any).mock.calls.at(-1)[0]
+    expect(lastUpdateCall.data.status).toBe('error')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('restart()', () => {
+  it('active → stop() + start() → returns active', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    db.channelConfig.findUnique = vi.fn()
+      .mockResolvedValueOnce(ch)              // restart load
+      .mockResolvedValueOnce(ch)              // stop load
+      .mockResolvedValueOnce({ ...ch, status: 'stopped', isActive: false }) // start load
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('error → calls start() directly (no stop())', async () => {
+    const ch = makeChannel('error')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('stopped → calls start() directly', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('starting → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('starting')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.restart('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('stopping → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('stopping')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.restart('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('status()', () => {
+  it('returns ChannelStatusDto with all fields for existing channel', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    const result = await svc.status('ch-001')
+    expect(result.id).toBe('ch-001')
+    expect(result.status).toBe('active')
+    expect(result.isActive).toBe(true)
+    expect(result.bindingCount).toBe(0)
+    expect(result.activeSessions).toBe(0)
+    expect(result.createdAt).toBeTruthy()
+  })
+
+  it('throws ChannelNotFoundError when channel does not exist', async () => {
+    const db = makeDb(null)
+    db.channelConfig.findUnique = vi.fn().mockResolvedValue(null)
+    const svc = makeSvc(db)
+    await expect(svc.status('nonexistent')).rejects.toBeInstanceOf(ChannelNotFoundError)
+  })
+})

--- a/apps/api/src/modules/channels/channel-lifecycle.errors.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.errors.ts
@@ -1,0 +1,40 @@
+export class ChannelNotFoundError extends Error {
+  constructor(channelConfigId: string) {
+    super(`[ChannelLifecycle] ChannelConfig "${channelConfigId}" not found.`)
+    this.name = 'ChannelNotFoundError'
+  }
+}
+
+export class InvalidTransitionError extends Error {
+  constructor(
+    channelConfigId: string,
+    from: string,
+    to: string,
+  ) {
+    super(
+      `[ChannelLifecycle] Cannot transition channel "${channelConfigId}" ` +
+      `from status="${from}" to "${to}". ` +
+      `Check allowed transitions in ChannelLifecycleService.TRANSITIONS.`
+    )
+    this.name = 'InvalidTransitionError'
+  }
+}
+
+export class ChannelAlreadyInStateError extends Error {
+  constructor(channelConfigId: string, status: string) {
+    super(
+      `[ChannelLifecycle] Channel "${channelConfigId}" is already in status="${status}".`
+    )
+    this.name = 'ChannelAlreadyInStateError'
+  }
+}
+
+export class WebhookRegistrationError extends Error {
+  constructor(channelConfigId: string, cause: string) {
+    super(
+      `[ChannelLifecycle] Failed to register webhook for channel ` +
+      `"${channelConfigId}": ${cause}`
+    )
+    this.name = 'WebhookRegistrationError'
+  }
+}

--- a/apps/api/src/modules/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.service.ts
@@ -1,0 +1,352 @@
+import { Injectable, Logger }    from '@nestjs/common'
+import { PrismaService }         from '../../prisma/prisma.service.js'
+import { GatewayService }        from '../gateway/gateway.service.js'
+import { AgentResolverService }  from '../gateway/agent-resolver.service.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from './channel-lifecycle.errors.js'
+import type { ProvisionChannelDto, ChannelStatusDto } from './dto/provision-channel.dto.js'
+import { createCipheriv, randomBytes }               from 'crypto'
+
+// ── Tipos ───────────────────────────────────────────────────────────────
+
+type ChannelStatus =
+  | 'provisioned'
+  | 'starting'
+  | 'active'
+  | 'stopping'
+  | 'stopped'
+  | 'error'
+
+// ── Transiciones permitidas (mapa explícito) ────────────────────────────
+
+const TRANSITIONS: Record<ChannelStatus, ChannelStatus[]> = {
+  provisioned: ['starting'],
+  starting:    ['active', 'error'],
+  active:      ['stopping'],
+  stopping:    ['stopped', 'error'],
+  stopped:     ['starting'],
+  error:       ['starting'],
+}
+
+// ── Servicio ────────────────────────────────────────────────────────────
+
+@Injectable()
+export class ChannelLifecycleService {
+  private readonly logger = new Logger(ChannelLifecycleService.name)
+
+  constructor(
+    private readonly db:       PrismaService,
+    private readonly gateway:  GatewayService,
+    private readonly resolver: AgentResolverService,
+  ) {}
+
+  // ────────────────────────────────────────────────────────────────────
+  // PROVISION — Crea el ChannelConfig en BD con status='provisioned'
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Crea un nuevo canal en la BD en estado 'provisioned'.
+   * No registra webhooks ni activa el canal.
+   * Si dto.autoStart=true, llama start() inmediatamente después.
+   *
+   * @returns ChannelStatusDto del canal creado
+   */
+  async provision(dto: ProvisionChannelDto): Promise<ChannelStatusDto> {
+    const secretsEncrypted = dto.secrets
+      ? this.encryptSecrets(dto.secrets)
+      : null
+
+    const channel = await this.db.channelConfig.create({
+      data: {
+        type:             dto.type,
+        name:             dto.name,
+        config:           dto.config,
+        secretsEncrypted,
+        isActive:         false,
+        status:           'provisioned',
+        errorMessage:     null,
+        lastStartedAt:    null,
+        lastStoppedAt:    null,
+      },
+    })
+
+    this.logger.log(`[provision] Channel "${channel.id}" (${channel.type}) created`)
+
+    if (dto.autoStart) {
+      return this.start(channel.id)
+    }
+
+    return this.toStatusDto(channel, 0, 0)
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // START — Activa el canal: registra webhooks y marca isActive=true
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Inicia un canal en estado 'provisioned', 'stopped', o 'error'.
+   * Flujo:
+   *   1. Validar transición → 'starting'
+   *   2. Persistir status='starting', isActive=true
+   *   3. Llamar GatewayService.activateChannel() (con stub de seguridad)
+   *   4a. Éxito → persistir status='active', lastStartedAt=now
+   *   4b. Fallo → persistir status='error', isActive=false, errorMessage
+   *
+   * @throws InvalidTransitionError si el canal no puede hacer start desde su estado actual
+   */
+  async start(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'active') {
+      throw new ChannelAlreadyInStateError(channelConfigId, 'active')
+    }
+
+    this.assertTransition(channel.status as ChannelStatus, 'starting', channelConfigId)
+
+    // Marcar como 'starting'
+    await this.db.channelConfig.update({
+      where: { id: channelConfigId },
+      data:  { status: 'starting', isActive: true, errorMessage: null },
+    })
+    this.resolver.invalidateCache(channelConfigId)
+
+    try {
+      // Delegar al GatewayService la activación real del canal (stub-safe)
+      await this.callGatewayActivate(channelConfigId)
+
+      // Marcar como 'active'
+      const updated = await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'active', lastStartedAt: new Date() },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.log(`[start] Channel "${channelConfigId}" is now active`)
+      return this.buildStatusDto(updated, channelConfigId)
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'error', isActive: false, errorMessage },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.error(`[start] Channel "${channelConfigId}" failed to start: ${errorMessage}`)
+      throw new WebhookRegistrationError(channelConfigId, errorMessage)
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STOP — Desactiva el canal: desregistra webhooks y marca isActive=false
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Detiene un canal en estado 'active'.
+   * Flujo:
+   *   1. Validar transición → 'stopping'
+   *   2. Persistir status='stopping', isActive=false
+   *   3. Llamar GatewayService.deactivateChannel() (con stub de seguridad)
+   *   4a. Éxito → persistir status='stopped', lastStoppedAt=now
+   *   4b. Fallo → persistir status='error', errorMessage
+   *
+   * @throws InvalidTransitionError si el canal no está en estado 'active'
+   */
+  async stop(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'stopped') {
+      throw new ChannelAlreadyInStateError(channelConfigId, 'stopped')
+    }
+
+    this.assertTransition(channel.status as ChannelStatus, 'stopping', channelConfigId)
+
+    await this.db.channelConfig.update({
+      where: { id: channelConfigId },
+      data:  { status: 'stopping', isActive: false, errorMessage: null },
+    })
+    this.resolver.invalidateCache(channelConfigId)
+
+    try {
+      await this.callGatewayDeactivate(channelConfigId)
+
+      const updated = await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'stopped', lastStoppedAt: new Date() },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.log(`[stop] Channel "${channelConfigId}" is now stopped`)
+      return this.buildStatusDto(updated, channelConfigId)
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'error', errorMessage },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.error(`[stop] Channel "${channelConfigId}" failed to stop: ${errorMessage}`)
+      throw err
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // RESTART — stop() + start() con manejo de estado intermedio
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Reinicia el canal.
+   * - Si está 'active' → stop() + start()
+   * - Si está 'error', 'stopped', 'provisioned' → start() directo
+   * - Si está 'starting' o 'stopping' → InvalidTransitionError
+   */
+  async restart(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'starting' || channel.status === 'stopping') {
+      throw new InvalidTransitionError(
+        channelConfigId,
+        channel.status,
+        'restart',
+      )
+    }
+
+    if (channel.status === 'active') {
+      await this.stop(channelConfigId)
+    }
+
+    return this.start(channelConfigId)
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STATUS — Lectura enriquecida del estado del canal
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Retorna el ChannelStatusDto con conteos de bindings y sesiones activas.
+   * Nunca lanza errores de transición — solo lanza ChannelNotFoundError.
+   */
+  async status(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+    return this.buildStatusDto(channel, channelConfigId)
+  }
+
+  /**
+   * Lista todos los canales con su estado actual.
+   * Ordenados por: activos primero, luego por nombre.
+   */
+  async listAll(): Promise<ChannelStatusDto[]> {
+    const channels = await this.db.channelConfig.findMany({
+      orderBy: [
+        { isActive: 'desc' },
+        { name: 'asc' },
+      ],
+    })
+
+    return Promise.all(
+      channels.map((ch) => this.buildStatusDto(ch, ch.id))
+    )
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STUBS DE GATEWAY (safe delegation)
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Llama gateway.activateChannel() si el método existe.
+   * Si aún no está implementado en GatewayService, actúa como no-op
+   * para que el build no rompa.
+   */
+  private async callGatewayActivate(id: string): Promise<void> {
+    if (typeof (this.gateway as any).activateChannel === 'function') {
+      await (this.gateway as any).activateChannel(id)
+    }
+    // else: no-op hasta que GatewayService implemente el método
+  }
+
+  /**
+   * Llama gateway.deactivateChannel() si el método existe.
+   * Si aún no está implementado en GatewayService, actúa como no-op.
+   */
+  private async callGatewayDeactivate(id: string): Promise<void> {
+    if (typeof (this.gateway as any).deactivateChannel === 'function') {
+      await (this.gateway as any).deactivateChannel(id)
+    }
+    // else: no-op hasta que GatewayService implemente el método
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // PRIVADOS
+  // ────────────────────────────────────────────────────────────────────
+
+  private assertTransition(
+    from:             ChannelStatus,
+    to:               ChannelStatus,
+    channelConfigId:  string,
+  ): void {
+    const allowed = TRANSITIONS[from] ?? []
+    if (!allowed.includes(to)) {
+      throw new InvalidTransitionError(channelConfigId, from, to)
+    }
+  }
+
+  private async loadOrThrow(channelConfigId: string) {
+    const channel = await this.db.channelConfig.findUnique({
+      where: { id: channelConfigId },
+    })
+    if (!channel) throw new ChannelNotFoundError(channelConfigId)
+    return channel
+  }
+
+  private async buildStatusDto(
+    channel:         any,
+    channelConfigId: string,
+  ): Promise<ChannelStatusDto> {
+    const [bindingCount, activeSessions] = await Promise.all([
+      this.db.channelBinding.count({ where: { channelConfigId } }),
+      this.db.gatewaySession.count({
+        where: { channelConfigId, state: 'active' },
+      }),
+    ])
+    return this.toStatusDto(channel, bindingCount, activeSessions)
+  }
+
+  private toStatusDto(
+    ch:             any,
+    bindingCount:   number,
+    activeSessions: number,
+  ): ChannelStatusDto {
+    return {
+      id:             ch.id,
+      name:           ch.name,
+      type:           ch.type,
+      status:         ch.status,
+      isActive:       ch.isActive,
+      errorMessage:   ch.errorMessage ?? null,
+      lastStartedAt:  ch.lastStartedAt?.toISOString() ?? null,
+      lastStoppedAt:  ch.lastStoppedAt?.toISOString() ?? null,
+      bindingCount,
+      activeSessions,
+      createdAt:      ch.createdAt.toISOString(),
+      updatedAt:      ch.updatedAt.toISOString(),
+    }
+  }
+
+  /**
+   * Encripta los secretos del canal usando AES-256-GCM.
+   * Mismo esquema que GatewayService: [12 IV][16 tag][N ciphertext]
+   */
+  private encryptSecrets(secrets: Record<string, unknown>): string {
+    const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? ''
+    if (!keyHex) throw new Error('GATEWAY_ENCRYPTION_KEY is not set')
+    const key    = Buffer.from(keyHex, 'hex')
+    const iv     = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    const plain  = Buffer.from(JSON.stringify(secrets), 'utf8')
+    const enc    = Buffer.concat([cipher.update(plain), cipher.final()])
+    const tag    = cipher.getAuthTag()
+    return Buffer.concat([iv, tag, enc]).toString('base64')
+  }
+}

--- a/apps/api/src/modules/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger }    from '@nestjs/common'
-import { PrismaService }         from '../../prisma/prisma.service.js'
+import { PrismaService }         from '../../lib/prisma.service.js'
 import { GatewayService }        from '../gateway/gateway.service.js'
 import { AgentResolverService }  from '../gateway/agent-resolver.service.js'
 import {
@@ -246,7 +246,7 @@ export class ChannelLifecycleService {
     })
 
     return Promise.all(
-      channels.map((ch) => this.buildStatusDto(ch, ch.id))
+      channels.map((ch: any) => this.buildStatusDto(ch, ch.id))
     )
   }
 
@@ -260,10 +260,7 @@ export class ChannelLifecycleService {
    * para que el build no rompa.
    */
   private async callGatewayActivate(id: string): Promise<void> {
-    if (typeof (this.gateway as any).activateChannel === 'function') {
-      await (this.gateway as any).activateChannel(id)
-    }
-    // else: no-op hasta que GatewayService implemente el método
+    await this.gateway.activateChannel(id)
   }
 
   /**
@@ -271,10 +268,7 @@ export class ChannelLifecycleService {
    * Si aún no está implementado en GatewayService, actúa como no-op.
    */
   private async callGatewayDeactivate(id: string): Promise<void> {
-    if (typeof (this.gateway as any).deactivateChannel === 'function') {
-      await (this.gateway as any).deactivateChannel(id)
-    }
-    // else: no-op hasta que GatewayService implemente el método
+    await this.gateway.deactivateChannel(id)
   }
 
   // ────────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/channels/channels.controller.ts
+++ b/apps/api/src/modules/channels/channels.controller.ts
@@ -1,57 +1,75 @@
-import { Router } from 'express';
+import {
+  Controller, Get, Post, Param,
+  Body, HttpCode, HttpStatus, HttpException,
+} from '@nestjs/common'
+import { ChannelLifecycleService } from './channel-lifecycle.service.js'
+import { ProvisionChannelDto }     from './dto/provision-channel.dto.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from './channel-lifecycle.errors.js'
 
-import { ChannelsService } from './channels.service';
+@Controller('channels')
+export class ChannelsController {
+  constructor(private readonly lifecycle: ChannelLifecycleService) {}
 
-export function registerChannelsRoutes(router: Router) {
-  const service = new ChannelsService();
+  /** GET /channels — lista todos los canales */
+  @Get()
+  listAll() {
+    return this.lifecycle.listAll()
+  }
 
-  /**
-   * GET /channels
-   * Lista todos los canales activos con conteo de sesiones.
-   */
-  router.get('/channels', async (_req, res) => {
+  /** GET /channels/:id/status — estado detallado */
+  @Get(':id/status')
+  async status(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.status(id))
+  }
+
+  /** POST /channels — provisionar nuevo canal */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async provision(@Body() dto: ProvisionChannelDto) {
+    return this.wrap(() => this.lifecycle.provision(dto))
+  }
+
+  /** POST /channels/:id/start */
+  @Post(':id/start')
+  async start(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.start(id))
+  }
+
+  /** POST /channels/:id/stop */
+  @Post(':id/stop')
+  async stop(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.stop(id))
+  }
+
+  /** POST /channels/:id/restart */
+  @Post(':id/restart')
+  async restart(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.restart(id))
+  }
+
+  // Mapeo de errores de dominio → HTTP
+  private async wrap<T>(fn: () => Promise<T>): Promise<T> {
     try {
-      res.json(await service.listChannels());
+      return await fn()
     } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
+      if (err instanceof ChannelNotFoundError) {
+        throw new HttpException(err.message, HttpStatus.NOT_FOUND)
+      }
+      if (err instanceof ChannelAlreadyInStateError) {
+        throw new HttpException(err.message, HttpStatus.CONFLICT)
+      }
+      if (err instanceof InvalidTransitionError) {
+        throw new HttpException(err.message, HttpStatus.UNPROCESSABLE_ENTITY)
+      }
+      if (err instanceof WebhookRegistrationError) {
+        throw new HttpException(err.message, HttpStatus.BAD_GATEWAY)
+      }
+      throw err
     }
-  });
-
-  /**
-   * GET /channels/:channel
-   * Detalle de un canal por nombre (e.g. "whatsapp", "web", "api").
-   */
-  router.get('/channels/:channel', async (req, res) => {
-    try {
-      const result = await service.getChannel(req.params.channel);
-      if (!result.ok) return res.status(404).json(result);
-      return res.json(result);
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
-
-  /**
-   * GET /channels/:channel/sessions
-   * Lista todas las sesiones dentro de un canal.
-   */
-  router.get('/channels/:channel/sessions', async (req, res) => {
-    try {
-      res.json(await service.getChannelSessions(req.params.channel));
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
-
-  /**
-   * POST /channels/:channel/disconnect
-   * Desconecta todas las sesiones activas de un canal.
-   */
-  router.post('/channels/:channel/disconnect', async (req, res) => {
-    try {
-      res.json(await service.disconnectChannel(req.params.channel));
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
+  }
 }

--- a/apps/api/src/modules/channels/channels.controller.ts
+++ b/apps/api/src/modules/channels/channels.controller.ts
@@ -2,7 +2,11 @@ import {
   Controller, Get, Post, Param,
   Body, HttpCode, HttpStatus, HttpException,
 } from '@nestjs/common'
+import { Router } from 'express'
+import { PrismaService } from '../../lib/prisma.service.js'
 import { ChannelLifecycleService } from './channel-lifecycle.service.js'
+import { GatewayService } from '../gateway/gateway.service.js'
+import { AgentResolverService } from '../gateway/agent-resolver.service.js'
 import { ProvisionChannelDto }     from './dto/provision-channel.dto.js'
 import {
   ChannelNotFoundError,
@@ -72,4 +76,83 @@ export class ChannelsController {
       throw err
     }
   }
+}
+
+export function registerChannelsRoutes(router: Router): void {
+  const db = new PrismaService()
+  const lifecycle = new ChannelLifecycleService(
+    db as any,
+    new GatewayService(),
+    new AgentResolverService(),
+  )
+
+  router.get('/channels', async (_req, res) => {
+    try {
+      res.json(await lifecycle.listAll())
+    } catch (err) {
+      sendError(res, err)
+    }
+  })
+
+  router.get('/channels/:id/status', async (req, res) => {
+    try {
+      res.json(await lifecycle.status(req.params.id))
+    } catch (err) {
+      sendError(res, err)
+    }
+  })
+
+  router.post('/channels', async (req, res) => {
+    try {
+      res.status(HttpStatus.CREATED).json(await lifecycle.provision(req.body as ProvisionChannelDto))
+    } catch (err) {
+      sendError(res, err)
+    }
+  })
+
+  router.post('/channels/:id/start', async (req, res) => {
+    try {
+      res.json(await lifecycle.start(req.params.id))
+    } catch (err) {
+      sendError(res, err)
+    }
+  })
+
+  router.post('/channels/:id/stop', async (req, res) => {
+    try {
+      res.json(await lifecycle.stop(req.params.id))
+    } catch (err) {
+      sendError(res, err)
+    }
+  })
+
+  router.post('/channels/:id/restart', async (req, res) => {
+    try {
+      res.json(await lifecycle.restart(req.params.id))
+    } catch (err) {
+      sendError(res, err)
+    }
+  })
+}
+
+function sendError(res: import('express').Response, err: unknown): void {
+  if (err instanceof ChannelNotFoundError) {
+    res.status(HttpStatus.NOT_FOUND).json({ ok: false, error: err.message })
+    return
+  }
+  if (err instanceof ChannelAlreadyInStateError) {
+    res.status(HttpStatus.CONFLICT).json({ ok: false, error: err.message })
+    return
+  }
+  if (err instanceof InvalidTransitionError) {
+    res.status(HttpStatus.UNPROCESSABLE_ENTITY).json({ ok: false, error: err.message })
+    return
+  }
+  if (err instanceof WebhookRegistrationError) {
+    res.status(HttpStatus.BAD_GATEWAY).json({ ok: false, error: err.message })
+    return
+  }
+
+  const message = err instanceof Error ? err.message : 'Internal error'
+  res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({ ok: false, error: message })
 }

--- a/apps/api/src/modules/channels/channels.module.ts
+++ b/apps/api/src/modules/channels/channels.module.ts
@@ -2,9 +2,10 @@ import { Module }                    from '@nestjs/common'
 import { ChannelsController }        from './channels.controller.js'
 import { ChannelLifecycleService }   from './channel-lifecycle.service.js'
 import { GatewayModule }             from '../gateway/gateway.module.js'
+import { PrismaModule }              from '../../lib/prisma.module.js'
 
 @Module({
-  imports:     [GatewayModule],   // provee GatewayService + AgentResolverService
+  imports:     [GatewayModule, PrismaModule],   // provee GatewayService + AgentResolverService + PrismaService
   controllers: [ChannelsController],
   providers:   [ChannelLifecycleService],
   exports:     [ChannelLifecycleService],

--- a/apps/api/src/modules/channels/channels.module.ts
+++ b/apps/api/src/modules/channels/channels.module.ts
@@ -1,15 +1,12 @@
-import { Module } from '@nestjs/common';
-import { ChannelsService }    from './channels.service';
-// import { ChannelsController } from './channels.controller';
-// Commented out: ChannelsController uses Express routing, not NestJS decorators
+import { Module }                    from '@nestjs/common'
+import { ChannelsController }        from './channels.controller.js'
+import { ChannelLifecycleService }   from './channel-lifecycle.service.js'
+import { GatewayModule }             from '../gateway/gateway.module.js'
 
-/**
- * ChannelsModule — ya no necesita proveer PrismaService porque PrismaModule
- * es @Global() y está disponible globalmente desde que se importa en AppModule.
- */
 @Module({
-  // controllers: [ChannelsController],
-  providers:   [ChannelsService],
-  exports:     [ChannelsService],   // para que el runtime lo inyecte
+  imports:     [GatewayModule],   // provee GatewayService + AgentResolverService
+  controllers: [ChannelsController],
+  providers:   [ChannelLifecycleService],
+  exports:     [ChannelLifecycleService],
 })
 export class ChannelsModule {}

--- a/apps/api/src/modules/channels/dto/provision-channel.dto.ts
+++ b/apps/api/src/modules/channels/dto/provision-channel.dto.ts
@@ -1,0 +1,37 @@
+import { IsString, IsNotEmpty, IsObject, IsOptional, IsBoolean } from 'class-validator'
+
+export class ProvisionChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  type: string          // 'telegram' | 'whatsapp' | 'webchat' | 'slack' | ...
+
+  @IsString()
+  @IsNotEmpty()
+  name: string          // Nombre legible del canal
+
+  @IsObject()
+  config: Record<string, unknown>   // Configuración pública (webhook URL, bot_username…)
+
+  @IsObject()
+  @IsOptional()
+  secrets?: Record<string, unknown> // Secretos — se encriptan antes de guardar
+
+  @IsBoolean()
+  @IsOptional()
+  autoStart?: boolean   // Si true: provision() + start() en una llamada
+}
+
+export class ChannelStatusDto {
+  id:             string
+  name:           string
+  type:           string
+  status:         string
+  isActive:       boolean
+  errorMessage:   string | null
+  lastStartedAt:  string | null
+  lastStoppedAt:  string | null
+  bindingCount:   number
+  activeSessions: number
+  createdAt:      string
+  updatedAt:      string
+}

--- a/apps/api/src/modules/gateway/agent-resolver.service.ts
+++ b/apps/api/src/modules/gateway/agent-resolver.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class AgentResolverService {
+  private readonly cache = new Map<string, unknown>()
+
+  invalidateCache(channelConfigId?: string): void {
+    if (channelConfigId) {
+      this.cache.delete(channelConfigId)
+      return
+    }
+
+    this.cache.clear()
+  }
+}

--- a/apps/api/src/modules/gateway/gateway.module.ts
+++ b/apps/api/src/modules/gateway/gateway.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+
+import { AgentResolverService } from './agent-resolver.service.js'
+import { GatewayService } from './gateway.service.js'
+
+@Module({
+  providers: [GatewayService, AgentResolverService],
+  exports: [GatewayService, AgentResolverService],
+})
+export class GatewayModule {}

--- a/apps/api/src/modules/gateway/gateway.service.ts
+++ b/apps/api/src/modules/gateway/gateway.service.ts
@@ -1,7 +1,9 @@
+import { Injectable } from '@nestjs/common';
 import { gatewayMethods } from '../../../../../packages/gateway-sdk/src';
 import { studioConfig } from '../../config';
 import type { RuntimeCapabilityMatrix, SessionState } from '../../../../../packages/core-types/src';
 
+@Injectable()
 export class GatewayService {
   async call(method: string, params?: Record<string, unknown>): Promise<unknown> {
     let response: Response | null = null;
@@ -199,5 +201,43 @@ export class GatewayService {
       channel,
       ...stats,
     }));
+  }
+
+  async activateChannel(channelConfigId: string): Promise<void> {
+    await this.postChannelAction(channelConfigId, 'activate');
+  }
+
+  async deactivateChannel(channelConfigId: string): Promise<void> {
+    await this.postChannelAction(channelConfigId, 'deactivate');
+  }
+
+  private async postChannelAction(
+    channelConfigId: string,
+    action: 'activate' | 'deactivate',
+  ): Promise<void> {
+    let response: Response | null = null;
+    try {
+      response = await fetch(
+        `${studioConfig.gatewayBaseUrl}/api/channels/${encodeURIComponent(channelConfigId)}/${action}`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    } catch {
+      throw new Error(`Gateway transport unavailable for channels.${action}`);
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      let message = text || `Gateway channels.${action} failed`;
+      try {
+        const json = JSON.parse(text) as { error?: string; message?: string };
+        message = json.error ?? json.message ?? message;
+      } catch {
+        // keep fallback message
+      }
+      throw new Error(message);
+    }
   }
 }


### PR DESCRIPTION
…t/status

- Add channel-lifecycle.errors.ts with typed domain errors
- Add dto/provision-channel.dto.ts and ChannelStatusDto
- Add channel-lifecycle.service.ts with full state machine (provisioned/starting/active/stopping/stopped/error)
- Add callGatewayActivate/callGatewayDeactivate stubs for safe gateway delegation
- Replace channels.controller.ts with NestJS Controller using lifecycle service
- Replace channels.module.ts to register ChannelLifecycleService + GatewayModule
- Add __tests__/channel-lifecycle.service.test.ts with 18 vitest cases
- Mark channels.service.ts @deprecated (preserved for F3a-15 cleanup)

Closes #F3a-14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel lifecycle endpoints: provision, start, stop, restart, and status queries
  * Encrypted secret storage for channels and optional automatic startup
  * Channel status now shows binding counts, active sessions, and timestamps
  * Gateway activation/deactivation integrated for reliable start/stop behavior

* **Bug Fixes / Reliability**
  * Improved error reporting and mapped HTTP error responses for lifecycle operations

* **Tests**
  * Comprehensive unit tests covering lifecycle flows and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->