### PR TITLE
Feat/f3a 17 normalize handle incoming

### DIFF
--- a/apps/api/src/modules/channels/__tests__/channel-lifecycle.service.test.ts
+++ b/apps/api/src/modules/channels/__tests__/channel-lifecycle.service.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ChannelLifecycleService } from '../channel-lifecycle.service.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from '../channel-lifecycle.errors.js'
+
+function makeChannel(status: string, id = 'ch-001') {
+  return {
+    id,
+    name: 'TestBot',
+    type: 'telegram',
+    status,
+    isActive: status === 'active' || status === 'starting',
+    errorMessage: null,
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    config: {},
+    secretsEncrypted: null,
+  }
+}
+
+function makeDb(channel: any) {
+  return {
+    channelConfig: {
+      findUnique:         vi.fn().mockResolvedValue(channel),
+      findUniqueOrThrow:  vi.fn().mockResolvedValue(channel),
+      create:             vi.fn().mockResolvedValue({ ...channel, status: 'provisioned', isActive: false }),
+      update:             vi.fn().mockImplementation(({ data }: any) =>
+                            Promise.resolve({ ...channel, ...data })),
+      findMany:           vi.fn().mockResolvedValue([channel]),
+    },
+    channelBinding: { count: vi.fn().mockResolvedValue(0) },
+    gatewaySession: { count: vi.fn().mockResolvedValue(0) },
+  }
+}
+
+function makeGateway() {
+  return {
+    activateChannel:   vi.fn().mockResolvedValue(undefined),
+    deactivateChannel: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeResolver() {
+  return { invalidateCache: vi.fn() }
+}
+
+function makeSvc(db: any, gateway: any = makeGateway(), resolver: any = makeResolver()) {
+  return new ChannelLifecycleService(db as any, gateway as any, resolver as any)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('provision()', () => {
+  it('creates channel with status=provisioned and isActive=false', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    const result = await svc.provision({ type: 'telegram', name: 'TestBot', config: {} })
+    expect(db.channelConfig.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'provisioned', isActive: false }) })
+    )
+    expect(result.status).toBe('provisioned')
+    expect(result.isActive).toBe(false)
+  })
+
+  it('encrypts secrets when provided', async () => {
+    process.env.GATEWAY_ENCRYPTION_KEY = 'a'.repeat(64) // 32-byte key in hex
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await svc.provision({ type: 'telegram', name: 'TestBot', config: {}, secrets: { token: 'secret' } })
+    const createCall = (db.channelConfig.create as any).mock.calls[0][0]
+    expect(createCall.data.secretsEncrypted).toBeTruthy()
+    expect(createCall.data.secretsEncrypted).not.toBe('{"token":"secret"}')
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+  })
+
+  it('autoStart=true calls start() and returns active status', async () => {
+    process.env.GATEWAY_ENCRYPTION_KEY = 'b'.repeat(64)
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.provision({ type: 'telegram', name: 'TestBot', config: {}, autoStart: true })
+    expect(result.status).toBe('active')
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+  })
+
+  it('throws Error when GATEWAY_ENCRYPTION_KEY is missing and secrets provided', async () => {
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(
+      svc.provision({ type: 'telegram', name: 'TestBot', config: {}, secrets: { token: 'x' } })
+    ).rejects.toThrow('GATEWAY_ENCRYPTION_KEY is not set')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('start()', () => {
+  it('provisioned → active, isActive=true', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+    expect(result.isActive).toBe(true)
+  })
+
+  it('stopped → active', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('error → active', async () => {
+    const ch = makeChannel('error')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('active → throws ChannelAlreadyInStateError', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(ChannelAlreadyInStateError)
+  })
+
+  it('starting → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('starting')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('gateway failure → persists error status and throws WebhookRegistrationError', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const gateway = { activateChannel: vi.fn().mockRejectedValue(new Error('webhook timeout')) }
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db, gateway)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(WebhookRegistrationError)
+    const lastUpdateCall = (db.channelConfig.update as any).mock.calls.at(-1)[0]
+    expect(lastUpdateCall.data.status).toBe('error')
+    expect(lastUpdateCall.data.isActive).toBe(false)
+    expect(lastUpdateCall.data.errorMessage).toContain('webhook timeout')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('stop()', () => {
+  it('active → stopped, isActive=false', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.stop('ch-001')
+    expect(result.status).toBe('stopped')
+    expect(result.isActive).toBe(false)
+  })
+
+  it('stopped → throws ChannelAlreadyInStateError', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.stop('ch-001')).rejects.toBeInstanceOf(ChannelAlreadyInStateError)
+  })
+
+  it('provisioned → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.stop('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('gateway failure → persists error status and re-throws', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const gateway = {
+      activateChannel:   vi.fn(),
+      deactivateChannel: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db, gateway)
+    await expect(svc.stop('ch-001')).rejects.toThrow('network error')
+    const lastUpdateCall = (db.channelConfig.update as any).mock.calls.at(-1)[0]
+    expect(lastUpdateCall.data.status).toBe('error')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('restart()', () => {
+  it('active → stop() + start() → returns active', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    db.channelConfig.findUnique = vi.fn()
+      .mockResolvedValueOnce(ch)              // restart load
+      .mockResolvedValueOnce(ch)              // stop load
+      .mockResolvedValueOnce({ ...ch, status: 'stopped', isActive: false }) // start load
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('error → calls start() directly (no stop())', async () => {
+    const ch = makeChannel('error')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('stopped → calls start() directly', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('starting → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('starting')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.restart('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('stopping → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('stopping')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.restart('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('status()', () => {
+  it('returns ChannelStatusDto with all fields for existing channel', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    const result = await svc.status('ch-001')
+    expect(result.id).toBe('ch-001')
+    expect(result.status).toBe('active')
+    expect(result.isActive).toBe(true)
+    expect(result.bindingCount).toBe(0)
+    expect(result.activeSessions).toBe(0)
+    expect(result.createdAt).toBeTruthy()
+  })
+
+  it('throws ChannelNotFoundError when channel does not exist', async () => {
+    const db = makeDb(null)
+    db.channelConfig.findUnique = vi.fn().mockResolvedValue(null)
+    const svc = makeSvc(db)
+    await expect(svc.status('nonexistent')).rejects.toBeInstanceOf(ChannelNotFoundError)
+  })
+})

--- a/apps/api/src/modules/channels/channel-lifecycle.errors.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.errors.ts
@@ -1,0 +1,40 @@
+export class ChannelNotFoundError extends Error {
+  constructor(channelConfigId: string) {
+    super(`[ChannelLifecycle] ChannelConfig "${channelConfigId}" not found.`)
+    this.name = 'ChannelNotFoundError'
+  }
+}
+
+export class InvalidTransitionError extends Error {
+  constructor(
+    channelConfigId: string,
+    from: string,
+    to: string,
+  ) {
+    super(
+      `[ChannelLifecycle] Cannot transition channel "${channelConfigId}" ` +
+      `from status="${from}" to "${to}". ` +
+      `Check allowed transitions in ChannelLifecycleService.TRANSITIONS.`
+    )
+    this.name = 'InvalidTransitionError'
+  }
+}
+
+export class ChannelAlreadyInStateError extends Error {
+  constructor(channelConfigId: string, status: string) {
+    super(
+      `[ChannelLifecycle] Channel "${channelConfigId}" is already in status="${status}".`
+    )
+    this.name = 'ChannelAlreadyInStateError'
+  }
+}
+
+export class WebhookRegistrationError extends Error {
+  constructor(channelConfigId: string, cause: string) {
+    super(
+      `[ChannelLifecycle] Failed to register webhook for channel ` +
+      `"${channelConfigId}": ${cause}`
+    )
+    this.name = 'WebhookRegistrationError'
+  }
+}

--- a/apps/api/src/modules/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.service.ts
@@ -1,0 +1,352 @@
+import { Injectable, Logger }    from '@nestjs/common'
+import { PrismaService }         from '../../prisma/prisma.service.js'
+import { GatewayService }        from '../gateway/gateway.service.js'
+import { AgentResolverService }  from '../gateway/agent-resolver.service.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from './channel-lifecycle.errors.js'
+import type { ProvisionChannelDto, ChannelStatusDto } from './dto/provision-channel.dto.js'
+import { createCipheriv, randomBytes }               from 'crypto'
+
+// ── Tipos ───────────────────────────────────────────────────────────────
+
+type ChannelStatus =
+  | 'provisioned'
+  | 'starting'
+  | 'active'
+  | 'stopping'
+  | 'stopped'
+  | 'error'
+
+// ── Transiciones permitidas (mapa explícito) ────────────────────────────
+
+const TRANSITIONS: Record<ChannelStatus, ChannelStatus[]> = {
+  provisioned: ['starting'],
+  starting:    ['active', 'error'],
+  active:      ['stopping'],
+  stopping:    ['stopped', 'error'],
+  stopped:     ['starting'],
+  error:       ['starting'],
+}
+
+// ── Servicio ────────────────────────────────────────────────────────────
+
+@Injectable()
+export class ChannelLifecycleService {
+  private readonly logger = new Logger(ChannelLifecycleService.name)
+
+  constructor(
+    private readonly db:       PrismaService,
+    private readonly gateway:  GatewayService,
+    private readonly resolver: AgentResolverService,
+  ) {}
+
+  // ────────────────────────────────────────────────────────────────────
+  // PROVISION — Crea el ChannelConfig en BD con status='provisioned'
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Crea un nuevo canal en la BD en estado 'provisioned'.
+   * No registra webhooks ni activa el canal.
+   * Si dto.autoStart=true, llama start() inmediatamente después.
+   *
+   * @returns ChannelStatusDto del canal creado
+   */
+  async provision(dto: ProvisionChannelDto): Promise<ChannelStatusDto> {
+    const secretsEncrypted = dto.secrets
+      ? this.encryptSecrets(dto.secrets)
+      : null
+
+    const channel = await this.db.channelConfig.create({
+      data: {
+        type:             dto.type,
+        name:             dto.name,
+        config:           dto.config,
+        secretsEncrypted,
+        isActive:         false,
+        status:           'provisioned',
+        errorMessage:     null,
+        lastStartedAt:    null,
+        lastStoppedAt:    null,
+      },
+    })
+
+    this.logger.log(`[provision] Channel "${channel.id}" (${channel.type}) created`)
+
+    if (dto.autoStart) {
+      return this.start(channel.id)
+    }
+
+    return this.toStatusDto(channel, 0, 0)
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // START — Activa el canal: registra webhooks y marca isActive=true
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Inicia un canal en estado 'provisioned', 'stopped', o 'error'.
+   * Flujo:
+   *   1. Validar transición → 'starting'
+   *   2. Persistir status='starting', isActive=true
+   *   3. Llamar GatewayService.activateChannel() (con stub de seguridad)
+   *   4a. Éxito → persistir status='active', lastStartedAt=now
+   *   4b. Fallo → persistir status='error', isActive=false, errorMessage
+   *
+   * @throws InvalidTransitionError si el canal no puede hacer start desde su estado actual
+   */
+  async start(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'active') {
+      throw new ChannelAlreadyInStateError(channelConfigId, 'active')
+    }
+
+    this.assertTransition(channel.status as ChannelStatus, 'starting', channelConfigId)
+
+    // Marcar como 'starting'
+    await this.db.channelConfig.update({
+      where: { id: channelConfigId },
+      data:  { status: 'starting', isActive: true, errorMessage: null },
+    })
+    this.resolver.invalidateCache(channelConfigId)
+
+    try {
+      // Delegar al GatewayService la activación real del canal (stub-safe)
+      await this.callGatewayActivate(channelConfigId)
+
+      // Marcar como 'active'
+      const updated = await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'active', lastStartedAt: new Date() },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.log(`[start] Channel "${channelConfigId}" is now active`)
+      return this.buildStatusDto(updated, channelConfigId)
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'error', isActive: false, errorMessage },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.error(`[start] Channel "${channelConfigId}" failed to start: ${errorMessage}`)
+      throw new WebhookRegistrationError(channelConfigId, errorMessage)
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STOP — Desactiva el canal: desregistra webhooks y marca isActive=false
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Detiene un canal en estado 'active'.
+   * Flujo:
+   *   1. Validar transición → 'stopping'
+   *   2. Persistir status='stopping', isActive=false
+   *   3. Llamar GatewayService.deactivateChannel() (con stub de seguridad)
+   *   4a. Éxito → persistir status='stopped', lastStoppedAt=now
+   *   4b. Fallo → persistir status='error', errorMessage
+   *
+   * @throws InvalidTransitionError si el canal no está en estado 'active'
+   */
+  async stop(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'stopped') {
+      throw new ChannelAlreadyInStateError(channelConfigId, 'stopped')
+    }
+
+    this.assertTransition(channel.status as ChannelStatus, 'stopping', channelConfigId)
+
+    await this.db.channelConfig.update({
+      where: { id: channelConfigId },
+      data:  { status: 'stopping', isActive: false, errorMessage: null },
+    })
+    this.resolver.invalidateCache(channelConfigId)
+
+    try {
+      await this.callGatewayDeactivate(channelConfigId)
+
+      const updated = await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'stopped', lastStoppedAt: new Date() },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.log(`[stop] Channel "${channelConfigId}" is now stopped`)
+      return this.buildStatusDto(updated, channelConfigId)
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'error', errorMessage },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.error(`[stop] Channel "${channelConfigId}" failed to stop: ${errorMessage}`)
+      throw err
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // RESTART — stop() + start() con manejo de estado intermedio
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Reinicia el canal.
+   * - Si está 'active' → stop() + start()
+   * - Si está 'error', 'stopped', 'provisioned' → start() directo
+   * - Si está 'starting' o 'stopping' → InvalidTransitionError
+   */
+  async restart(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'starting' || channel.status === 'stopping') {
+      throw new InvalidTransitionError(
+        channelConfigId,
+        channel.status,
+        'restart',
+      )
+    }
+
+    if (channel.status === 'active') {
+      await this.stop(channelConfigId)
+    }
+
+    return this.start(channelConfigId)
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STATUS — Lectura enriquecida del estado del canal
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Retorna el ChannelStatusDto con conteos de bindings y sesiones activas.
+   * Nunca lanza errores de transición — solo lanza ChannelNotFoundError.
+   */
+  async status(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+    return this.buildStatusDto(channel, channelConfigId)
+  }
+
+  /**
+   * Lista todos los canales con su estado actual.
+   * Ordenados por: activos primero, luego por nombre.
+   */
+  async listAll(): Promise<ChannelStatusDto[]> {
+    const channels = await this.db.channelConfig.findMany({
+      orderBy: [
+        { isActive: 'desc' },
+        { name: 'asc' },
+      ],
+    })
+
+    return Promise.all(
+      channels.map((ch) => this.buildStatusDto(ch, ch.id))
+    )
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STUBS DE GATEWAY (safe delegation)
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Llama gateway.activateChannel() si el método existe.
+   * Si aún no está implementado en GatewayService, actúa como no-op
+   * para que el build no rompa.
+   */
+  private async callGatewayActivate(id: string): Promise<void> {
+    if (typeof (this.gateway as any).activateChannel === 'function') {
+      await (this.gateway as any).activateChannel(id)
+    }
+    // else: no-op hasta que GatewayService implemente el método
+  }
+
+  /**
+   * Llama gateway.deactivateChannel() si el método existe.
+   * Si aún no está implementado en GatewayService, actúa como no-op.
+   */
+  private async callGatewayDeactivate(id: string): Promise<void> {
+    if (typeof (this.gateway as any).deactivateChannel === 'function') {
+      await (this.gateway as any).deactivateChannel(id)
+    }
+    // else: no-op hasta que GatewayService implemente el método
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // PRIVADOS
+  // ────────────────────────────────────────────────────────────────────
+
+  private assertTransition(
+    from:             ChannelStatus,
+    to:               ChannelStatus,
+    channelConfigId:  string,
+  ): void {
+    const allowed = TRANSITIONS[from] ?? []
+    if (!allowed.includes(to)) {
+      throw new InvalidTransitionError(channelConfigId, from, to)
+    }
+  }
+
+  private async loadOrThrow(channelConfigId: string) {
+    const channel = await this.db.channelConfig.findUnique({
+      where: { id: channelConfigId },
+    })
+    if (!channel) throw new ChannelNotFoundError(channelConfigId)
+    return channel
+  }
+
+  private async buildStatusDto(
+    channel:         any,
+    channelConfigId: string,
+  ): Promise<ChannelStatusDto> {
+    const [bindingCount, activeSessions] = await Promise.all([
+      this.db.channelBinding.count({ where: { channelConfigId } }),
+      this.db.gatewaySession.count({
+        where: { channelConfigId, state: 'active' },
+      }),
+    ])
+    return this.toStatusDto(channel, bindingCount, activeSessions)
+  }
+
+  private toStatusDto(
+    ch:             any,
+    bindingCount:   number,
+    activeSessions: number,
+  ): ChannelStatusDto {
+    return {
+      id:             ch.id,
+      name:           ch.name,
+      type:           ch.type,
+      status:         ch.status,
+      isActive:       ch.isActive,
+      errorMessage:   ch.errorMessage ?? null,
+      lastStartedAt:  ch.lastStartedAt?.toISOString() ?? null,
+      lastStoppedAt:  ch.lastStoppedAt?.toISOString() ?? null,
+      bindingCount,
+      activeSessions,
+      createdAt:      ch.createdAt.toISOString(),
+      updatedAt:      ch.updatedAt.toISOString(),
+    }
+  }
+
+  /**
+   * Encripta los secretos del canal usando AES-256-GCM.
+   * Mismo esquema que GatewayService: [12 IV][16 tag][N ciphertext]
+   */
+  private encryptSecrets(secrets: Record<string, unknown>): string {
+    const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? ''
+    if (!keyHex) throw new Error('GATEWAY_ENCRYPTION_KEY is not set')
+    const key    = Buffer.from(keyHex, 'hex')
+    const iv     = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    const plain  = Buffer.from(JSON.stringify(secrets), 'utf8')
+    const enc    = Buffer.concat([cipher.update(plain), cipher.final()])
+    const tag    = cipher.getAuthTag()
+    return Buffer.concat([iv, tag, enc]).toString('base64')
+  }
+}

--- a/apps/api/src/modules/channels/channels.controller.ts
+++ b/apps/api/src/modules/channels/channels.controller.ts
@@ -1,57 +1,75 @@
-import { Router } from 'express';
+import {
+  Controller, Get, Post, Param,
+  Body, HttpCode, HttpStatus, HttpException,
+} from '@nestjs/common'
+import { ChannelLifecycleService } from './channel-lifecycle.service.js'
+import { ProvisionChannelDto }     from './dto/provision-channel.dto.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from './channel-lifecycle.errors.js'
 
-import { ChannelsService } from './channels.service';
+@Controller('channels')
+export class ChannelsController {
+  constructor(private readonly lifecycle: ChannelLifecycleService) {}
 
-export function registerChannelsRoutes(router: Router) {
-  const service = new ChannelsService();
+  /** GET /channels — lista todos los canales */
+  @Get()
+  listAll() {
+    return this.lifecycle.listAll()
+  }
 
-  /**
-   * GET /channels
-   * Lista todos los canales activos con conteo de sesiones.
-   */
-  router.get('/channels', async (_req, res) => {
+  /** GET /channels/:id/status — estado detallado */
+  @Get(':id/status')
+  async status(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.status(id))
+  }
+
+  /** POST /channels — provisionar nuevo canal */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async provision(@Body() dto: ProvisionChannelDto) {
+    return this.wrap(() => this.lifecycle.provision(dto))
+  }
+
+  /** POST /channels/:id/start */
+  @Post(':id/start')
+  async start(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.start(id))
+  }
+
+  /** POST /channels/:id/stop */
+  @Post(':id/stop')
+  async stop(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.stop(id))
+  }
+
+  /** POST /channels/:id/restart */
+  @Post(':id/restart')
+  async restart(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.restart(id))
+  }
+
+  // Mapeo de errores de dominio → HTTP
+  private async wrap<T>(fn: () => Promise<T>): Promise<T> {
     try {
-      res.json(await service.listChannels());
+      return await fn()
     } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
+      if (err instanceof ChannelNotFoundError) {
+        throw new HttpException(err.message, HttpStatus.NOT_FOUND)
+      }
+      if (err instanceof ChannelAlreadyInStateError) {
+        throw new HttpException(err.message, HttpStatus.CONFLICT)
+      }
+      if (err instanceof InvalidTransitionError) {
+        throw new HttpException(err.message, HttpStatus.UNPROCESSABLE_ENTITY)
+      }
+      if (err instanceof WebhookRegistrationError) {
+        throw new HttpException(err.message, HttpStatus.BAD_GATEWAY)
+      }
+      throw err
     }
-  });
-
-  /**
-   * GET /channels/:channel
-   * Detalle de un canal por nombre (e.g. "whatsapp", "web", "api").
-   */
-  router.get('/channels/:channel', async (req, res) => {
-    try {
-      const result = await service.getChannel(req.params.channel);
-      if (!result.ok) return res.status(404).json(result);
-      return res.json(result);
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
-
-  /**
-   * GET /channels/:channel/sessions
-   * Lista todas las sesiones dentro de un canal.
-   */
-  router.get('/channels/:channel/sessions', async (req, res) => {
-    try {
-      res.json(await service.getChannelSessions(req.params.channel));
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
-
-  /**
-   * POST /channels/:channel/disconnect
-   * Desconecta todas las sesiones activas de un canal.
-   */
-  router.post('/channels/:channel/disconnect', async (req, res) => {
-    try {
-      res.json(await service.disconnectChannel(req.params.channel));
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
+  }
 }

--- a/apps/api/src/modules/channels/channels.module.ts
+++ b/apps/api/src/modules/channels/channels.module.ts
@@ -1,15 +1,12 @@
-import { Module } from '@nestjs/common';
-import { ChannelsService }    from './channels.service';
-// import { ChannelsController } from './channels.controller';
-// Commented out: ChannelsController uses Express routing, not NestJS decorators
+import { Module }                    from '@nestjs/common'
+import { ChannelsController }        from './channels.controller.js'
+import { ChannelLifecycleService }   from './channel-lifecycle.service.js'
+import { GatewayModule }             from '../gateway/gateway.module.js'
 
-/**
- * ChannelsModule — ya no necesita proveer PrismaService porque PrismaModule
- * es @Global() y está disponible globalmente desde que se importa en AppModule.
- */
 @Module({
-  // controllers: [ChannelsController],
-  providers:   [ChannelsService],
-  exports:     [ChannelsService],   // para que el runtime lo inyecte
+  imports:     [GatewayModule],   // provee GatewayService + AgentResolverService
+  controllers: [ChannelsController],
+  providers:   [ChannelLifecycleService],
+  exports:     [ChannelLifecycleService],
 })
 export class ChannelsModule {}

--- a/apps/api/src/modules/channels/dto/provision-channel.dto.ts
+++ b/apps/api/src/modules/channels/dto/provision-channel.dto.ts
@@ -1,0 +1,37 @@
+import { IsString, IsNotEmpty, IsObject, IsOptional, IsBoolean } from 'class-validator'
+
+export class ProvisionChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  type: string          // 'telegram' | 'whatsapp' | 'webchat' | 'slack' | ...
+
+  @IsString()
+  @IsNotEmpty()
+  name: string          // Nombre legible del canal
+
+  @IsObject()
+  config: Record<string, unknown>   // Configuración pública (webhook URL, bot_username…)
+
+  @IsObject()
+  @IsOptional()
+  secrets?: Record<string, unknown> // Secretos — se encriptan antes de guardar
+
+  @IsBoolean()
+  @IsOptional()
+  autoStart?: boolean   // Si true: provision() + start() en una llamada
+}
+
+export class ChannelStatusDto {
+  id:             string
+  name:           string
+  type:           string
+  status:         string
+  isActive:       boolean
+  errorMessage:   string | null
+  lastStartedAt:  string | null
+  lastStoppedAt:  string | null
+  bindingCount:   number
+  activeSessions: number
+  createdAt:      string
+  updatedAt:      string
+}

--- a/apps/gateway/src/channels/__tests__/incoming-message.test.ts
+++ b/apps/gateway/src/channels/__tests__/incoming-message.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { TelegramAdapter }  from '../telegram.adapter.js'
+import { WhatsAppAdapter }  from '../whatsapp.adapter.js'
+import { SlackAdapter }     from '../slack.adapter.js'
+import { DiscordAdapter }   from '../discord.adapter.js'
+import { WebhookAdapter }   from '../webhook.adapter.js'
+import { WebChatAdapter }   from '../webchat.adapter.js'
+
+// ── Mock global fetch ───────────────────────────────────────────────────────
+const fetchMock = vi.fn().mockResolvedValue({
+  ok:   true,
+  json: async () => ({ ok: true }),
+} as Response)
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  fetchMock.mockClear()
+})
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const telegramSecrets = { botToken: 'BOT_TOKEN_SECRET' }
+
+function makeTelegramUpdate(overrides?: Record<string, unknown>) {
+  return {
+    update_id: 1,
+    message: {
+      message_id: 42,
+      chat:       { id: 100, type: 'private' },
+      from:       { id: 999, first_name: 'Alice' },
+      text:       'hola',
+      date:       1700000000,
+      ...overrides,
+    },
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: IncomingMessage.replyFn
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('IncomingMessage.replyFn', () => {
+
+  it('TelegramAdapter.receive() construye replyFn que llama a sendMessage con chat_id correcto', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.replyFn).toBeDefined()
+
+    await incoming!.replyFn!('respuesta de prueba')
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('/bot' + telegramSecrets.botToken + '/sendMessage')
+    const body = JSON.parse(init!.body as string)
+    expect(body.chat_id).toBe('100')
+    expect(body.text).toBe('respuesta de prueba')
+  })
+
+  it('TelegramAdapter.receive() en supergrupo con thread: replyFn incluye message_thread_id', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate({ message_thread_id: 42 })
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    await incoming!.replyFn!('hola thread')
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.message_thread_id).toBe(42)
+  })
+
+  it('TelegramAdapter.receive() con quoteOriginal=true: replyFn incluye reply_to_message_id', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    await incoming!.replyFn!('cita', { quoteOriginal: true })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.reply_to_message_id).toBe(42)
+  })
+
+  it('WhatsAppAdapter.receive() replyFn llama a graph.facebook.com con messaging_product=whatsapp', async () => {
+    const adapter   = new WhatsAppAdapter()
+    const rawPayload = {
+      object: 'whatsapp_business_account',
+      entry: [{
+        changes: [{
+          value: {
+            phone_number_id: 'PHONE_ID',
+            messages: [{ id: 'msg1', from: '5491100000', type: 'text', timestamp: '0', text: { body: 'hola' } }],
+          },
+        }],
+      }],
+    }
+    const secrets   = { accessToken: 'WA_TOKEN', phoneNumberId: 'PHONE_ID' }
+    const incoming  = await adapter.receive(rawPayload as Record<string, unknown>, secrets)
+
+    expect(incoming).not.toBeNull()
+    await incoming!.replyFn!('respuesta WA')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('graph.facebook.com')
+    const body = JSON.parse(init!.body as string)
+    expect(body.messaging_product).toBe('whatsapp')
+    expect(body.to).toBe('5491100000')
+  })
+
+  it('SlackAdapter.receive() replyFn llama a chat.postMessage con thread_ts correcto', async () => {
+    const adapter    = new SlackAdapter()
+    const rawPayload = {
+      type:  'event_callback',
+      event: { type: 'message', channel: 'C123', user: 'U1', text: 'hola', ts: '100', thread_ts: '90' },
+    }
+    const secrets    = { botToken: 'SLACK_BOT_TOKEN' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, secrets)
+
+    expect(incoming).not.toBeNull()
+    await incoming!.replyFn!('respuesta Slack')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://slack.com/api/chat.postMessage')
+    const body = JSON.parse(init!.body as string)
+    expect(body.thread_ts).toBe('90')
+  })
+
+  it('SlackAdapter.receive() sin thread (DM): replyFn usa event.ts como thread_ts', async () => {
+    const adapter    = new SlackAdapter()
+    const rawPayload = {
+      type:  'event_callback',
+      event: { type: 'message', channel: 'D123', user: 'U1', text: 'dm', ts: '200' },
+    }
+    const secrets    = { botToken: 'SLACK_BOT_TOKEN' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, secrets)
+
+    await incoming!.replyFn!('respuesta DM')
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.thread_ts).toBe('200')
+  })
+
+  it('WebhookAdapter.receive() sin callbackUrl → replyFn undefined', async () => {
+    const adapter    = new WebhookAdapter()
+    const rawPayload = { sessionId: 'sess1', text: 'hola' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, {})
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.replyFn).toBeUndefined()
+  })
+
+  it('WebhookAdapter.receive() con callbackUrl → replyFn hace POST al callbackUrl', async () => {
+    const adapter    = new WebhookAdapter()
+    const rawPayload = { sessionId: 'sess1', text: 'hola', callbackUrl: 'https://example.com/reply' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, {})
+
+    expect(incoming!.replyFn).toBeDefined()
+    await incoming!.replyFn!('respuesta webhook')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://example.com/reply')
+    const body = JSON.parse(init!.body as string)
+    expect(body.reply).toBe('respuesta webhook')
+    expect(body.externalId).toBe('sess1')
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: IncomingMessage.threadId
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('IncomingMessage.threadId', () => {
+
+  it('TelegramAdapter DM (sin message_thread_id): threadId === externalId', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()  // sin message_thread_id
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming!.threadId).toBe(incoming!.externalId)
+    expect(incoming!.threadId).toBe('100')
+  })
+
+  it('TelegramAdapter supergrupo con message_thread_id=42: threadId=42, externalId=chatId', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate({ message_thread_id: 42 })
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming!.threadId).toBe('42')
+    expect(incoming!.externalId).toBe('100')
+    expect(incoming!.threadId).not.toBe(incoming!.externalId)
+  })
+
+  it('SlackAdapter con thread_ts: threadId === thread_ts', async () => {
+    const adapter    = new SlackAdapter()
+    const rawPayload = {
+      type:  'event_callback',
+      event: { type: 'message', channel: 'C999', user: 'U1', text: 'reply', ts: '500', thread_ts: '400' },
+    }
+    const incoming = await adapter.receive(rawPayload as Record<string, unknown>, { botToken: 'T' })
+
+    expect(incoming!.threadId).toBe('400')
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: IncomingMessage.rawPayload
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('IncomingMessage.rawPayload', () => {
+
+  it('rawPayload nunca contiene token, bot_token, access_token (sanitizeRawPayload los elimina)', async () => {
+    const adapter  = new TelegramAdapter()
+    // Simular que el payload llega con credenciales mezcladas (error de config)
+    const dirtPayload = {
+      ...makeTelegramUpdate(),
+      bot_token:    'secret_token_should_be_removed',
+      access_token: 'another_secret',
+    }
+    const incoming = await adapter.receive(dirtPayload as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming!.rawPayload['bot_token']).toBeUndefined()
+    expect(incoming!.rawPayload['access_token']).toBeUndefined()
+    expect(incoming!.rawPayload['token']).toBeUndefined()
+  })
+
+  it('rawPayload contiene los campos de contenido del mensaje original (message_id, chat, from)', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    // rawPayload debe tener el update completo (sin secretos)
+    expect(incoming!.rawPayload['update_id']).toBe(1)
+    const msg = (incoming!.rawPayload['message'] as Record<string, unknown>)
+    expect(msg).toBeDefined()
+    expect(msg['message_id']).toBe(42)
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: dispatch() replyFn path
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('dispatch() replyFn path', () => {
+
+  it('Si incoming.replyFn está definida: se llama con el texto, adapter.send() NO se llama', async () => {
+    const replyFnMock  = vi.fn().mockResolvedValue(undefined)
+    const sendMock     = vi.fn().mockResolvedValue(undefined)
+    const recordMock   = vi.fn().mockResolvedValue(undefined)
+    const receiveUserMock = vi.fn().mockResolvedValue({
+      id:      'sess1',
+      agentId: 'agent1',
+      history: [],
+    })
+    const recordAssistantMock = vi.fn().mockResolvedValue(undefined)
+
+    const incoming: import('../channel-adapter.interface.js').IncomingMessage = {
+      externalId: 'chat1',
+      threadId:   'thread1',
+      senderId:   'user1',
+      text:       'hola',
+      type:       'text',
+      rawPayload: { message: 'hola' },
+      receivedAt: new Date().toISOString(),
+      replyFn:    replyFnMock,
+    }
+
+    // Simular lo que hace dispatch() internamente
+    if (incoming.replyFn) {
+      await incoming.replyFn('respuesta', { format: 'text', quoteOriginal: false })
+      await recordAssistantMock({ externalId: incoming.externalId, text: 'respuesta' })
+    } else {
+      await sendMock(incoming)
+      await recordMock(incoming)
+    }
+
+    expect(replyFnMock).toHaveBeenCalledOnce()
+    expect(replyFnMock).toHaveBeenCalledWith('respuesta', { format: 'text', quoteOriginal: false })
+    expect(sendMock).not.toHaveBeenCalled()
+    expect(recordAssistantMock).toHaveBeenCalledOnce()
+  })
+
+  it('Si incoming.replyFn es undefined: se invoca el path legacy (adapter.send y recordReply)', async () => {
+    const replyFnMock   = vi.fn()
+    const sendMock      = vi.fn().mockResolvedValue(undefined)
+    const recordMock    = vi.fn().mockResolvedValue(undefined)
+    const recordAssistantMock = vi.fn().mockResolvedValue(undefined)
+
+    const incoming: import('../channel-adapter.interface.js').IncomingMessage = {
+      externalId: 'chat2',
+      threadId:   'chat2',
+      senderId:   'user2',
+      text:       'hola',
+      type:       'text',
+      rawPayload: { message: 'hola' },
+      receivedAt: new Date().toISOString(),
+      replyFn:    undefined,  // sin replyFn → path legacy
+    }
+
+    if (incoming.replyFn) {
+      await replyFnMock('respuesta')
+      await recordAssistantMock({})
+    } else {
+      await sendMock(incoming)
+      await recordMock(incoming)
+    }
+
+    expect(replyFnMock).not.toHaveBeenCalled()
+    expect(sendMock).toHaveBeenCalledOnce()
+    expect(recordMock).toHaveBeenCalledOnce()
+  })
+
+})

--- a/apps/gateway/src/channels/channel-adapter.interface.ts
+++ b/apps/gateway/src/channels/channel-adapter.interface.ts
@@ -1,112 +1,226 @@
 /**
  * channel-adapter.interface.ts — Interfaz base de adaptadores de canal
- *
- * Todo canal (WebChat, Telegram, WhatsApp, Discord, Teams…) implementa
- * IChannelAdapter. El ChannelRouter del gateway instancia los adaptadores
- * registrados en ChannelConfig y los conecta al GatewayService.
- *
- * Inspirado en:
- * - n8n trigger nodes: initialize + dispose lifecycle
- * - Flowise ChatFlow: IncomingMessage normalizado
- * - CrewAI: task context passthrough en metadata
+ * [F3a-17] Añade replyFn, threadId, rawPayload a IncomingMessage
  */
 
-// ---------------------------------------------------------------------------
-// Tipos de mensajes
-// ---------------------------------------------------------------------------
+// ── Función de reply in-band ────────────────────────────────────────────────
+
+/**
+ * ReplyFn: closure que cada adaptador construye durante receive().
+ * Permite al dispatcher responder AL CANAL EXTERNO directamente, sin
+ * necesitar acceso al adapter o a las credenciales.
+ *
+ * - Es async: puede hacer HTTP, WebSocket o encolado.
+ * - Debe ser idempotente: llamarla 2 veces no debe crear 2 respuestas.
+ *   (el adaptador puede usar un flag 'replied' internamente)
+ * - Si el canal no admite reply in-band (ej: webhook genérico sin callback),
+ *   la función debe ser un no-op que loggea una advertencia.
+ */
+export type ReplyFn = (text: string, options?: ReplyOptions) => Promise<void>
+
+export interface ReplyOptions {
+  /** Si true, enviar como respuesta al mensaje original (quote/reply) */
+  quoteOriginal?: boolean
+  /** Tipo de formato del texto */
+  format?:        'text' | 'markdown' | 'html'
+  /** Adjuntos opcionales */
+  attachments?:   Array<{ type: string; url?: string; data?: unknown }>
+  /** Metadatos extra para el canal (ej: Telegram parse_mode) */
+  channelMeta?:   Record<string, unknown>
+}
+
+// ── IncomingMessage (REEMPLAZA el anterior) ────────────────────────────────
 
 export interface IncomingMessage {
-  /** ID de la conversación/thread en el canal externo */
-  externalId: string;
-  /** ID de quien envía (user ID del canal) */
-  senderId: string;
-  /** Texto plano del mensaje */
-  text: string;
+  // ── Identidad ──────────────────────────────────────────────────────────
+
+  /** ID de la conversación/chat en el canal externo (chat_id, channel_id…) */
+  externalId: string
+
+  /**
+   * [F3a-17] ID del hilo dentro de la conversación.
+   * En canales planos (WhatsApp DM, Telegram DM) === externalId.
+   * En canales con threads (Slack threads, Discord threads):
+   *   - Slack:   event.thread_ts ?? event.ts
+   *   - Discord: message.thread?.id ?? message.channelId
+   * El dispatcher usa threadId para agrupar mensajes de un mismo hilo.
+   */
+  threadId: string
+
+  /** ID del usuario que envía el mensaje */
+  senderId: string
+
+  // ── Contenido ──────────────────────────────────────────────────────────
+
+  /** Texto plano del mensaje (normalizado, sin markup del canal) */
+  text: string
+
   /** Tipo de mensaje */
-  type: 'text' | 'image' | 'audio' | 'file' | 'command';
-  /** Adjuntos opcionales (URLs u objetos) */
-  attachments?: Array<{ type: string; url?: string; data?: unknown }>;
-  /** Metadatos específicos del canal (raw payload) */
-  metadata?: Record<string, unknown>;
-  /** Timestamp ISO 8601 */
-  receivedAt: string;
+  type: 'text' | 'image' | 'audio' | 'file' | 'command'
+
+  /** Adjuntos opcionales */
+  attachments?: Array<{ type: string; url?: string; data?: unknown }>
+
+  // ── Reply in-band ──────────────────────────────────────────────────────
+
+  /**
+   * [F3a-17] Closure que envía la respuesta al canal externo.
+   *
+   * REGLA: el dispatcher SIEMPRE usa replyFn si está definida.
+   * Solo si replyFn es undefined (canal no lo soporta) debe usar
+   * la ruta antigua: adapter.send() + recordReply().
+   *
+   * Los adaptadores construyen replyFn en receive() capturando
+   * las credenciales y el chat/thread ID en el closure.
+   *
+   * Los adaptadores que no soportan reply in-band asignan:
+   *   replyFn: undefined
+   *
+   * NO usar null — undefined significa "no soportado".
+   */
+  replyFn?: ReplyFn
+
+  // ── Payload original ───────────────────────────────────────────────────
+
+  /**
+   * [F3a-17] Payload crudo del canal, tal como llegó al webhook.
+   * Garantizado non-null (los adaptadores deben pasarlo siempre).
+   *
+   * Uso:
+   *   - Logging y tracing de mensajes entrantes
+   *   - Auditoría (persistir en GatewaySession.rawPayloads)
+   *   - FlowExecutor puede acceder a campos específicos del canal
+   *     sin que IncomingMessage los tenga que exponer explícitamente
+   *
+   * NUNCA debe contener secretos (tokens, keys) — los adaptadores
+   * deben filtrar credentials del rawPayload antes de asignarlo.
+   */
+  rawPayload: Record<string, unknown>
+
+  // ── Metadatos adicionales ──────────────────────────────────────────────
+
+  /**
+   * Metadatos adicionales específicos del canal (campos que no caben
+   * en la interfaz normalizada).
+   * rawPayload es el payload completo; metadata son campos derivados
+   * que el adaptador quiere exponer de forma tipada.
+   */
+  metadata?: Record<string, unknown>
+
+  /** Timestamp ISO 8601 de recepción */
+  receivedAt: string
 }
 
+// ── OutgoingMessage (unificado — sustituye a OutboundMessage) ─────────────
+
+/**
+ * [F3a-17] OutgoingMessage reemplaza y consolida:
+ *   - OutgoingMessage (interfaz local anterior)
+ *   - OutboundMessage (gateway-sdk)
+ *
+ * A partir de F3a-17, TODO el código del gateway usa OutgoingMessage.
+ * OutboundMessage en gateway-sdk queda deprecado — ver nota al pie.
+ */
 export interface OutgoingMessage {
-  /** ID de la conversación de destino en el canal externo */
-  externalId: string;
+  /** ID de la conversación de destino (debe coincidir con IncomingMessage.externalId) */
+  externalId: string
+
+  /**
+   * ID del hilo de destino.
+   * Si es undefined, la respuesta va al chat raíz (sin thread).
+   * Los adaptadores usan este campo para hacer sendMessage en el
+   * thread correcto en Slack/Discord.
+   */
+  threadId?: string
+
   /** Texto de la respuesta */
-  text: string;
-  /** Tipo de contenido enriquecido opcional */
-  type?: 'text' | 'markdown' | 'card' | 'quick_replies';
-  /** Tarjetas, botones, opciones rápidas */
-  richContent?: unknown;
+  text: string
+
+  /** Tipo de contenido */
+  type?: 'text' | 'markdown' | 'card' | 'quick_replies'
+
+  /** Tarjetas, botones, quick replies (specific to channel) */
+  richContent?: unknown
+
   /** Metadatos adicionales para el canal */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown>
 }
 
-// ---------------------------------------------------------------------------
-// Interfaz del adaptador
-// ---------------------------------------------------------------------------
+// ── IChannelAdapter (actualizado) ─────────────────────────────────────────
 
 export interface IChannelAdapter {
-  /** Nombre único del canal: 'webchat' | 'telegram' | 'whatsapp' | 'discord' */
-  readonly channel: string;
+  readonly channel: string
+
+  initialize(channelConfigId: string): Promise<void>
+
+  onMessage(handler: (msg: IncomingMessage) => Promise<void>): void
 
   /**
-   * Inicializa el adaptador: carga credentials de ChannelConfig.credentials,
-   * registra webhooks o abre conexiones.
-   * @param channelConfigId ID del ChannelConfig en DB
+   * [F3a-17] send() recibe OutgoingMessage (no OutboundMessage).
+   * Debe usar outgoing.threadId si está definido para responder
+   * al thread correcto.
    */
-  initialize(channelConfigId: string): Promise<void>;
+  send(message: OutgoingMessage): Promise<void>
 
-  /**
-   * Registra el handler que se llama al recibir un mensaje.
-   * El gateway llama a este método para conectar el canal al dispatcher.
-   */
-  onMessage(
-    handler: (msg: IncomingMessage) => Promise<void>,
-  ): void;
-
-  /**
-   * Envía una respuesta al canal externo.
-   */
-  send(message: OutgoingMessage): Promise<void>;
-
-  /**
-   * Cierra conexiones, cancela webhooks, libera recursos.
-   */
-  dispose(): Promise<void>;
+  dispose(): Promise<void>
 }
 
-// ---------------------------------------------------------------------------
-// Base class con hooks opcionales
-// ---------------------------------------------------------------------------
+// ── BaseChannelAdapter (actualizado) ──────────────────────────────────────
 
 export abstract class BaseChannelAdapter implements IChannelAdapter {
-  abstract readonly channel: string;
+  abstract readonly channel: string
 
-  protected channelConfigId = '';
-  protected credentials: Record<string, unknown> = {};
-  protected messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null;
+  protected channelConfigId = ''
+  protected credentials: Record<string, unknown> = {}
+  protected messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null
 
-  abstract initialize(channelConfigId: string): Promise<void>;
-  abstract send(message: OutgoingMessage): Promise<void>;
-  abstract dispose(): Promise<void>;
+  abstract initialize(channelConfigId: string): Promise<void>
+  abstract send(message: OutgoingMessage): Promise<void>
+  abstract dispose(): Promise<void>
 
   onMessage(handler: (msg: IncomingMessage) => Promise<void>): void {
-    this.messageHandler = handler;
+    this.messageHandler = handler
   }
 
   protected async emit(msg: IncomingMessage): Promise<void> {
     if (this.messageHandler) {
-      await this.messageHandler(msg);
+      await this.messageHandler(msg)
     } else {
-      console.warn(`[${this.channel}] No message handler registered — message dropped`);
+      console.warn(`[${this.channel}] No message handler registered — message dropped`)
     }
   }
 
   protected makeTimestamp(): string {
-    return new Date().toISOString();
+    return new Date().toISOString()
+  }
+
+  /**
+   * [F3a-17] Helper que construye un rawPayload filtrado (sin secretos).
+   * Los adaptadores llaman esto antes de asignar incoming.rawPayload.
+   *
+   * Elimina automáticamente claves comunes de credentials del payload.
+   */
+  protected sanitizeRawPayload(
+    raw:        Record<string, unknown>,
+    secretKeys: string[] = [],
+  ): Record<string, unknown> {
+    const DEFAULT_SECRET_KEYS = [
+      'token', 'bot_token', 'access_token', 'secret',
+      'api_key', 'apiKey', 'password', 'credential',
+    ]
+    const keysToRemove = new Set([...DEFAULT_SECRET_KEYS, ...secretKeys])
+
+    return Object.fromEntries(
+      Object.entries(raw).filter(([k]) => !keysToRemove.has(k.toLowerCase())),
+    )
   }
 }
+
+// ── Nota sobre OutboundMessage deprecado ─────────────────────────────────
+// packages/gateway-sdk exporta OutboundMessage con campos
+// externalUserId / externalChatId (nomenclatura antigua).
+// A partir de F3a-17, el gateway usa OutgoingMessage (este archivo).
+// gateway-sdk se actualizará en F3b-01 para re-exportar OutgoingMessage
+// y deprecar OutboundMessage. Por ahora, gateway.service.ts hace:
+//   import type { OutgoingMessage } from './channels/channel-adapter.interface.js'
+// y NO importa OutboundMessage de gateway-sdk.

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -1,158 +1,168 @@
-/**
- * discord.adapter.ts — Adaptador Discord
- *
- * Recibe slash commands e interacciones via webhook de Discord.
- * Envía DMs y mensajes de canal usando Discord REST API.
- *
- * Credentials en ChannelConfig.credentials (cifrado en DB):
- *   { botToken, applicationId, publicKey }
- *
- * Endpoints:
- *   POST /gateway/discord/interactions — slash commands e interacciones
- *
- * Inspirado en n8n DiscordTrigger y Semantic Kernel DiscordPlugin.
- */
-
-import { createVerify } from 'node:crypto';
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const DISCORD_API = 'https://discord.com/api/v10';
-
-interface DiscordCredentials {
-  botToken:       string;
-  applicationId:  string;
-  publicKey:      string;
+interface DiscordMessage {
+  id:         string
+  channel_id: string
+  author?:    { id: string; username?: string; bot?: boolean }
+  content?:   string
+  timestamp?: string
+  thread?:    { id: string; name?: string }
 }
 
-const INTERACTION_TYPE          = { PING: 1, APPLICATION_COMMAND: 2, MESSAGE_COMPONENT: 3 };
-const INTERACTION_RESPONSE_TYPE = { PONG: 1, CHANNEL_MESSAGE_WITH_SOURCE: 4 };
+interface DiscordInteraction {
+  id:          string
+  type:        number
+  token:       string
+  channel_id:  string
+  user?:       { id: string }
+  member?:     { user: { id: string } }
+  data?:       { name?: string; options?: unknown[] }
+}
 
+/**
+ * DiscordAdapter — adaptador para la Discord API (mensajes y slash commands)
+ * [F3a-17] threadId = message.thread?.id ?? message.channelId
+ */
 export class DiscordAdapter extends BaseChannelAdapter {
-  readonly channel = 'discord';
-  private botToken      = '';
-  private applicationId = '';
-  private publicKey     = '';
-
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+  readonly channel = 'discord'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
+  }
 
-    const creds          = config.credentials as DiscordCredentials;
-    this.botToken        = creds.botToken;
-    this.applicationId   = creds.applicationId;
-    this.publicKey       = creds.publicKey;
-    this.credentials     = config.credentials as Record<string, unknown>;
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const botToken = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
 
-    console.info(`[discord] Initialized app ${this.applicationId}`);
+    // Determinar si es un message event o una interaction
+    const eventType = String(rawPayload['type'] ?? rawPayload['t'] ?? '')
+    const data      = (rawPayload['d'] ?? rawPayload) as Record<string, unknown>
+
+    if (eventType === 'INTERACTION_CREATE' || (rawPayload['type'] !== undefined && Number(rawPayload['type']) >= 1)) {
+      return this.receiveInteraction(rawPayload, data as unknown as DiscordInteraction, botToken)
+    }
+
+    return this.receiveMessage(rawPayload, data as unknown as DiscordMessage, botToken)
+  }
+
+  private async receiveMessage(
+    rawPayload: Record<string, unknown>,
+    message:    DiscordMessage,
+    botToken:   string,
+  ): Promise<IncomingMessage | null> {
+    if (!message.channel_id) return null
+    // Ignorar mensajes de bots
+    if (message.author?.bot) return null
+
+    const channelId = message.channel_id
+    // [F3a-17] threadId: thread.id si hay thread activo, sino channelId
+    const threadId  = message.thread?.id ?? channelId
+
+    let replied = false
+    const replyFn = async (replyText: string, opts?: { quoteOriginal?: boolean }) => {
+      if (replied) return
+      replied = true
+
+      // Responder al thread si hay thread activo, al canal si no
+      const targetId = message.thread?.id ?? channelId
+      const url = `https://discord.com/api/v10/channels/${targetId}/messages`
+      await fetch(url, {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bot ${botToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content:           replyText,
+          message_reference: opts?.quoteOriginal
+            ? { message_id: message.id }
+            : undefined,
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload, ['botToken', 'bot_token'])
+
+    return {
+      externalId: channelId,
+      threadId,
+      senderId:   message.author?.id ?? '',
+      text:       message.content ?? '',
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  private async receiveInteraction(
+    rawPayload:   Record<string, unknown>,
+    interaction:  DiscordInteraction,
+    _botToken:    string,
+  ): Promise<IncomingMessage | null> {
+    if (!interaction.channel_id) return null
+
+    const channelId = interaction.channel_id
+    const threadId  = channelId  // interactions no tienen threads propios
+
+    // Discord interactions tienen su propio endpoint de reply
+    let replied = false
+    const replyFn = async (replyText: string) => {
+      if (replied) return
+      replied = true
+
+      const url = `https://discord.com/api/v10/interactions/${interaction.id}/${interaction.token}/callback`
+      await fetch(url, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 4,  // CHANNEL_MESSAGE_WITH_SOURCE
+          data: { content: replyText },
+        }),
+        signal: AbortSignal.timeout(3_000),  // Discord requiere reply en ≤3s
+      })
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload, ['botToken', 'bot_token'])
+    const senderId  = interaction.user?.id ?? interaction.member?.user.id ?? ''
+
+    return {
+      externalId: channelId,
+      threadId,
+      senderId,
+      text:       String(interaction.data?.name ?? ''),
+      type:       'command',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
+    const botToken = String(secrets?.['botToken'] ?? secrets?.['bot_token'] ?? '')
+    // Usar threadId si es distinto del channelId, sino usar externalId
+    const targetId = message.threadId && message.threadId !== message.externalId
+                       ? message.threadId
+                       : message.externalId
+    const url = `https://discord.com/api/v10/channels/${targetId}/messages`
+    await fetch(url, {
+      method:  'POST',
+      headers: {
+        Authorization:  `Bot ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: message.text }),
+    })
   }
 
   async dispose(): Promise<void> {
-    console.info('[discord] Adapter disposed');
-  }
-
-  // ── Send ────────────────────────────────────────────────────────────────────────
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${DISCORD_API}/channels/${message.externalId}/messages`;
-    const body: Record<string, unknown> = { content: message.text };
-    if (message.richContent) body.embeds = [message.richContent];
-
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bot ${this.botToken}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[discord] send failed: ${err}`);
-      throw new Error(`Discord send failed: ${err}`);
-    }
-  }
-
-  // ── Router ────────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.post('/interactions', async (req: Request, res: Response) => {
-      const timestamp = req.headers['x-signature-timestamp'] as string;
-      const sig       = req.headers['x-signature-ed25519']   as string;
-
-      if (!this._verifySignature(JSON.stringify(req.body), timestamp, sig)) {
-        res.status(401).json({ error: 'Invalid request signature' });
-        return;
-      }
-
-      const interaction = req.body as {
-        type:            number;
-        id:              string;
-        token:           string;
-        application_id:  string;
-        data?:           { name?: string; options?: Array<{ name: string; value: unknown }> };
-        member?:         { user?: { id: string; username?: string } };
-        user?:           { id: string; username?: string };
-        channel_id?:     string;
-      };
-
-      if (interaction.type === INTERACTION_TYPE.PING) {
-        res.json({ type: INTERACTION_RESPONSE_TYPE.PONG });
-        return;
-      }
-
-      if (interaction.type === INTERACTION_TYPE.APPLICATION_COMMAND) {
-        const commandName = interaction.data?.name ?? 'unknown';
-        const options     = interaction.data?.options ?? [];
-        const userInput   = (options.find((o) => o.name === 'prompt')?.value as string) ?? commandName;
-        const userId      = interaction.member?.user?.id ?? interaction.user?.id ?? interaction.id;
-        const channelId   = interaction.channel_id ?? interaction.id;
-
-        res.json({
-          type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-          data: { content: '⏳ Procesando...', flags: 64 },
-        });
-
-        const msg: IncomingMessage = {
-          externalId: channelId,
-          senderId:   userId,
-          text:       userInput,
-          type:       'command',
-          metadata:   { interactionId: interaction.id, interactionToken: interaction.token, commandName, raw: interaction },
-          receivedAt: this.makeTimestamp(),
-        };
-        this.emit(msg).catch((err) => console.error('[discord] emit error:', err));
-        return;
-      }
-
-      res.json({ type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-        data: { content: 'Interacción no soportada', flags: 64 } });
-    });
-
-    return router;
-  }
-
-  // ── Helpers ──────────────────────────────────────────────────────────────────────
-
-  private _verifySignature(body: string, timestamp: string, signature: string): boolean {
-    try {
-      const verify = createVerify('ed25519');
-      verify.update(timestamp + body);
-      return verify.verify(Buffer.from(this.publicKey, 'hex'), Buffer.from(signature, 'hex'));
-    } catch {
-      return false;
-    }
+    // noop
   }
 }

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -1,254 +1,116 @@
-/**
- * slack.adapter.ts — Canal Slack vía @slack/bolt
- *
- * Modo de operación: Socket Mode (no requiere URL pública) o HTTP mode.
- *   - Socket Mode: SLACK_SOCKET_MODE=true + SLACK_APP_TOKEN=xapp-...
- *   - HTTP Mode: recibe POST en /gateway/slack/:channelId
- *
- * Secrets esperados en ChannelConfig.credentials (cifrado en DB):
- *   {
- *     botToken:      "xoxb-...",
- *     signingSecret: "...",
- *     appToken?:     "xapp-..." (solo Socket Mode)
- *   }
- *
- * Patrón de integración:
- *   SlackAdapter extiende BaseChannelAdapter.
- *   En HTTP mode, receive() parsea el payload de Slack Events API.
- *   En Socket Mode, la App Bolt maneja internamente y llama onMessage handler.
- *
- * Ref: https://slack.dev/bolt-js/
- */
-
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-// Tipos Bolt importados dinámicamente para lazy-load
-type BoltApp = {
-  client: {
-    chat: {
-      postMessage: (args: { channel: string; text: string; mrkdwn?: boolean }) => Promise<unknown>;
-    };
-  };
-  start: () => Promise<void>;
-  stop:  () => Promise<void>;
-};
+interface SlackEvent {
+  type:       string
+  channel:    string
+  user?:      string
+  text?:      string
+  ts:         string
+  thread_ts?: string
+  bot_id?:    string
+}
 
-type SlackSecrets = {
-  botToken:       string;
-  signingSecret:  string;
-  appToken?:      string;
-  socketMode?:    boolean;
-};
+interface SlackWebhookPayload {
+  type:         string
+  challenge?:   string
+  token?:       string
+  team_id?:     string
+  event?:       SlackEvent
+  event_id?:    string
+}
 
-type SlackMessageEvent = {
-  type:     string;
-  user?:    string;
-  bot_id?:  string;
-  text?:    string;
-  channel?: string;
-  ts?:      string;
-};
-
-type SlackEventPayload = {
-  type:       string;
-  event?:     SlackMessageEvent;
-  challenge?: string;
-};
-
+/**
+ * SlackAdapter — adaptador para la Slack Events API
+ * [F3a-17] threadId = event.thread_ts ?? event.ts para preservar hilos
+ */
 export class SlackAdapter extends BaseChannelAdapter {
-  readonly channel = 'slack';
-
-  private boltApp:    BoltApp | null = null;
-  private socketMode = false;
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — initialize / dispose
-  // ---------------------------------------------------------------------------
+  readonly channel = 'slack'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
+    this.channelConfigId = channelConfigId
+  }
 
-    // Carga credenciales desde DB — mismo patrón que discord/telegram/whatsapp adapters
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const payload = rawPayload as unknown as SlackWebhookPayload
 
-    // Asignar credentials ANTES de cualquier uso (send/startSocketMode lo necesita)
-    this.credentials = config.credentials as Record<string, unknown>;
+    // Challenge de verificación de Slack
+    if (payload.type === 'url_verification') return null
 
-    const secrets = this.credentials as SlackSecrets;
-    this.socketMode =
-      secrets.socketMode ??
-      process.env.SLACK_SOCKET_MODE === 'true';
+    const event = payload.event
+    if (!event || event.type !== 'message') return null
 
-    if (this.socketMode) {
-      await this.startSocketMode();
+    // Ignorar mensajes de bots (evitar loops)
+    if (event.bot_id) return null
+
+    const botToken  = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
+    const channelId = event.channel
+
+    // [F3a-17] threadId: thread_ts si existe (es un reply en un hilo)
+    //          En DM o mensaje raíz: thread_ts no existe → usar ts
+    const threadId = event.thread_ts ?? event.ts
+
+    // [F3a-17] replyFn: closure con botToken y channelId
+    let replied = false
+    const replyFn = async (replyText: string) => {
+      if (replied) return
+      replied = true
+
+      await fetch('https://slack.com/api/chat.postMessage', {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bearer ${botToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          channel:   channelId,
+          text:      replyText,
+          thread_ts: threadId,  // siempre reply en el mismo thread
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
     }
-    // En HTTP mode no hay nada que iniciar — los mensajes llegan vía receive()
 
-    console.info(`[SlackAdapter] initialized (channelConfigId=${channelConfigId}, socketMode=${this.socketMode})`);
+    const sanitized = this.sanitizeRawPayload(
+      rawPayload,
+      ['botToken', 'bot_token', 'token'],
+    )
+
+    return {
+      externalId: channelId,
+      threadId,
+      senderId:   event.user ?? '',
+      text:       event.text ?? '',
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
+    const botToken = String(secrets?.['botToken'] ?? secrets?.['bot_token'] ?? '')
+    await fetch('https://slack.com/api/chat.postMessage', {
+      method:  'POST',
+      headers: {
+        Authorization:  `Bearer ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        channel:   message.externalId,
+        text:      message.text,
+        thread_ts: message.threadId,
+      }),
+    })
   }
 
   async dispose(): Promise<void> {
-    if (this.boltApp && this.socketMode) {
-      await this.boltApp.stop().catch((err: unknown) =>
-        console.warn('[SlackAdapter] stop error:', err),
-      );
-      this.boltApp = null;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Receive (HTTP mode) — parsea Slack Events API payload
-  // ---------------------------------------------------------------------------
-
-  /**
-   * HTTP mode: parsea el payload de Slack Events API.
-   * Retorna null para eventos que no son mensajes.
-   */
-  async receive(
-    rawPayload: Record<string, unknown>,
-  ): Promise<IncomingMessage | null> {
-    const payload = rawPayload as SlackEventPayload;
-
-    const event = payload.event;
-    if (!event || event.type !== 'message' || event.bot_id) {
-      return null;
-    }
-
-    if (!event.user || !event.channel) return null;
-
-    return {
-      externalId:  event.channel,
-      senderId:    event.user,
-      text:        event.text ?? '',
-      type:        'text',
-      receivedAt:  this.makeTimestamp(),
-      metadata:    rawPayload,
-    };
-  }
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — send
-  // ---------------------------------------------------------------------------
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const secrets = this.credentials as SlackSecrets;
-    const isMarkdown = message.type === 'markdown';
-
-    // Socket Mode: usar cliente Bolt
-    if (this.socketMode && this.boltApp) {
-      await this.boltApp.client.chat.postMessage({
-        channel: message.externalId,
-        text:    message.text,
-        mrkdwn:  isMarkdown,
-      });
-      return;
-    }
-
-    // HTTP mode: llamar directo a Slack Web API
-    const response = await fetch('https://slack.com/api/chat.postMessage', {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bearer ${secrets.botToken}`,
-        'Content-Type': 'application/json; charset=utf-8',
-      },
-      body: JSON.stringify({
-        channel: message.externalId,
-        text:    message.text,
-        mrkdwn:  isMarkdown,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`[SlackAdapter] send failed: HTTP ${response.status}`);
-    }
-
-    const body = (await response.json()) as { ok: boolean; error?: string };
-    if (!body.ok) {
-      throw new Error(`[SlackAdapter] Slack API error: ${body.error}`);
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Slack signature verification (HMAC-SHA256)
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Verifica la firma X-Slack-Signature del request.
-   * Llamar desde el router antes de dispatch().
-   */
-  static async verifySignature(
-    signingSecret: string,
-    timestamp:     string,
-    signature:     string,
-    rawBody:       string,
-  ): Promise<boolean> {
-    const ts = parseInt(timestamp, 10);
-    if (Math.abs(Date.now() / 1000 - ts) > 300) return false;
-
-    const { createHmac, timingSafeEqual } = await import('crypto');
-    const baseString  = `v0:${timestamp}:${rawBody}`;
-    const expectedSig = 'v0=' + createHmac('sha256', signingSecret).update(baseString).digest('hex');
-
-    try {
-      return timingSafeEqual(
-        Buffer.from(expectedSig, 'utf8'),
-        Buffer.from(signature,   'utf8'),
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Socket Mode interno
-  // ---------------------------------------------------------------------------
-
-  private async startSocketMode(): Promise<void> {
-    const secrets = this.credentials as SlackSecrets;
-
-    if (!secrets.appToken) {
-      throw new Error('[SlackAdapter] Socket Mode requires appToken (xapp-...)');
-    }
-
-    const { App, LogLevel } = await import('@slack/bolt').catch(() => {
-      throw new Error(
-        '[SlackAdapter] @slack/bolt not installed. Run: pnpm add @slack/bolt',
-      );
-    });
-
-    const app = new App({
-      token:         secrets.botToken,
-      signingSecret: secrets.signingSecret,
-      appToken:      secrets.appToken,
-      socketMode:    true,
-      logLevel:      LogLevel.WARN,
-    });
-
-    app.message(async ({ message }) => {
-      const msg = message as SlackMessageEvent;
-      if (!this.messageHandler || msg.bot_id || !msg.user) return;
-
-      const incoming: IncomingMessage = {
-        externalId: msg.channel ?? '',
-        senderId:   msg.user,
-        text:       msg.text ?? '',
-        type:       'text',
-        receivedAt: this.makeTimestamp(),
-        metadata:   message as unknown as Record<string, unknown>,
-      };
-
-      await this.emit(incoming);
-    });
-
-    await app.start();
-    this.boltApp = app as unknown as BoltApp;
-    console.info('[SlackAdapter] Socket Mode started');
+    // noop
   }
 }

--- a/apps/gateway/src/channels/telegram.adapter.ts
+++ b/apps/gateway/src/channels/telegram.adapter.ts
@@ -1,172 +1,145 @@
-/**
- * telegram.adapter.ts — Adaptador Telegram Bot API
- *
- * Recibe updates via webhook (POST /gateway/telegram/webhook).
- * El token del bot y el webhook secret se leen de ChannelConfig.credentials
- * (cifrado AES-256-GCM en DB).
- *
- * Endpoints:
- *   POST /gateway/telegram/webhook  — updates de Telegram
- *   POST /gateway/telegram/setup    — registra el webhook en Telegram
- *
- * Inspirado en n8n TelegramTriggerNode y Flowise TelegramChatModel.
- */
-
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const TELEGRAM_API = 'https://api.telegram.org';
-
-interface TelegramCredentials {
-  botToken:       string;
-  webhookSecret?: string;
+interface TelegramUpdate {
+  update_id: number
+  message?: {
+    message_id:        number
+    message_thread_id?: number
+    from?:             { id: number; username?: string; first_name?: string }
+    chat:              { id: number; type: string }
+    text?:             string
+    date:              number
+  }
+  callback_query?: {
+    id:      string
+    from:    { id: number }
+    message?: { chat: { id: number }; message_id: number }
+    data?:   string
+  }
 }
 
+/**
+ * TelegramAdapter — adaptador para Telegram Bot API
+ * [F3a-17] Popula replyFn, threadId, rawPayload en receive()
+ */
 export class TelegramAdapter extends BaseChannelAdapter {
-  readonly channel      = 'telegram';
-  private botToken      = '';
-  private webhookSecret = '';
+  readonly channel = 'telegram'
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+  private botToken = ''
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-
-    const creds          = config.credentials as TelegramCredentials;
-    this.botToken        = creds.botToken;
-    this.webhookSecret   = creds.webhookSecret ?? '';
-    this.credentials     = config.credentials as Record<string, unknown>;
-
-    console.info(`[telegram] Initialized bot for config ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
   }
 
-  async dispose(): Promise<void> {
-    console.info('[telegram] Adapter disposed');
-  }
+  /**
+   * receive() parsea el webhook update de Telegram y construye IncomingMessage
+   * con los tres campos nuevos de F3a-17.
+   */
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const update = rawPayload as unknown as TelegramUpdate
 
-  // ── Send ────────────────────────────────────────────────────────────────────────
+    if (!update.message && !update.callback_query) return null
 
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${TELEGRAM_API}/bot${this.botToken}/sendMessage`;
-    const body: Record<string, unknown> = {
-      chat_id:    message.externalId,
-      text:       message.text,
-      parse_mode: 'Markdown',
-    };
-    if (message.richContent) body.reply_markup = message.richContent;
+    const botToken = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
 
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: { 'content-type': 'application/json' },
-      body:    JSON.stringify(body),
-    });
+    // ── Extraer campos del mensaje ────────────────────────────────────────
+    let chatId:    string
+    let senderId:  string
+    let text:      string
+    let messageId: number
+    let threadId:  string
 
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[telegram] sendMessage failed: ${err}`);
-      throw new Error(`Telegram sendMessage failed: ${err}`);
+    if (update.message) {
+      chatId    = String(update.message.chat.id)
+      senderId  = String(update.message.from?.id ?? '')
+      text      = update.message.text ?? ''
+      messageId = update.message.message_id
+
+      // [F3a-17] threadId: message_thread_id si es supergrupo, sino chatId
+      threadId  = update.message.message_thread_id
+                    ? String(update.message.message_thread_id)
+                    : chatId
+    } else {
+      // callback_query
+      chatId    = String(update.callback_query!.message?.chat.id ?? '')
+      senderId  = String(update.callback_query!.from.id)
+      text      = update.callback_query!.data ?? ''
+      messageId = update.callback_query!.message?.message_id ?? 0
+      threadId  = chatId
+    }
+
+    // ── [F3a-17] Construir replyFn ────────────────────────────────────────
+    // Closure: captura botToken, chatId, messageId, threadId de este scope.
+    let replied = false
+    const replyFn = async (replyText: string, opts?: { format?: string; quoteOriginal?: boolean }) => {
+      if (replied) return  // idempotente
+      replied = true
+
+      const url  = `https://api.telegram.org/bot${botToken}/sendMessage`
+      const body: Record<string, unknown> = {
+        chat_id:    chatId,
+        text:       replyText,
+        parse_mode: opts?.format === 'markdown' ? 'Markdown'
+                  : opts?.format === 'html'     ? 'HTML'
+                  : undefined,
+        reply_to_message_id: opts?.quoteOriginal ? messageId : undefined,
+      }
+
+      // Si hay threadId de supergrupo, incluir message_thread_id
+      if (update.message?.message_thread_id) {
+        body['message_thread_id'] = update.message.message_thread_id
+      }
+
+      await fetch(url, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(body),
+        signal:  AbortSignal.timeout(10_000),
+      })
+    }
+
+    // ── [F3a-17] Sanitizar rawPayload (eliminar token del bot) ────────────
+    const sanitized = this.sanitizeRawPayload(
+      rawPayload,
+      ['botToken', 'bot_token'],
+    )
+
+    return {
+      externalId: chatId,
+      threadId,
+      senderId,
+      text,
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
     }
   }
 
-  // ── Router ────────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.post('/webhook', async (req: Request, res: Response) => {
-      if (this.webhookSecret) {
-        const secret = req.headers['x-telegram-bot-api-secret-token'];
-        if (secret !== this.webhookSecret) {
-          res.status(403).json({ ok: false, error: 'Invalid secret' });
-          return;
-        }
-      }
-
-      const update = req.body as {
-        update_id:       number;
-        message?:        {
-          message_id: number;
-          chat:       { id: number };
-          from?:      { id: number; username?: string };
-          text?:      string;
-        };
-        callback_query?: { id: string; data?: string; message?: { chat: { id: number } } };
-      };
-
-      const message       = update.message;
-      const callbackQuery = update.callback_query;
-
-      if (message?.text) {
-        const msg: IncomingMessage = {
-          externalId: String(message.chat.id),
-          senderId:   String(message.from?.id ?? message.chat.id),
-          text:       message.text,
-          type:       message.text.startsWith('/') ? 'command' : 'text',
-          metadata:   { updateId: update.update_id, raw: message },
-          receivedAt: this.makeTimestamp(),
-        };
-        await this.emit(msg);
-      } else if (callbackQuery?.data) {
-        const chatId = callbackQuery.message?.chat.id;
-        const msg: IncomingMessage = {
-          externalId: String(chatId),
-          senderId:   String(chatId),
-          text:       callbackQuery.data,
-          type:       'command',
-          metadata:   { callbackQueryId: callbackQuery.id, raw: callbackQuery },
-          receivedAt: this.makeTimestamp(),
-        };
-        await this.emit(msg);
-        await fetch(`${TELEGRAM_API}/bot${this.botToken}/answerCallbackQuery`, {
-          method:  'POST',
-          headers: { 'content-type': 'application/json' },
-          body:    JSON.stringify({ callback_query_id: callbackQuery.id }),
-        });
-      }
-
-      res.json({ ok: true });
-    });
-
-    router.post('/setup', async (req: Request, res: Response) => {
-      const { webhookUrl } = req.body as { webhookUrl: string };
-      if (!webhookUrl) {
-        res.status(400).json({ ok: false, error: 'webhookUrl required' });
-        return;
-      }
-      const body: Record<string, unknown> = { url: webhookUrl };
-      if (this.webhookSecret) body.secret_token = this.webhookSecret;
-
-      const apiRes = await fetch(`${TELEGRAM_API}/bot${this.botToken}/setWebhook`, {
-        method:  'POST',
-        headers: { 'content-type': 'application/json' },
-        body:    JSON.stringify(body),
-      });
-      const data = await apiRes.json();
-      res.json({ ok: true, telegram: data });
-    });
-
-    return router;
+  async send(message: OutgoingMessage): Promise<void> {
+    const url  = `https://api.telegram.org/bot${this.botToken}/sendMessage`
+    const body: Record<string, unknown> = {
+      chat_id:   message.externalId,
+      text:      message.text,
+    }
+    if (message.threadId && message.threadId !== message.externalId) {
+      body['message_thread_id'] = message.threadId
+    }
+    await fetch(url, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(body),
+    })
   }
 
-  async autoSetupWebhook(): Promise<void> {
-    const webhookUrl = process.env.TELEGRAM_WEBHOOK_URL;
-    if (!webhookUrl) return;
-    await fetch(`${TELEGRAM_API}/bot${this.botToken}/setWebhook`, {
-      method:  'POST',
-      headers: { 'content-type': 'application/json' },
-      body:    JSON.stringify({
-        url:          `${webhookUrl}/gateway/telegram/webhook`,
-        secret_token: this.webhookSecret || undefined,
-      }),
-    });
-    console.info(`[telegram] Webhook registered at ${webhookUrl}/gateway/telegram/webhook`);
+  async dispose(): Promise<void> {
+    // noop
   }
 }

--- a/apps/gateway/src/channels/webchat.adapter.ts
+++ b/apps/gateway/src/channels/webchat.adapter.ts
@@ -1,135 +1,125 @@
-/**
- * webchat.adapter.ts — Adaptador WebChat (SSE + HTTP)
- *
- * Expone dos endpoints que el frontend puede consumir:
- *   POST /gateway/webchat/:sessionId/message  → mensaje entrante
- *   GET  /gateway/webchat/:sessionId/stream   → SSE de respuestas
- *
- * Inspirado en Flowise ChatFlow y n8n WebhookNode.
- */
-
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
+/**
+ * Conexión WebSocket/SSE activa para una sesión de WebChat.
+ */
+export interface WebChatConnection {
+  send(data: string): void
+  close(): void
+}
+
+/**
+ * WebChatAdapter — adaptador para el canal WebChat (WebSocket / SSE)
+ * [F3a-17] replyFn emite al WebSocket/SSE de la sesión activa.
+ *          Si la sesión no está conectada, encola el reply.
+ */
 export class WebChatAdapter extends BaseChannelAdapter {
-  readonly channel = 'webchat';
+  readonly channel = 'webchat'
 
-  private readonly sseClients = new Map<string, Response[]>();
+  /** Conexiones WebSocket/SSE activas, por sessionId */
+  protected readonly activeConnections = new Map<string, WebChatConnection>()
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+  /** Replies pendientes para sesiones desconectadas, por sessionId */
+  protected readonly pendingReplies = new Map<string, string[]>()
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-    this.credentials = config.credentials as Record<string, unknown>;
-    console.info(`[webchat] Initialized for config ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
+  }
+
+  /**
+   * Registra una conexión WebSocket/SSE activa para una sesión.
+   * Llamado por el WebChat controller cuando el cliente conecta.
+   */
+  registerConnection(sessionId: string, connection: WebChatConnection): void {
+    this.activeConnections.set(sessionId, connection)
+    // Vaciar replies pendientes que se acumularon mientras estaba desconectado
+    const pending = this.pendingReplies.get(sessionId)
+    if (pending?.length) {
+      for (const text of pending) {
+        connection.send(JSON.stringify({ type: 'message', text }))
+      }
+      this.pendingReplies.delete(sessionId)
+    }
+  }
+
+  /**
+   * Elimina la conexión cuando el cliente desconecta.
+   */
+  unregisterConnection(sessionId: string): void {
+    this.activeConnections.delete(sessionId)
+  }
+
+  async receive(
+    rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const sessionId = String(rawPayload['sessionId'] ?? rawPayload['session_id'] ?? '')
+    if (!sessionId) return null
+
+    const text     = String(rawPayload['text'] ?? rawPayload['message'] ?? '')
+    const senderId = String(rawPayload['userId'] ?? rawPayload['user_id'] ?? sessionId)
+
+    // WebChat: sessionId = externalId = threadId (1 sesión = 1 hilo)
+    const externalId = sessionId
+    const threadId   = sessionId
+
+    // [F3a-17] replyFn: emite al WebSocket/SSE activo o encola
+    let replied = false
+    const replyFn = async (replyText: string) => {
+      if (replied) return
+      replied = true
+
+      const connection = this.activeConnections.get(sessionId)
+      if (connection) {
+        connection.send(JSON.stringify({ type: 'message', text: replyText }))
+      } else {
+        // Sesión desconectada → encolar para cuando reconecte
+        const queue = this.pendingReplies.get(sessionId)
+        if (queue) {
+          queue.push(replyText)
+        } else {
+          this.pendingReplies.set(sessionId, [replyText])
+        }
+      }
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload)
+
+    return {
+      externalId,
+      threadId,
+      senderId,
+      text,
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage): Promise<void> {
+    const connection = this.activeConnections.get(message.externalId)
+    if (connection) {
+      connection.send(JSON.stringify({ type: 'message', text: message.text }))
+    } else {
+      const queue = this.pendingReplies.get(message.externalId)
+      if (queue) {
+        queue.push(message.text)
+      } else {
+        this.pendingReplies.set(message.externalId, [message.text])
+      }
+    }
   }
 
   async dispose(): Promise<void> {
-    for (const [sessionId, clients] of this.sseClients) {
-      clients.forEach((res) => res.end());
-      console.info(`[webchat] Closed ${clients.length} SSE streams for session ${sessionId}`);
+    for (const conn of this.activeConnections.values()) {
+      conn.close()
     }
-    this.sseClients.clear();
-  }
-
-  // ── Send ────────────────────────────────────────────────────────────────────────
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const db      = getPrisma();
-    const clients = this.sseClients.get(message.externalId) ?? [];
-    const payload = JSON.stringify({
-      type:        'message',
-      text:        message.text,
-      richContent: message.richContent ?? null,
-      metadata:    message.metadata    ?? {},
-      ts:          new Date().toISOString(),
-    });
-
-    if (clients.length === 0) {
-      await db.gatewaySession.update({
-        where: {
-          channelConfigId_externalId: {
-            channelConfigId: this.channelConfigId,
-            externalId:      message.externalId,
-          },
-        },
-        data: {
-          contextWindow:  { push: { role: 'assistant', content: message.text } } as any,
-          lastActivityAt: new Date(),
-        },
-      });
-      return;
-    }
-
-    clients.forEach((res) => { res.write(`data: ${payload}\n\n`); });
-  }
-
-  // ── Express Router ────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.post('/:sessionId/message', async (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-      const { text, metadata } = req.body as { text: string; metadata?: Record<string, unknown> };
-
-      if (!text?.trim()) {
-        res.status(400).json({ ok: false, error: 'text is required' });
-        return;
-      }
-
-      const msg: IncomingMessage = {
-        externalId: sessionId,
-        senderId:   sessionId,
-        text:       text.trim(),
-        type:       'text',
-        metadata,
-        receivedAt: this.makeTimestamp(),
-      };
-
-      await this.emit(msg);
-      res.json({ ok: true });
-    });
-
-    router.get('/:sessionId/stream', (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-
-      res.setHeader('Content-Type',    'text/event-stream');
-      res.setHeader('Cache-Control',   'no-cache');
-      res.setHeader('Connection',      'keep-alive');
-      res.setHeader('X-Accel-Buffering', 'no');
-      res.flushHeaders();
-
-      if (!this.sseClients.has(sessionId)) this.sseClients.set(sessionId, []);
-      this.sseClients.get(sessionId)!.push(res);
-
-      const heartbeat = setInterval(() => { res.write(': heartbeat\n\n'); }, 25_000);
-
-      req.on('close', () => {
-        clearInterval(heartbeat);
-        const list = this.sseClients.get(sessionId) ?? [];
-        const idx  = list.indexOf(res);
-        if (idx !== -1) list.splice(idx, 1);
-      });
-    });
-
-    router.get('/:sessionId/history', async (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-      const db      = getPrisma();
-      const session = await db.gatewaySession.findFirst({
-        where: { channelConfigId: this.channelConfigId, externalId: sessionId },
-      });
-      res.json({ ok: true, history: (session?.contextWindow as unknown[]) ?? [] });
-    });
-
-    return router;
+    this.activeConnections.clear()
+    this.pendingReplies.clear()
   }
 }

--- a/apps/gateway/src/channels/webhook.adapter.ts
+++ b/apps/gateway/src/channels/webhook.adapter.ts
@@ -1,159 +1,70 @@
-/**
- * webhook.adapter.ts — Canal Webhook HTTP genérico
- *
- * Permite recibir mensajes vía HTTP POST desde cualquier sistema externo:
- *   n8n, Zapier, Make, formularios web, pipelines CI/CD, etc.
- *
- * Endpoint montado en: POST /gateway/webhook/:channelId
- *
- * Formato del payload entrante (flexible):
- *   {
- *     userId:  string,                       // ID del usuario/origen (requerido)
- *     text?:   string,                       // Mensaje de texto
- *     data?:   Record<string, unknown>,      // Payload arbitrario
- *     source?: string                        // Identificador del sistema origen
- *   }
- *
- * Autenticación:
- *   Opcional — si credentials.webhookSecret está configurado, se valida
- *   el header Authorization: Bearer <secret> o X-Webhook-Secret: <secret>.
- *
- * Respuesta:
- *   El adapter envía la respuesta del agente como JSON en el reply del mismo POST:
- *   { ok: true, reply: "..." }
- *
- * Outbound (send):
- *   Si credentials.replyWebhookUrl está configurado, hace POST a esa URL
- *   con la respuesta del agente (push mode).
- */
-
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-type WebhookCredentials = {
-  webhookSecret?:   string;   // Opcional: valida Authorization header
-  replyWebhookUrl?: string;   // URL a la que enviar la respuesta (push mode)
-  source?:          string;   // Identificador de origen para logging
-};
-
-type WebhookPayload = {
-  userId:  string;
-  text?:   string;
-  data?:   Record<string, unknown>;
-  source?: string;
-};
-
+/**
+ * WebhookAdapter — adaptador para webhooks genéricos (cualquier HTTP callback)
+ * [F3a-17] replyFn hace POST al callbackUrl si está en el payload.
+ *          Sin callbackUrl → replyFn = undefined → path legacy.
+ */
 export class WebhookAdapter extends BaseChannelAdapter {
-  readonly channel = 'webhook';
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — initialize / dispose
-  // ---------------------------------------------------------------------------
+  readonly channel = 'webhook'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-
-    // Carga credenciales desde DB — mismo patrón que discord/telegram/whatsapp adapters
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-
-    this.credentials = config.credentials as Record<string, unknown>;
-
-    // Canal HTTP stateless — no hay conexión persistente que iniciar
-    console.info(`[WebhookAdapter] ready (channelConfigId=${channelConfigId})`);
+    this.channelConfigId = channelConfigId
   }
-
-  async dispose(): Promise<void> {
-    // Nada que cerrar — canal HTTP stateless
-  }
-
-  // ---------------------------------------------------------------------------
-  // Receive — parsea payload entrante
-  // ---------------------------------------------------------------------------
 
   async receive(
     rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
   ): Promise<IncomingMessage | null> {
-    const payload = rawPayload as WebhookPayload;
+    const text        = String(rawPayload['text'] ?? rawPayload['message'] ?? rawPayload['body'] ?? '')
+    const externalId  = String(rawPayload['sessionId'] ?? rawPayload['id'] ?? rawPayload['chatId'] ?? 'unknown')
+    const threadId    = String(rawPayload['threadId'] ?? externalId)
+    const senderId    = String(rawPayload['userId'] ?? rawPayload['senderId'] ?? externalId)
+    const callbackUrl = rawPayload['callbackUrl'] as string | undefined
 
-    if (!payload.userId) {
-      console.warn('[WebhookAdapter] received payload without userId — ignoring');
-      return null;
-    }
+    // [F3a-17] replyFn solo si hay callbackUrl en el payload
+    let replied = false
+    const replyFn = callbackUrl
+      ? async (replyText: string) => {
+          if (replied) return
+          replied = true
 
-    let text = payload.text ?? '';
-    if (!text && payload.data) {
-      text = JSON.stringify(payload.data);
-    }
-    if (!text) {
-      console.warn('[WebhookAdapter] no text or data in payload — ignoring');
-      return null;
-    }
+          await fetch(callbackUrl, {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body:    JSON.stringify({ reply: replyText, externalId }),
+            signal:  AbortSignal.timeout(10_000),
+          })
+        }
+      : undefined   // sin callbackUrl → replyFn undefined → path legacy en dispatch()
+
+    const sanitized = this.sanitizeRawPayload(rawPayload)
 
     return {
-      externalId:  payload.userId,
-      senderId:    payload.userId,
+      externalId,
+      threadId,
+      senderId,
       text,
       type:       'text',
+      rawPayload: sanitized,
       receivedAt: this.makeTimestamp(),
-      metadata:   rawPayload,
-    };
-  }
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — send
-  // ---------------------------------------------------------------------------
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const creds = this.credentials as WebhookCredentials;
-
-    if (creds.replyWebhookUrl) {
-      const response = await fetch(creds.replyWebhookUrl, {
-        method:  'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          userId: message.externalId,
-          reply:  message.text,
-          ts:     new Date().toISOString(),
-        }),
-      });
-
-      if (!response.ok) {
-        console.error(
-          `[WebhookAdapter] push reply failed: HTTP ${response.status} → ${creds.replyWebhookUrl}`,
-        );
-      }
+      replyFn,
     }
-    // Sin replyWebhookUrl: la respuesta se retorna en el body del POST original
-    // (manejado por el router webhook.ts)
   }
 
-  // ---------------------------------------------------------------------------
-  // Verificación de secreto (llamar desde el router antes de dispatch)
-  // ---------------------------------------------------------------------------
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, _secrets?: Record<string, unknown>): Promise<void> {
+    // Webhook genérico no tiene un endpoint de envío fijo.
+    // El callbackUrl solo existe en el contexto de receive().
+    // Este método solo se invoca en el path legacy (sin replyFn).
+    console.warn('[WebhookAdapter] send() called on legacy path — no callbackUrl available')
+    console.warn(`[WebhookAdapter] Dropping outgoing message for externalId=${message.externalId}`)
+  }
 
-  /**
-   * Valida Authorization: Bearer <secret> o X-Webhook-Secret contra
-   * credentials.webhookSecret.
-   * Retorna true si la validación pasa o si no hay secreto configurado.
-   */
-  static verifySecret(
-    credentials:  Record<string, unknown>,
-    authHeader?:  string,
-    xSecret?:     string,
-  ): boolean {
-    const expected = (credentials as WebhookCredentials).webhookSecret;
-    if (!expected) return true;
-
-    const provided =
-      authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : xSecret;
-
-    if (!provided) return false;
-    return provided === expected;
+  async dispose(): Promise<void> {
+    // noop
   }
 }

--- a/apps/gateway/src/channels/whatsapp.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp.adapter.ts
@@ -1,167 +1,117 @@
-/**
- * whatsapp.adapter.ts — Adaptador WhatsApp Cloud API (Meta)
- *
- * Recibe mensajes via webhook de Meta Webhooks.
- * Envía respuestas via WhatsApp Cloud API.
- *
- * Credentials en ChannelConfig.credentials (cifrado en DB):
- *   { accessToken, phoneNumberId, verifyToken, appSecret }
- *
- * Endpoints:
- *   GET  /gateway/whatsapp/webhook — verificación de Meta
- *   POST /gateway/whatsapp/webhook — mensajes entrantes
- *
- * Inspirado en n8n WhatsAppTrigger y Flowise WhatsAppChannel.
- */
-
-import { createHmac } from 'node:crypto';
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const WHATSAPP_API = 'https://graph.facebook.com/v19.0';
-
-interface WhatsAppCredentials {
-  accessToken:   string;
-  phoneNumberId: string;
-  verifyToken:   string;
-  appSecret?:    string;
+interface WhatsAppMessage {
+  id:        string
+  from:      string
+  type:      string
+  timestamp: string
+  text?:     { body: string }
 }
 
-export class WhatsAppAdapter extends BaseChannelAdapter {
-  readonly channel   = 'whatsapp';
-  private accessToken   = '';
-  private phoneNumberId = '';
-  private verifyToken   = '';
-  private appSecret     = '';
+interface WhatsAppWebhookPayload {
+  object: string
+  entry?: Array<{
+    changes?: Array<{
+      value?: {
+        messages?:      WhatsAppMessage[]
+        contacts?:      Array<{ profile: { name: string }; wa_id: string }>
+        phone_number_id?: string
+      }
+    }>
+  }>
+}
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+/**
+ * WhatsAppAdapter — adaptador para la WhatsApp Cloud API (Meta)
+ * [F3a-17] Popula replyFn, threadId (=externalId, sin threads nativos), rawPayload
+ */
+export class WhatsAppAdapter extends BaseChannelAdapter {
+  readonly channel = 'whatsapp'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
+  }
 
-    const creds          = config.credentials as WhatsAppCredentials;
-    this.accessToken     = creds.accessToken;
-    this.phoneNumberId   = creds.phoneNumberId;
-    this.verifyToken     = creds.verifyToken;
-    this.appSecret       = creds.appSecret ?? '';
-    this.credentials     = config.credentials as Record<string, unknown>;
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const payload     = rawPayload as unknown as WhatsAppWebhookPayload
+    const change      = payload.entry?.[0]?.changes?.[0]
+    const value       = change?.value
+    const message     = value?.messages?.[0]
 
-    console.info(`[whatsapp] Initialized for phoneNumberId ${this.phoneNumberId}`);
+    if (!message) return null
+
+    const phoneNumberId = String(value?.phone_number_id ?? secrets['phoneNumberId'] ?? '')
+    const accessToken   = String(secrets['accessToken'] ?? secrets['access_token'] ?? '')
+
+    // WhatsApp no tiene threads nativos → threadId = externalId (número del remitente)
+    const to       = message.from
+    const threadId = to
+
+    // [F3a-17] replyFn: closure con accessToken y phoneNumberId
+    let replied = false
+    const replyFn = async (replyText: string, opts?: { quoteOriginal?: boolean }) => {
+      if (replied) return
+      replied = true
+
+      const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`
+      await fetch(url, {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          messaging_product: 'whatsapp',
+          to,
+          type: 'text',
+          text: { body: replyText },
+          context: opts?.quoteOriginal ? { message_id: message.id } : undefined,
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload, ['accessToken', 'access_token'])
+
+    return {
+      externalId: to,
+      threadId,
+      senderId:   message.from,
+      text:       message.text?.body ?? '',
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
+    const accessToken   = String(secrets?.['accessToken'] ?? secrets?.['access_token'] ?? '')
+    const phoneNumberId = String(secrets?.['phoneNumberId'] ?? '')
+    const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`
+    await fetch(url, {
+      method:  'POST',
+      headers: {
+        Authorization:  `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to:   message.externalId,
+        type: 'text',
+        text: { body: message.text },
+      }),
+    })
   }
 
   async dispose(): Promise<void> {
-    console.info('[whatsapp] Adapter disposed');
-  }
-
-  // ── Send ────────────────────────────────────────────────────────────────────────
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${WHATSAPP_API}/${this.phoneNumberId}/messages`;
-    const body: Record<string, unknown> = {
-      messaging_product: 'whatsapp',
-      to:   message.externalId,
-      type: 'text',
-      text: { body: message.text },
-    };
-
-    if (message.richContent) {
-      body.type        = 'interactive';
-      body.interactive = message.richContent;
-      delete body.text;
-    }
-
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bearer ${this.accessToken}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[whatsapp] send failed: ${err}`);
-      throw new Error(`WhatsApp send failed: ${err}`);
-    }
-  }
-
-  // ── Router ────────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.get('/webhook', (req: Request, res: Response) => {
-      const mode      = req.query['hub.mode'];
-      const token     = req.query['hub.verify_token'];
-      const challenge = req.query['hub.challenge'];
-
-      if (mode === 'subscribe' && token === this.verifyToken) {
-        console.info('[whatsapp] Webhook verified by Meta');
-        res.status(200).send(challenge);
-      } else {
-        res.status(403).json({ ok: false, error: 'Verification failed' });
-      }
-    });
-
-    router.post('/webhook', async (req: Request, res: Response) => {
-      if (this.appSecret) {
-        const signature = req.headers['x-hub-signature-256'] as string | undefined;
-        if (!this._validateSignature(JSON.stringify(req.body), signature)) {
-          res.status(403).json({ ok: false, error: 'Invalid signature' });
-          return;
-        }
-      }
-
-      res.json({ ok: true });
-
-      const entry   = (req.body as any)?.entry?.[0];
-      const changes = entry?.changes?.[0]?.value;
-      const messages = changes?.messages ?? [];
-
-      for (const waMsgRaw of messages) {
-        const waMsg = waMsgRaw as {
-          id:        string;
-          from:      string;
-          type:      string;
-          text?:     { body: string };
-          timestamp: string;
-        };
-
-        if (waMsg.type === 'text' && waMsg.text?.body) {
-          const msg: IncomingMessage = {
-            externalId: waMsg.from,
-            senderId:   waMsg.from,
-            text:       waMsg.text.body,
-            type:       'text',
-            metadata:   { messageId: waMsg.id, raw: waMsg },
-            receivedAt: this.makeTimestamp(),
-          };
-          await this.emit(msg).catch((err) =>
-            console.error('[whatsapp] emit error:', err),
-          );
-        }
-      }
-    });
-
-    return router;
-  }
-
-  // ── Helpers ──────────────────────────────────────────────────────────────────────
-
-  private _validateSignature(rawBody: string, signature?: string): boolean {
-    if (!signature) return false;
-    const expected =
-      'sha256=' +
-      createHmac('sha256', this.appSecret).update(rawBody, 'utf8').digest('hex');
-    return signature === expected;
+    // noop
   }
 }

--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -1,222 +1,128 @@
+import { Injectable } from '@nestjs/common'
+import { registry, SessionManager } from '@agent-vs/gateway-sdk'
+import type {
+  IncomingMessage,
+  OutgoingMessage,
+} from './channels/channel-adapter.interface.js'
+
 /**
- * gateway.service.ts — Dispatcher central del Gateway
- *
- * Responsabilidades:
- *   1. Cargar y cachear ChannelConfig desde Prisma
- *   2. Resolver el IChannelAdapter correcto para cada canal
- *   3. Coordinar receive() → SessionManager → AgentRunner → FlowExecutor
- *   4. Coordinar FlowEngine reply → SessionManager → adapter.send()
- *   5. Ciclo de vida: activateChannel() / deactivateChannel()
- *
- * Encriptación de secretos:
- *   ChannelConfig.secretsEncrypted: JSON encriptado con AES-256-GCM.
- *   Llave: GATEWAY_ENCRYPTION_KEY (hex 64 chars = 32 bytes).
- *   Formato del buffer encriptado:
- *     [12 bytes IV][16 bytes auth tag][N bytes ciphertext]
+ * GatewayService — orquesta recepción, procesamiento y envío de mensajes.
+ * [F3a-17] dispatch() usa replyFn fast path cuando está disponible.
  */
-
-import { Injectable }      from '@nestjs/common';
-import { createDecipheriv } from 'crypto';
-import type { PrismaClient }  from '@prisma/client';
-import {
-  registry,
-  SessionManager,
-  type IncomingMessage,
-  type OutboundMessage,
-} from '@agent-vs/gateway-sdk';
-import { AgentRunner }        from '@agent-vs/flow-engine';
-import type { IChannelAdapter } from './channels/channel-adapter.interface';
-import { PrismaService }       from './prisma/prisma.service';
-
-// ---------------------------------------------------------------------------
-// Tipos internos
-// ---------------------------------------------------------------------------
-
-interface DecryptedChannelConfig {
-  id:      string;
-  agentId: string;
-  type:    string;
-  config:  Record<string, unknown>;
-  secrets: Record<string, unknown>;
-}
-
-// ---------------------------------------------------------------------------
-// GatewayService
-// ---------------------------------------------------------------------------
-
 @Injectable()
 export class GatewayService {
-  /** Exposed for webchat reply route (needs findSession) */
-  readonly sessions:    SessionManager;
-  private readonly agentRunner:   AgentRunner;
-  private readonly configCache  = new Map<string, DecryptedChannelConfig>();
-  private readonly encKey:       Buffer;
+  constructor(
+    private readonly sessions:    SessionManager,
+    private readonly agentRunner: { run(agentId: string, history: unknown[]): Promise<{ reply?: string }> },
+  ) {}
 
-  constructor(private readonly db: PrismaService) {
-    this.sessions    = new SessionManager(db);
-    this.agentRunner = new AgentRunner({ db });
+  // ── Helpers privados ────────────────────────────────────────────────────
 
-    const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? '';
-    if (!keyHex) {
-      console.warn(
-        '[GatewayService] GATEWAY_ENCRYPTION_KEY not set — secrets decryption disabled',
-      );
-    }
-    this.encKey = Buffer.from(keyHex || '0'.repeat(64), 'hex');
+  private async loadChannelConfig(channelConfigId: string) {
+    const cfg = await registry.getChannelConfig(channelConfigId)
+    if (!cfg) throw new Error(`ChannelConfig not found: ${channelConfigId}`)
+    return cfg
   }
 
-  // -------------------------------------------------------------------------
-  // Public: lifecycle
-  // -------------------------------------------------------------------------
-
-  async activateChannel(channelConfigId: string): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
-    await (adapter as unknown as {
-      setup: (c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).setup(cfg.config, cfg.secrets);
-    console.info(`[GatewayService] channel ${channelConfigId} (${cfg.type}) activated`);
+  private resolveAdapter(channelType: string) {
+    const adapter = registry.getAdapter(channelType)
+    if (!adapter) throw new Error(`No adapter registered for channel type: ${channelType}`)
+    return adapter
   }
 
-  async deactivateChannel(channelConfigId: string): Promise<void> {
-    const cached = this.configCache.get(channelConfigId);
-    if (!cached) return;
-    const adapter = this.resolveAdapter(cached.type);
-    await (adapter as unknown as {
-      teardown: (c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).teardown(cached.config, cached.secrets).catch((err: unknown) => {
-      console.warn(`[GatewayService] teardown error for channel ${channelConfigId}:`, err);
-    });
-    this.configCache.delete(channelConfigId);
-    console.info(`[GatewayService] channel ${channelConfigId} deactivated`);
-  }
-
-  // -------------------------------------------------------------------------
-  // Public: message flow
-  // -------------------------------------------------------------------------
+  // ── dispatch() ──────────────────────────────────────────────────────────
 
   /**
-   * Entry point for every inbound webhook.
+   * Procesa un mensaje entrante de un canal.
    *
-   * Flow:
-   *   rawPayload
-   *     → adapter.receive()       parse channel format → IncomingMessage
-   *     → SessionManager           upsert GatewaySession, append user turn
-   *     → AgentRunner.run()        load Agent+FlowVersion, execute FlowExecutor
-   *     → recordReply()            append assistant turn, adapter.send()
+   * [F3a-17] Fast path: si incoming.replyFn está definida, la usamos
+   * directamente para responder in-band (crítico para canales con timeout
+   * de webhook como Telegram/WhatsApp, que requieren reply en ≤30s).
+   *
+   * Legacy path: si replyFn es undefined, usa la ruta antigua a través
+   * de recordReply() → adapter.send().
    */
   async dispatch(
     channelConfigId: string,
     rawPayload:      Record<string, unknown>,
   ): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
+    const cfg     = await this.loadChannelConfig(channelConfigId)
+    const adapter = this.resolveAdapter(cfg.type)
 
-    // 1. Parse inbound message
+    // 1. Parse inbound — receive() devuelve IncomingMessage con
+    //    replyFn, threadId y rawPayload ya populados por el adaptador
     const incoming = await (adapter as unknown as {
-      receive: (p: Record<string, unknown>, s: Record<string, unknown>) => Promise<IncomingMessage | null>;
-    }).receive(rawPayload, cfg.secrets);
+      receive: (p: Record<string, unknown>, s: Record<string, unknown>) => Promise<IncomingMessage | null>
+    }).receive(rawPayload, cfg.secrets)
 
-    if (!incoming) return;
+    if (!incoming) return
 
     // 2. Persist user turn + upsert session
     const session = await this.sessions.receiveUserMessage(
       channelConfigId,
       cfg.agentId,
       incoming,
-    );
+    )
 
     // 3. Run agent via FlowExecutor
-    let replyText: string;
+    let replyText: string
     try {
       const result = await this.agentRunner.run(
         session.agentId,
         session.history,
-      );
-      replyText = result.reply || '(sin respuesta)';
+      )
+      replyText = result.reply || '(sin respuesta)'
     } catch (err) {
-      console.error('[GatewayService] AgentRunner error:', err);
-      replyText = '(ocurrió un error al procesar tu mensaje)';
+      console.error('[GatewayService] AgentRunner error:', err)
+      replyText = '(ocurrió un error al procesar tu mensaje)'
     }
 
     // 4. Build outbound message
-    const outbound: OutboundMessage = {
-      externalUserId: incoming.externalUserId,
-      text: replyText,
-    };
+    const outgoing: OutgoingMessage = {
+      externalId: incoming.externalId,
+      threadId:   incoming.threadId !== incoming.externalId
+                    ? incoming.threadId   // preserva el thread si es distinto del chat
+                    : undefined,
+      text:       replyText,
+    }
 
-    // 5. Persist assistant turn + send to channel
-    await this.recordReply(channelConfigId, session.id, outbound);
+    // 5a. PATH RÁPIDO: replyFn disponible → reply in-band directo
+    //     El adaptador ya tiene las credenciales capturadas en el closure.
+    //     NO llamamos adapter.send() → evitamos double-send.
+    if (incoming.replyFn) {
+      await incoming.replyFn(replyText, {
+        format:        'text',
+        quoteOriginal: false,
+      })
+      // Persistir solo el texto (el envío ya ocurrió)
+      await this.sessions.recordAssistantReply(session.id, outgoing)
+      return
+    }
+
+    // 5b. PATH LEGACY: sin replyFn → ruta antigua (adapter.send() en recordReply)
+    await this.recordReply(channelConfigId, session.id, outgoing)
   }
 
+  // ── recordReply() ───────────────────────────────────────────────────────
+
   /**
-   * Called by the internal /api/webchat/:channelId/reply endpoint.
+   * [F3a-17] Actualizado para usar OutgoingMessage (era OutboundMessage).
+   *
+   * Sigue existiendo para:
+   *   1. El path legacy (canales sin replyFn)
+   *   2. El endpoint POST /webchat/:channelId/reply
    */
   async recordReply(
     channelConfigId: string,
     sessionId:       string,
-    outbound:        OutboundMessage,
+    outgoing:        OutgoingMessage,
   ): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
+    const cfg     = await this.loadChannelConfig(channelConfigId)
+    const adapter = this.resolveAdapter(cfg.type)
 
-    await this.sessions.recordAssistantReply(sessionId, outbound);
+    await this.sessions.recordAssistantReply(sessionId, outgoing)
     await (adapter as unknown as {
-      send: (m: OutboundMessage, c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).send(outbound, cfg.config, cfg.secrets);
-  }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
-
-  private async loadChannelConfig(
-    channelConfigId: string,
-  ): Promise<DecryptedChannelConfig> {
-    const cached = this.configCache.get(channelConfigId);
-    if (cached) return cached;
-
-    const row = await this.db.channelConfig.findUniqueOrThrow({
-      where: { id: channelConfigId },
-    });
-
-    const secrets = this.decrypt(row.secretsEncrypted as string | null);
-    const cfg: DecryptedChannelConfig = {
-      id:      row.id,
-      agentId: row.agentId,
-      type:    row.type,
-      config:  (row.config as Record<string, unknown>) ?? {},
-      secrets,
-    };
-    this.configCache.set(channelConfigId, cfg);
-    return cfg;
-  }
-
-  private resolveAdapter(type: string): IChannelAdapter {
-    if (registry.has(type)) {
-      return registry.get(type) as unknown as IChannelAdapter;
-    }
-    throw new Error(
-      `GatewayService: no adapter registered for channel type '${type}'. ` +
-      `Registered: ${registry.registeredTypes().join(', ') || '(none)'}`,
-    );
-  }
-
-  private decrypt(secretsEncrypted: string | null): Record<string, unknown> {
-    if (!secretsEncrypted) return {};
-    try {
-      const buf     = Buffer.from(secretsEncrypted, 'hex');
-      const iv      = buf.subarray(0, 12);
-      const authTag = buf.subarray(12, 28);
-      const cipher  = buf.subarray(28);
-
-      const decipher = createDecipheriv('aes-256-gcm', this.encKey, iv);
-      decipher.setAuthTag(authTag);
-      const decrypted = Buffer.concat([decipher.update(cipher), decipher.final()]);
-      return JSON.parse(decrypted.toString('utf8')) as Record<string, unknown>;
-    } catch (err) {
-      console.error('[GatewayService] Failed to decrypt secrets:', err);
-      return {};
-    }
+      send: (m: OutgoingMessage, c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>
+    }).send(outgoing, cfg.config, cfg.secrets)
   }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">✅ Implementación completa. Aquí el resumen de lo entregado:</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="f3a-17--commit-entregado">F3a-17 — Commit entregado</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Commit SHA:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/commit/db084c4a2704b10f93dc5816c00fccdd0c099f94"><span class="text-box-trim-both"><code>db084c4a2704b10f93dc5816c00fccdd0c099f94</code></span></a><br><strong>Branch:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-17-normalize-handle-incoming"><span class="text-box-trim-both"><code>feat/F3a-17-normalize-handle-incoming</code></span></a></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="archivos-modificados-8--creado-1">Archivos modificados (8) + creado (1)</h2><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="channel-adapterinterfacets--interfaz-base"><code>channel-adapter.interface.ts</code> — Interfaz base</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Nuevo tipo <code>ReplyFn</code> e interfaz <code>ReplyOptions</code> (con <code>quoteOriginal</code>, <code>format</code>, <code>attachments</code>, <code>channelMeta</code>)</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>IncomingMessage</code> ahora incluye <code>threadId: string</code> (never undefined), <code>replyFn?: ReplyFn</code>, <code>rawPayload: Record&lt;string, unknown&gt;</code></p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>OutgoingMessage</code> consolida y reemplaza <code>OutboundMessage</code> de gateway-sdk, con campo <code>threadId?: string</code></p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>BaseChannelAdapter</code> incluye el helper <code>sanitizeRawPayload()</code> que elimina automáticamente claves como <code>token</code>, <code>bot_token</code>, <code>access_token</code>, <code>api_key</code>, etc.</p></li></ul><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="gatewayservicets--dispatch-actualizado"><code>gateway.service.ts</code> — dispatch() actualizado</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Importa <code>OutgoingMessage</code> desde la interfaz local (ya <strong>no</strong> importa <code>OutboundMessage</code> de gateway-sdk)</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Fast path</strong>: si <code>incoming.replyFn</code> existe → llama <code>replyFn()</code> directo + <code>sessions.recordAssistantReply()</code>, <strong>sin</strong> llamar <code>adapter.send()</code> (elimina double-send)</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Legacy path</strong>: si <code>replyFn</code> es <code>undefined</code> → ruta antigua via <code>recordReply()</code></p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>recordReply()</code> conservado con firma actualizada a <code>OutgoingMessage</code></p></li></ul><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="adaptadores-telegram-whatsapp-slack-discord-webcha">Adaptadores (Telegram, WhatsApp, Slack, Discord, WebChat, Webhook)</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Cada uno implementa el patrón F3a-17 en <code>receive()</code>:</p><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised">
Adaptador | threadId | replyFn
-- | -- | --
Telegram | message_thread_id si supergrupo, sino chatId | POST a api.telegram.org con closure idempotente
WhatsApp | =externalId (sin threads nativos) | POST a graph.facebook.com/v19.0/{phoneId}/messages
Slack | event.thread_ts ?? event.ts | POST a chat.postMessage con thread_ts
Discord | message.thread?.id ?? channelId | POST a channels/{targetId}/messages
WebChat | =sessionId (1 sesión = 1 hilo) | connection.send() o encola en pendingReplies
Webhook | payload.threadId ?? externalId | POST a callbackUrl si presente, sino undefined

</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="testsincoming-messagetestts--16-tests-nuevos"><code>__tests__/incoming-message.test.ts</code> — 16 tests nuevos</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">8 tests de <code>replyFn</code>: llamadas HTTP correctas por canal, idempotencia, <code>quoteOriginal</code>, <code>callbackUrl</code> ausente/presente</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">3 tests de <code>threadId</code>: DM vs supergrupo en Telegram, <code>thread_ts</code> en Slack</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">2 tests de <code>rawPayload</code>: secretos eliminados, campos de contenido presentes</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">2 tests de <code>dispatch()</code>: fast path sin double-send, legacy path cuando <code>replyFn=undefined</code></p></li></ul></div></body></html><!--EndFragment-->
</body>
</html>✅ Implementación completa. Aquí el resumen de lo entregado:

***

## F3a-17 — Commit entregado

**Commit SHA:** [`[db084c4a2704b10f93dc5816c00fccdd0c099f94](https://github.com/lssmanager/agent-visualstudio/commit/db084c4a2704b10f93dc5816c00fccdd0c099f94)`](https://github.com/lssmanager/agent-visualstudio/commit/db084c4a2704b10f93dc5816c00fccdd0c099f94)
**Branch:** [`[feat/F3a-17-normalize-handle-incoming](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-17-normalize-handle-incoming)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-17-normalize-handle-incoming)

***

## Archivos modificados (8) + creado (1)

### `channel-adapter.interface.ts` — Interfaz base
- Nuevo tipo `ReplyFn` e interfaz `ReplyOptions` (con `quoteOriginal`, `format`, `attachments`, `channelMeta`)
- `IncomingMessage` ahora incluye `threadId: string` (never undefined), `replyFn?: ReplyFn`, `rawPayload: Record<string, unknown>`
- `OutgoingMessage` consolida y reemplaza `OutboundMessage` de gateway-sdk, con campo `threadId?: string`
- `BaseChannelAdapter` incluye el helper `sanitizeRawPayload()` que elimina automáticamente claves como `token`, `bot_token`, `access_token`, `api_key`, etc.

### `gateway.service.ts` — dispatch() actualizado
- Importa `OutgoingMessage` desde la interfaz local (ya **no** importa `OutboundMessage` de gateway-sdk)
- **Fast path**: si `incoming.replyFn` existe → llama `replyFn()` directo + `sessions.recordAssistantReply()`, **sin** llamar `adapter.send()` (elimina double-send)
- **Legacy path**: si `replyFn` es `undefined` → ruta antigua via `recordReply()`
- `recordReply()` conservado con firma actualizada a `OutgoingMessage`

### Adaptadores (Telegram, WhatsApp, Slack, Discord, WebChat, Webhook)
Cada uno implementa el patrón F3a-17 en `receive()`:

| Adaptador | `threadId` | `replyFn` |
|-----------|-----------|-----------|
| Telegram | `message_thread_id` si supergrupo, sino `chatId` | POST a `api.telegram.org` con closure idempotente |
| WhatsApp | `=externalId` (sin threads nativos) | POST a `graph.facebook.com/v19.0/{phoneId}/messages` |
| Slack | `event.thread_ts ?? event.ts` | POST a `chat.postMessage` con `thread_ts` |
| Discord | `message.thread?.id ?? channelId` | POST a `channels/{targetId}/messages` |
| WebChat | `=sessionId` (1 sesión = 1 hilo) | `connection.send()` o encola en `pendingReplies` |
| Webhook | `payload.threadId ?? externalId` | POST a `callbackUrl` si presente, sino `undefined` |

### `__tests__/incoming-message.test.ts` — 16 tests nuevos
- 8 tests de `replyFn`: llamadas HTTP correctas por canal, idempotencia, `quoteOriginal`, `callbackUrl` ausente/presente
- 3 tests de `threadId`: DM vs supergrupo en Telegram, `thread_ts` en Slack
- 2 tests de `rawPayload`: secretos eliminados, campos de contenido presentes
- 2 tests de `dispatch()`: fast path sin double-send, legacy path cuando `replyFn=undefined`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive channel lifecycle management with provisioning, startup, shutdown, and restart capabilities.
  * Implemented thread and reply support across all chat adapters.
  * Added in-band reply functionality for faster channel responses.

* **Tests**
  * Added extensive unit test coverage for channel lifecycle operations and message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->