### PR TITLE
Feat/f3a 18 telegram adapter hardening

### DIFF
--- a/apps/api/src/modules/channels/__tests__/channel-lifecycle.service.test.ts
+++ b/apps/api/src/modules/channels/__tests__/channel-lifecycle.service.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ChannelLifecycleService } from '../channel-lifecycle.service.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from '../channel-lifecycle.errors.js'
+
+function makeChannel(status: string, id = 'ch-001') {
+  return {
+    id,
+    name: 'TestBot',
+    type: 'telegram',
+    status,
+    isActive: status === 'active' || status === 'starting',
+    errorMessage: null,
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    config: {},
+    secretsEncrypted: null,
+  }
+}
+
+function makeDb(channel: any) {
+  return {
+    channelConfig: {
+      findUnique:         vi.fn().mockResolvedValue(channel),
+      findUniqueOrThrow:  vi.fn().mockResolvedValue(channel),
+      create:             vi.fn().mockResolvedValue({ ...channel, status: 'provisioned', isActive: false }),
+      update:             vi.fn().mockImplementation(({ data }: any) =>
+                            Promise.resolve({ ...channel, ...data })),
+      findMany:           vi.fn().mockResolvedValue([channel]),
+    },
+    channelBinding: { count: vi.fn().mockResolvedValue(0) },
+    gatewaySession: { count: vi.fn().mockResolvedValue(0) },
+  }
+}
+
+function makeGateway() {
+  return {
+    activateChannel:   vi.fn().mockResolvedValue(undefined),
+    deactivateChannel: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeResolver() {
+  return { invalidateCache: vi.fn() }
+}
+
+function makeSvc(db: any, gateway: any = makeGateway(), resolver: any = makeResolver()) {
+  return new ChannelLifecycleService(db as any, gateway as any, resolver as any)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('provision()', () => {
+  it('creates channel with status=provisioned and isActive=false', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    const result = await svc.provision({ type: 'telegram', name: 'TestBot', config: {} })
+    expect(db.channelConfig.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'provisioned', isActive: false }) })
+    )
+    expect(result.status).toBe('provisioned')
+    expect(result.isActive).toBe(false)
+  })
+
+  it('encrypts secrets when provided', async () => {
+    process.env.GATEWAY_ENCRYPTION_KEY = 'a'.repeat(64) // 32-byte key in hex
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await svc.provision({ type: 'telegram', name: 'TestBot', config: {}, secrets: { token: 'secret' } })
+    const createCall = (db.channelConfig.create as any).mock.calls[0][0]
+    expect(createCall.data.secretsEncrypted).toBeTruthy()
+    expect(createCall.data.secretsEncrypted).not.toBe('{"token":"secret"}')
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+  })
+
+  it('autoStart=true calls start() and returns active status', async () => {
+    process.env.GATEWAY_ENCRYPTION_KEY = 'b'.repeat(64)
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.provision({ type: 'telegram', name: 'TestBot', config: {}, autoStart: true })
+    expect(result.status).toBe('active')
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+  })
+
+  it('throws Error when GATEWAY_ENCRYPTION_KEY is missing and secrets provided', async () => {
+    delete process.env.GATEWAY_ENCRYPTION_KEY
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(
+      svc.provision({ type: 'telegram', name: 'TestBot', config: {}, secrets: { token: 'x' } })
+    ).rejects.toThrow('GATEWAY_ENCRYPTION_KEY is not set')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('start()', () => {
+  it('provisioned → active, isActive=true', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+    expect(result.isActive).toBe(true)
+  })
+
+  it('stopped → active', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('error → active', async () => {
+    const ch = makeChannel('error')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.start('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('active → throws ChannelAlreadyInStateError', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(ChannelAlreadyInStateError)
+  })
+
+  it('starting → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('starting')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('gateway failure → persists error status and throws WebhookRegistrationError', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const gateway = { activateChannel: vi.fn().mockRejectedValue(new Error('webhook timeout')) }
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db, gateway)
+    await expect(svc.start('ch-001')).rejects.toBeInstanceOf(WebhookRegistrationError)
+    const lastUpdateCall = (db.channelConfig.update as any).mock.calls.at(-1)[0]
+    expect(lastUpdateCall.data.status).toBe('error')
+    expect(lastUpdateCall.data.isActive).toBe(false)
+    expect(lastUpdateCall.data.errorMessage).toContain('webhook timeout')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('stop()', () => {
+  it('active → stopped, isActive=false', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.stop('ch-001')
+    expect(result.status).toBe('stopped')
+    expect(result.isActive).toBe(false)
+  })
+
+  it('stopped → throws ChannelAlreadyInStateError', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.stop('ch-001')).rejects.toBeInstanceOf(ChannelAlreadyInStateError)
+  })
+
+  it('provisioned → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('provisioned')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.stop('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('gateway failure → persists error status and re-throws', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const gateway = {
+      activateChannel:   vi.fn(),
+      deactivateChannel: vi.fn().mockRejectedValue(new Error('network error')),
+    }
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db, gateway)
+    await expect(svc.stop('ch-001')).rejects.toThrow('network error')
+    const lastUpdateCall = (db.channelConfig.update as any).mock.calls.at(-1)[0]
+    expect(lastUpdateCall.data.status).toBe('error')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('restart()', () => {
+  it('active → stop() + start() → returns active', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    db.channelConfig.findUnique = vi.fn()
+      .mockResolvedValueOnce(ch)              // restart load
+      .mockResolvedValueOnce(ch)              // stop load
+      .mockResolvedValueOnce({ ...ch, status: 'stopped', isActive: false }) // start load
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('error → calls start() directly (no stop())', async () => {
+    const ch = makeChannel('error')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('stopped → calls start() directly', async () => {
+    const ch = makeChannel('stopped')
+    const db = makeDb(ch)
+    db.channelConfig.update = vi.fn().mockImplementation(({ data }: any) =>
+      Promise.resolve({ ...ch, ...data }))
+    const svc = makeSvc(db)
+    const result = await svc.restart('ch-001')
+    expect(result.status).toBe('active')
+  })
+
+  it('starting → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('starting')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.restart('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+
+  it('stopping → throws InvalidTransitionError', async () => {
+    const ch = makeChannel('stopping')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    await expect(svc.restart('ch-001')).rejects.toBeInstanceOf(InvalidTransitionError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('status()', () => {
+  it('returns ChannelStatusDto with all fields for existing channel', async () => {
+    const ch = makeChannel('active')
+    const db = makeDb(ch)
+    const svc = makeSvc(db)
+    const result = await svc.status('ch-001')
+    expect(result.id).toBe('ch-001')
+    expect(result.status).toBe('active')
+    expect(result.isActive).toBe(true)
+    expect(result.bindingCount).toBe(0)
+    expect(result.activeSessions).toBe(0)
+    expect(result.createdAt).toBeTruthy()
+  })
+
+  it('throws ChannelNotFoundError when channel does not exist', async () => {
+    const db = makeDb(null)
+    db.channelConfig.findUnique = vi.fn().mockResolvedValue(null)
+    const svc = makeSvc(db)
+    await expect(svc.status('nonexistent')).rejects.toBeInstanceOf(ChannelNotFoundError)
+  })
+})

--- a/apps/api/src/modules/channels/channel-lifecycle.errors.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.errors.ts
@@ -1,0 +1,40 @@
+export class ChannelNotFoundError extends Error {
+  constructor(channelConfigId: string) {
+    super(`[ChannelLifecycle] ChannelConfig "${channelConfigId}" not found.`)
+    this.name = 'ChannelNotFoundError'
+  }
+}
+
+export class InvalidTransitionError extends Error {
+  constructor(
+    channelConfigId: string,
+    from: string,
+    to: string,
+  ) {
+    super(
+      `[ChannelLifecycle] Cannot transition channel "${channelConfigId}" ` +
+      `from status="${from}" to "${to}". ` +
+      `Check allowed transitions in ChannelLifecycleService.TRANSITIONS.`
+    )
+    this.name = 'InvalidTransitionError'
+  }
+}
+
+export class ChannelAlreadyInStateError extends Error {
+  constructor(channelConfigId: string, status: string) {
+    super(
+      `[ChannelLifecycle] Channel "${channelConfigId}" is already in status="${status}".`
+    )
+    this.name = 'ChannelAlreadyInStateError'
+  }
+}
+
+export class WebhookRegistrationError extends Error {
+  constructor(channelConfigId: string, cause: string) {
+    super(
+      `[ChannelLifecycle] Failed to register webhook for channel ` +
+      `"${channelConfigId}": ${cause}`
+    )
+    this.name = 'WebhookRegistrationError'
+  }
+}

--- a/apps/api/src/modules/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.service.ts
@@ -1,0 +1,352 @@
+import { Injectable, Logger }    from '@nestjs/common'
+import { PrismaService }         from '../../prisma/prisma.service.js'
+import { GatewayService }        from '../gateway/gateway.service.js'
+import { AgentResolverService }  from '../gateway/agent-resolver.service.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from './channel-lifecycle.errors.js'
+import type { ProvisionChannelDto, ChannelStatusDto } from './dto/provision-channel.dto.js'
+import { createCipheriv, randomBytes }               from 'crypto'
+
+// ── Tipos ───────────────────────────────────────────────────────────────
+
+type ChannelStatus =
+  | 'provisioned'
+  | 'starting'
+  | 'active'
+  | 'stopping'
+  | 'stopped'
+  | 'error'
+
+// ── Transiciones permitidas (mapa explícito) ────────────────────────────
+
+const TRANSITIONS: Record<ChannelStatus, ChannelStatus[]> = {
+  provisioned: ['starting'],
+  starting:    ['active', 'error'],
+  active:      ['stopping'],
+  stopping:    ['stopped', 'error'],
+  stopped:     ['starting'],
+  error:       ['starting'],
+}
+
+// ── Servicio ────────────────────────────────────────────────────────────
+
+@Injectable()
+export class ChannelLifecycleService {
+  private readonly logger = new Logger(ChannelLifecycleService.name)
+
+  constructor(
+    private readonly db:       PrismaService,
+    private readonly gateway:  GatewayService,
+    private readonly resolver: AgentResolverService,
+  ) {}
+
+  // ────────────────────────────────────────────────────────────────────
+  // PROVISION — Crea el ChannelConfig en BD con status='provisioned'
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Crea un nuevo canal en la BD en estado 'provisioned'.
+   * No registra webhooks ni activa el canal.
+   * Si dto.autoStart=true, llama start() inmediatamente después.
+   *
+   * @returns ChannelStatusDto del canal creado
+   */
+  async provision(dto: ProvisionChannelDto): Promise<ChannelStatusDto> {
+    const secretsEncrypted = dto.secrets
+      ? this.encryptSecrets(dto.secrets)
+      : null
+
+    const channel = await this.db.channelConfig.create({
+      data: {
+        type:             dto.type,
+        name:             dto.name,
+        config:           dto.config,
+        secretsEncrypted,
+        isActive:         false,
+        status:           'provisioned',
+        errorMessage:     null,
+        lastStartedAt:    null,
+        lastStoppedAt:    null,
+      },
+    })
+
+    this.logger.log(`[provision] Channel "${channel.id}" (${channel.type}) created`)
+
+    if (dto.autoStart) {
+      return this.start(channel.id)
+    }
+
+    return this.toStatusDto(channel, 0, 0)
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // START — Activa el canal: registra webhooks y marca isActive=true
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Inicia un canal en estado 'provisioned', 'stopped', o 'error'.
+   * Flujo:
+   *   1. Validar transición → 'starting'
+   *   2. Persistir status='starting', isActive=true
+   *   3. Llamar GatewayService.activateChannel() (con stub de seguridad)
+   *   4a. Éxito → persistir status='active', lastStartedAt=now
+   *   4b. Fallo → persistir status='error', isActive=false, errorMessage
+   *
+   * @throws InvalidTransitionError si el canal no puede hacer start desde su estado actual
+   */
+  async start(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'active') {
+      throw new ChannelAlreadyInStateError(channelConfigId, 'active')
+    }
+
+    this.assertTransition(channel.status as ChannelStatus, 'starting', channelConfigId)
+
+    // Marcar como 'starting'
+    await this.db.channelConfig.update({
+      where: { id: channelConfigId },
+      data:  { status: 'starting', isActive: true, errorMessage: null },
+    })
+    this.resolver.invalidateCache(channelConfigId)
+
+    try {
+      // Delegar al GatewayService la activación real del canal (stub-safe)
+      await this.callGatewayActivate(channelConfigId)
+
+      // Marcar como 'active'
+      const updated = await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'active', lastStartedAt: new Date() },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.log(`[start] Channel "${channelConfigId}" is now active`)
+      return this.buildStatusDto(updated, channelConfigId)
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'error', isActive: false, errorMessage },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.error(`[start] Channel "${channelConfigId}" failed to start: ${errorMessage}`)
+      throw new WebhookRegistrationError(channelConfigId, errorMessage)
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STOP — Desactiva el canal: desregistra webhooks y marca isActive=false
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Detiene un canal en estado 'active'.
+   * Flujo:
+   *   1. Validar transición → 'stopping'
+   *   2. Persistir status='stopping', isActive=false
+   *   3. Llamar GatewayService.deactivateChannel() (con stub de seguridad)
+   *   4a. Éxito → persistir status='stopped', lastStoppedAt=now
+   *   4b. Fallo → persistir status='error', errorMessage
+   *
+   * @throws InvalidTransitionError si el canal no está en estado 'active'
+   */
+  async stop(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'stopped') {
+      throw new ChannelAlreadyInStateError(channelConfigId, 'stopped')
+    }
+
+    this.assertTransition(channel.status as ChannelStatus, 'stopping', channelConfigId)
+
+    await this.db.channelConfig.update({
+      where: { id: channelConfigId },
+      data:  { status: 'stopping', isActive: false, errorMessage: null },
+    })
+    this.resolver.invalidateCache(channelConfigId)
+
+    try {
+      await this.callGatewayDeactivate(channelConfigId)
+
+      const updated = await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'stopped', lastStoppedAt: new Date() },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.log(`[stop] Channel "${channelConfigId}" is now stopped`)
+      return this.buildStatusDto(updated, channelConfigId)
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      await this.db.channelConfig.update({
+        where: { id: channelConfigId },
+        data:  { status: 'error', errorMessage },
+      })
+      this.resolver.invalidateCache(channelConfigId)
+      this.logger.error(`[stop] Channel "${channelConfigId}" failed to stop: ${errorMessage}`)
+      throw err
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // RESTART — stop() + start() con manejo de estado intermedio
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Reinicia el canal.
+   * - Si está 'active' → stop() + start()
+   * - Si está 'error', 'stopped', 'provisioned' → start() directo
+   * - Si está 'starting' o 'stopping' → InvalidTransitionError
+   */
+  async restart(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+
+    if (channel.status === 'starting' || channel.status === 'stopping') {
+      throw new InvalidTransitionError(
+        channelConfigId,
+        channel.status,
+        'restart',
+      )
+    }
+
+    if (channel.status === 'active') {
+      await this.stop(channelConfigId)
+    }
+
+    return this.start(channelConfigId)
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STATUS — Lectura enriquecida del estado del canal
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Retorna el ChannelStatusDto con conteos de bindings y sesiones activas.
+   * Nunca lanza errores de transición — solo lanza ChannelNotFoundError.
+   */
+  async status(channelConfigId: string): Promise<ChannelStatusDto> {
+    const channel = await this.loadOrThrow(channelConfigId)
+    return this.buildStatusDto(channel, channelConfigId)
+  }
+
+  /**
+   * Lista todos los canales con su estado actual.
+   * Ordenados por: activos primero, luego por nombre.
+   */
+  async listAll(): Promise<ChannelStatusDto[]> {
+    const channels = await this.db.channelConfig.findMany({
+      orderBy: [
+        { isActive: 'desc' },
+        { name: 'asc' },
+      ],
+    })
+
+    return Promise.all(
+      channels.map((ch) => this.buildStatusDto(ch, ch.id))
+    )
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // STUBS DE GATEWAY (safe delegation)
+  // ────────────────────────────────────────────────────────────────────
+
+  /**
+   * Llama gateway.activateChannel() si el método existe.
+   * Si aún no está implementado en GatewayService, actúa como no-op
+   * para que el build no rompa.
+   */
+  private async callGatewayActivate(id: string): Promise<void> {
+    if (typeof (this.gateway as any).activateChannel === 'function') {
+      await (this.gateway as any).activateChannel(id)
+    }
+    // else: no-op hasta que GatewayService implemente el método
+  }
+
+  /**
+   * Llama gateway.deactivateChannel() si el método existe.
+   * Si aún no está implementado en GatewayService, actúa como no-op.
+   */
+  private async callGatewayDeactivate(id: string): Promise<void> {
+    if (typeof (this.gateway as any).deactivateChannel === 'function') {
+      await (this.gateway as any).deactivateChannel(id)
+    }
+    // else: no-op hasta que GatewayService implemente el método
+  }
+
+  // ────────────────────────────────────────────────────────────────────
+  // PRIVADOS
+  // ────────────────────────────────────────────────────────────────────
+
+  private assertTransition(
+    from:             ChannelStatus,
+    to:               ChannelStatus,
+    channelConfigId:  string,
+  ): void {
+    const allowed = TRANSITIONS[from] ?? []
+    if (!allowed.includes(to)) {
+      throw new InvalidTransitionError(channelConfigId, from, to)
+    }
+  }
+
+  private async loadOrThrow(channelConfigId: string) {
+    const channel = await this.db.channelConfig.findUnique({
+      where: { id: channelConfigId },
+    })
+    if (!channel) throw new ChannelNotFoundError(channelConfigId)
+    return channel
+  }
+
+  private async buildStatusDto(
+    channel:         any,
+    channelConfigId: string,
+  ): Promise<ChannelStatusDto> {
+    const [bindingCount, activeSessions] = await Promise.all([
+      this.db.channelBinding.count({ where: { channelConfigId } }),
+      this.db.gatewaySession.count({
+        where: { channelConfigId, state: 'active' },
+      }),
+    ])
+    return this.toStatusDto(channel, bindingCount, activeSessions)
+  }
+
+  private toStatusDto(
+    ch:             any,
+    bindingCount:   number,
+    activeSessions: number,
+  ): ChannelStatusDto {
+    return {
+      id:             ch.id,
+      name:           ch.name,
+      type:           ch.type,
+      status:         ch.status,
+      isActive:       ch.isActive,
+      errorMessage:   ch.errorMessage ?? null,
+      lastStartedAt:  ch.lastStartedAt?.toISOString() ?? null,
+      lastStoppedAt:  ch.lastStoppedAt?.toISOString() ?? null,
+      bindingCount,
+      activeSessions,
+      createdAt:      ch.createdAt.toISOString(),
+      updatedAt:      ch.updatedAt.toISOString(),
+    }
+  }
+
+  /**
+   * Encripta los secretos del canal usando AES-256-GCM.
+   * Mismo esquema que GatewayService: [12 IV][16 tag][N ciphertext]
+   */
+  private encryptSecrets(secrets: Record<string, unknown>): string {
+    const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? ''
+    if (!keyHex) throw new Error('GATEWAY_ENCRYPTION_KEY is not set')
+    const key    = Buffer.from(keyHex, 'hex')
+    const iv     = randomBytes(12)
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    const plain  = Buffer.from(JSON.stringify(secrets), 'utf8')
+    const enc    = Buffer.concat([cipher.update(plain), cipher.final()])
+    const tag    = cipher.getAuthTag()
+    return Buffer.concat([iv, tag, enc]).toString('base64')
+  }
+}

--- a/apps/api/src/modules/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.service.ts
@@ -256,25 +256,16 @@ export class ChannelLifecycleService {
 
   /**
    * Llama gateway.activateChannel() si el método existe.
-   * Si aún no está implementado en GatewayService, actúa como no-op
-   * para que el build no rompa.
    */
   private async callGatewayActivate(id: string): Promise<void> {
-    if (typeof (this.gateway as any).activateChannel === 'function') {
-      await (this.gateway as any).activateChannel(id)
-    }
-    // else: no-op hasta que GatewayService implemente el método
+    await this.gateway.activateChannel(id)
   }
 
   /**
    * Llama gateway.deactivateChannel() si el método existe.
-   * Si aún no está implementado en GatewayService, actúa como no-op.
    */
   private async callGatewayDeactivate(id: string): Promise<void> {
-    if (typeof (this.gateway as any).deactivateChannel === 'function') {
-      await (this.gateway as any).deactivateChannel(id)
-    }
-    // else: no-op hasta que GatewayService implemente el método
+    await this.gateway.deactivateChannel(id)
   }
 
   // ────────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/channels/channels.controller.ts
+++ b/apps/api/src/modules/channels/channels.controller.ts
@@ -1,57 +1,75 @@
-import { Router } from 'express';
+import {
+  Controller, Get, Post, Param,
+  Body, HttpCode, HttpStatus, HttpException,
+} from '@nestjs/common'
+import { ChannelLifecycleService } from './channel-lifecycle.service.js'
+import { ProvisionChannelDto }     from './dto/provision-channel.dto.js'
+import {
+  ChannelNotFoundError,
+  InvalidTransitionError,
+  ChannelAlreadyInStateError,
+  WebhookRegistrationError,
+} from './channel-lifecycle.errors.js'
 
-import { ChannelsService } from './channels.service';
+@Controller('channels')
+export class ChannelsController {
+  constructor(private readonly lifecycle: ChannelLifecycleService) {}
 
-export function registerChannelsRoutes(router: Router) {
-  const service = new ChannelsService();
+  /** GET /channels — lista todos los canales */
+  @Get()
+  listAll() {
+    return this.lifecycle.listAll()
+  }
 
-  /**
-   * GET /channels
-   * Lista todos los canales activos con conteo de sesiones.
-   */
-  router.get('/channels', async (_req, res) => {
+  /** GET /channels/:id/status — estado detallado */
+  @Get(':id/status')
+  async status(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.status(id))
+  }
+
+  /** POST /channels — provisionar nuevo canal */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async provision(@Body() dto: ProvisionChannelDto) {
+    return this.wrap(() => this.lifecycle.provision(dto))
+  }
+
+  /** POST /channels/:id/start */
+  @Post(':id/start')
+  async start(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.start(id))
+  }
+
+  /** POST /channels/:id/stop */
+  @Post(':id/stop')
+  async stop(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.stop(id))
+  }
+
+  /** POST /channels/:id/restart */
+  @Post(':id/restart')
+  async restart(@Param('id') id: string) {
+    return this.wrap(() => this.lifecycle.restart(id))
+  }
+
+  // Mapeo de errores de dominio → HTTP
+  private async wrap<T>(fn: () => Promise<T>): Promise<T> {
     try {
-      res.json(await service.listChannels());
+      return await fn()
     } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
+      if (err instanceof ChannelNotFoundError) {
+        throw new HttpException(err.message, HttpStatus.NOT_FOUND)
+      }
+      if (err instanceof ChannelAlreadyInStateError) {
+        throw new HttpException(err.message, HttpStatus.CONFLICT)
+      }
+      if (err instanceof InvalidTransitionError) {
+        throw new HttpException(err.message, HttpStatus.UNPROCESSABLE_ENTITY)
+      }
+      if (err instanceof WebhookRegistrationError) {
+        throw new HttpException(err.message, HttpStatus.BAD_GATEWAY)
+      }
+      throw err
     }
-  });
-
-  /**
-   * GET /channels/:channel
-   * Detalle de un canal por nombre (e.g. "whatsapp", "web", "api").
-   */
-  router.get('/channels/:channel', async (req, res) => {
-    try {
-      const result = await service.getChannel(req.params.channel);
-      if (!result.ok) return res.status(404).json(result);
-      return res.json(result);
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
-
-  /**
-   * GET /channels/:channel/sessions
-   * Lista todas las sesiones dentro de un canal.
-   */
-  router.get('/channels/:channel/sessions', async (req, res) => {
-    try {
-      res.json(await service.getChannelSessions(req.params.channel));
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
-
-  /**
-   * POST /channels/:channel/disconnect
-   * Desconecta todas las sesiones activas de un canal.
-   */
-  router.post('/channels/:channel/disconnect', async (req, res) => {
-    try {
-      res.json(await service.disconnectChannel(req.params.channel));
-    } catch (err) {
-      res.status(500).json({ ok: false, error: String(err) });
-    }
-  });
+  }
 }

--- a/apps/api/src/modules/channels/channels.module.ts
+++ b/apps/api/src/modules/channels/channels.module.ts
@@ -1,15 +1,12 @@
-import { Module } from '@nestjs/common';
-import { ChannelsService }    from './channels.service';
-// import { ChannelsController } from './channels.controller';
-// Commented out: ChannelsController uses Express routing, not NestJS decorators
+import { Module }                    from '@nestjs/common'
+import { ChannelsController }        from './channels.controller.js'
+import { ChannelLifecycleService }   from './channel-lifecycle.service.js'
+import { GatewayModule }             from '../gateway/gateway.module.js'
 
-/**
- * ChannelsModule — ya no necesita proveer PrismaService porque PrismaModule
- * es @Global() y está disponible globalmente desde que se importa en AppModule.
- */
 @Module({
-  // controllers: [ChannelsController],
-  providers:   [ChannelsService],
-  exports:     [ChannelsService],   // para que el runtime lo inyecte
+  imports:     [GatewayModule],   // provee GatewayService + AgentResolverService
+  controllers: [ChannelsController],
+  providers:   [ChannelLifecycleService],
+  exports:     [ChannelLifecycleService],
 })
 export class ChannelsModule {}

--- a/apps/api/src/modules/channels/dto/provision-channel.dto.ts
+++ b/apps/api/src/modules/channels/dto/provision-channel.dto.ts
@@ -1,0 +1,37 @@
+import { IsString, IsNotEmpty, IsObject, IsOptional, IsBoolean } from 'class-validator'
+
+export class ProvisionChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  type: string          // 'telegram' | 'whatsapp' | 'webchat' | 'slack' | ...
+
+  @IsString()
+  @IsNotEmpty()
+  name: string          // Nombre legible del canal
+
+  @IsObject()
+  config: Record<string, unknown>   // Configuración pública (webhook URL, bot_username…)
+
+  @IsObject()
+  @IsOptional()
+  secrets?: Record<string, unknown> // Secretos — se encriptan antes de guardar
+
+  @IsBoolean()
+  @IsOptional()
+  autoStart?: boolean   // Si true: provision() + start() en una llamada
+}
+
+export class ChannelStatusDto {
+  id:             string
+  name:           string
+  type:           string
+  status:         string
+  isActive:       boolean
+  errorMessage:   string | null
+  lastStartedAt:  string | null
+  lastStoppedAt:  string | null
+  bindingCount:   number
+  activeSessions: number
+  createdAt:      string
+  updatedAt:      string
+}

--- a/apps/api/src/modules/gateway/gateway.service.ts
+++ b/apps/api/src/modules/gateway/gateway.service.ts
@@ -48,6 +48,40 @@ export class GatewayService {
     return response.json();
   }
 
+  async activateChannel(channelConfigId: string): Promise<unknown> {
+    let response: Response | null = null;
+    try {
+      response = await fetch(`${studioConfig.gatewayBaseUrl}/api/channels/${channelConfigId}/activate`, {
+        method: 'POST',
+      });
+    } catch {
+      throw new Error(`Unable to activate channel ${channelConfigId}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Unable to activate channel ${channelConfigId}: HTTP ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  async deactivateChannel(channelConfigId: string): Promise<unknown> {
+    let response: Response | null = null;
+    try {
+      response = await fetch(`${studioConfig.gatewayBaseUrl}/api/channels/${channelConfigId}/deactivate`, {
+        method: 'POST',
+      });
+    } catch {
+      throw new Error(`Unable to deactivate channel ${channelConfigId}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Unable to deactivate channel ${channelConfigId}: HTTP ${response.status}`);
+    }
+
+    return response.json();
+  }
+
   async dashboardState(): Promise<{ ok: boolean; agents: unknown[]; sessions: unknown[] }> {
     let response: Response | null = null;
     try {

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -1,0 +1,32 @@
+# ============================================================
+# Gateway Service — Variables de entorno
+# Copia este archivo como .env.local y rellena los valores
+# ============================================================
+
+# ---- Telegram Adapter ----------------------------------------
+
+# Modo de operación del adaptador Telegram:
+#   webhook  — Telegram hace POST a tu servidor (requiere HTTPS / dominio público)
+#   polling  — El adaptador consulta getUpdates en loop (válido para dev/staging sin HTTPS)
+#
+# Prioridad: TELEGRAM_MODE env > config.mode (en ChannelConfig) > default 'webhook'
+TELEGRAM_MODE=webhook
+
+# URL pública de tu servidor para auto-registrar el webhook al iniciar.
+# El adaptador añade /gateway/telegram/webhook automáticamente.
+# Ejemplo: https://api.tudominio.com
+# Dejar vacío si usas TELEGRAM_MODE=polling o si registras el webhook manualmente.
+TELEGRAM_WEBHOOK_URL=
+
+# ---- Database ------------------------------------------------
+# DATABASE_URL=postgresql://user:password@localhost:5432/agent_vs
+
+# ---- API Keys (gestionar vía ChannelConfig.secrets en DB) ----
+# Los tokens/secrets de los canales (Telegram, WhatsApp, Slack, Discord)
+# se almacenan cifrados en la base de datos dentro de ChannelConfig.secrets.
+# NO los pongas aquí directamente en producción.
+
+# ---- Env general --------------------------------------------
+# NODE_ENV=development
+# PORT=3001
+# LOG_LEVEL=info

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -1,32 +1,30 @@
-# ============================================================
-# Gateway Service — Variables de entorno
-# Copia este archivo como .env.local y rellena los valores
-# ============================================================
+# ── Gateway Service Environment Variables ─────────────────────────────────────
 
-# ---- Telegram Adapter ----------------------------------------
+# Server
+PORT=3010
+NODE_ENV=development
 
-# Modo de operación del adaptador Telegram:
-#   webhook  — Telegram hace POST a tu servidor (requiere HTTPS / dominio público)
-#   polling  — El adaptador consulta getUpdates en loop (válido para dev/staging sin HTTPS)
-#
-# Prioridad: TELEGRAM_MODE env > config.mode (en ChannelConfig) > default 'webhook'
+# Database
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agentvisualstudio
+
+# Encryption key for channel credentials (AES-256-GCM, 32-byte hex)
+CHANNEL_SECRETS_KEY=
+
+# ── Telegram Adapter ────────────────────────────────────────────────────────────
+# Mode: webhook (production) or polling (development/staging without public HTTPS)
+# Default: webhook
 TELEGRAM_MODE=webhook
 
-# URL pública de tu servidor para auto-registrar el webhook al iniciar.
-# El adaptador añade /gateway/telegram/webhook automáticamente.
-# Ejemplo: https://api.tudominio.com
-# Dejar vacío si usas TELEGRAM_MODE=polling o si registras el webhook manualmente.
+# Public URL for webhook auto-registration (autoSetupWebhook).
+# The adapter appends /gateway/telegram/webhook automatically.
+# Example: https://api.yourdomain.com
+# Leave empty when using polling mode.
 TELEGRAM_WEBHOOK_URL=
 
-# ---- Database ------------------------------------------------
-# DATABASE_URL=postgresql://user:password@localhost:5432/agent_vs
+# ── WebChat Adapter ──────────────────────────────────────────────────────────────
+# Origin allowed for WebSocket connections (CORS)
+WEBCHAT_ALLOWED_ORIGIN=http://localhost:3000
 
-# ---- API Keys (gestionar vía ChannelConfig.secrets en DB) ----
-# Los tokens/secrets de los canales (Telegram, WhatsApp, Slack, Discord)
-# se almacenan cifrados en la base de datos dentro de ChannelConfig.secrets.
-# NO los pongas aquí directamente en producción.
-
-# ---- Env general --------------------------------------------
-# NODE_ENV=development
-# PORT=3001
-# LOG_LEVEL=info
+# ── Internal Service URLs ───────────────────────────────────────────────────────
+# URL of the Orchestrator / Run Engine service
+ORCHESTRATOR_URL=http://localhost:3001

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -8,7 +8,7 @@ NODE_ENV=development
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agentvisualstudio
 
 # Encryption key for channel credentials (AES-256-GCM, 32-byte hex)
-CHANNEL_SECRETS_KEY=
+GATEWAY_ENCRYPTION_KEY=
 
 # ── Telegram Adapter ────────────────────────────────────────────────────────────
 # Mode: webhook (production) or polling (development/staging without public HTTPS)

--- a/apps/gateway/src/channels/__tests__/incoming-message.test.ts
+++ b/apps/gateway/src/channels/__tests__/incoming-message.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { TelegramAdapter }  from '../telegram.adapter.js'
+import { WhatsAppAdapter }  from '../whatsapp.adapter.js'
+import { SlackAdapter }     from '../slack.adapter.js'
+import { DiscordAdapter }   from '../discord.adapter.js'
+import { WebhookAdapter }   from '../webhook.adapter.js'
+import { WebChatAdapter }   from '../webchat.adapter.js'
+
+// ── Mock global fetch ───────────────────────────────────────────────────────
+const fetchMock = vi.fn().mockResolvedValue({
+  ok:   true,
+  json: async () => ({ ok: true }),
+} as Response)
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  fetchMock.mockClear()
+})
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const telegramSecrets = { botToken: 'BOT_TOKEN_SECRET' }
+
+function makeTelegramUpdate(overrides?: Record<string, unknown>) {
+  return {
+    update_id: 1,
+    message: {
+      message_id: 42,
+      chat:       { id: 100, type: 'private' },
+      from:       { id: 999, first_name: 'Alice' },
+      text:       'hola',
+      date:       1700000000,
+      ...overrides,
+    },
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: IncomingMessage.replyFn
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('IncomingMessage.replyFn', () => {
+
+  it('TelegramAdapter.receive() construye replyFn que llama a sendMessage con chat_id correcto', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.replyFn).toBeDefined()
+
+    await incoming!.replyFn!('respuesta de prueba')
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('/bot' + telegramSecrets.botToken + '/sendMessage')
+    const body = JSON.parse(init!.body as string)
+    expect(body.chat_id).toBe('100')
+    expect(body.text).toBe('respuesta de prueba')
+  })
+
+  it('TelegramAdapter.receive() en supergrupo con thread: replyFn incluye message_thread_id', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate({ message_thread_id: 42 })
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    await incoming!.replyFn!('hola thread')
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.message_thread_id).toBe(42)
+  })
+
+  it('TelegramAdapter.receive() con quoteOriginal=true: replyFn incluye reply_to_message_id', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    await incoming!.replyFn!('cita', { quoteOriginal: true })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.reply_to_message_id).toBe(42)
+  })
+
+  it('WhatsAppAdapter.receive() replyFn llama a graph.facebook.com con messaging_product=whatsapp', async () => {
+    const adapter   = new WhatsAppAdapter()
+    const rawPayload = {
+      object: 'whatsapp_business_account',
+      entry: [{
+        changes: [{
+          value: {
+            phone_number_id: 'PHONE_ID',
+            messages: [{ id: 'msg1', from: '5491100000', type: 'text', timestamp: '0', text: { body: 'hola' } }],
+          },
+        }],
+      }],
+    }
+    const secrets   = { accessToken: 'WA_TOKEN', phoneNumberId: 'PHONE_ID' }
+    const incoming  = await adapter.receive(rawPayload as Record<string, unknown>, secrets)
+
+    expect(incoming).not.toBeNull()
+    await incoming!.replyFn!('respuesta WA')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain('graph.facebook.com')
+    const body = JSON.parse(init!.body as string)
+    expect(body.messaging_product).toBe('whatsapp')
+    expect(body.to).toBe('5491100000')
+  })
+
+  it('SlackAdapter.receive() replyFn llama a chat.postMessage con thread_ts correcto', async () => {
+    const adapter    = new SlackAdapter()
+    const rawPayload = {
+      type:  'event_callback',
+      event: { type: 'message', channel: 'C123', user: 'U1', text: 'hola', ts: '100', thread_ts: '90' },
+    }
+    const secrets    = { botToken: 'SLACK_BOT_TOKEN' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, secrets)
+
+    expect(incoming).not.toBeNull()
+    await incoming!.replyFn!('respuesta Slack')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://slack.com/api/chat.postMessage')
+    const body = JSON.parse(init!.body as string)
+    expect(body.thread_ts).toBe('90')
+  })
+
+  it('SlackAdapter.receive() sin thread (DM): replyFn usa event.ts como thread_ts', async () => {
+    const adapter    = new SlackAdapter()
+    const rawPayload = {
+      type:  'event_callback',
+      event: { type: 'message', channel: 'D123', user: 'U1', text: 'dm', ts: '200' },
+    }
+    const secrets    = { botToken: 'SLACK_BOT_TOKEN' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, secrets)
+
+    await incoming!.replyFn!('respuesta DM')
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.thread_ts).toBe('200')
+  })
+
+  it('WebhookAdapter.receive() sin callbackUrl → replyFn undefined', async () => {
+    const adapter    = new WebhookAdapter()
+    const rawPayload = { sessionId: 'sess1', text: 'hola' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, {})
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.replyFn).toBeUndefined()
+  })
+
+  it('WebhookAdapter.receive() con callbackUrl → replyFn hace POST al callbackUrl', async () => {
+    const adapter    = new WebhookAdapter()
+    const rawPayload = { sessionId: 'sess1', text: 'hola', callbackUrl: 'https://example.com/reply' }
+    const incoming   = await adapter.receive(rawPayload as Record<string, unknown>, {})
+
+    expect(incoming!.replyFn).toBeDefined()
+    await incoming!.replyFn!('respuesta webhook')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://example.com/reply')
+    const body = JSON.parse(init!.body as string)
+    expect(body.reply).toBe('respuesta webhook')
+    expect(body.externalId).toBe('sess1')
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: IncomingMessage.threadId
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('IncomingMessage.threadId', () => {
+
+  it('TelegramAdapter DM (sin message_thread_id): threadId === externalId', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()  // sin message_thread_id
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming!.threadId).toBe(incoming!.externalId)
+    expect(incoming!.threadId).toBe('100')
+  })
+
+  it('TelegramAdapter supergrupo con message_thread_id=42: threadId=42, externalId=chatId', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate({ message_thread_id: 42 })
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming!.threadId).toBe('42')
+    expect(incoming!.externalId).toBe('100')
+    expect(incoming!.threadId).not.toBe(incoming!.externalId)
+  })
+
+  it('SlackAdapter con thread_ts: threadId === thread_ts', async () => {
+    const adapter    = new SlackAdapter()
+    const rawPayload = {
+      type:  'event_callback',
+      event: { type: 'message', channel: 'C999', user: 'U1', text: 'reply', ts: '500', thread_ts: '400' },
+    }
+    const incoming = await adapter.receive(rawPayload as Record<string, unknown>, { botToken: 'T' })
+
+    expect(incoming!.threadId).toBe('400')
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: IncomingMessage.rawPayload
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('IncomingMessage.rawPayload', () => {
+
+  it('rawPayload nunca contiene token, bot_token, access_token (sanitizeRawPayload los elimina)', async () => {
+    const adapter  = new TelegramAdapter()
+    // Simular que el payload llega con credenciales mezcladas (error de config)
+    const dirtPayload = {
+      ...makeTelegramUpdate(),
+      bot_token:    'secret_token_should_be_removed',
+      access_token: 'another_secret',
+    }
+    const incoming = await adapter.receive(dirtPayload as Record<string, unknown>, telegramSecrets)
+
+    expect(incoming!.rawPayload['bot_token']).toBeUndefined()
+    expect(incoming!.rawPayload['access_token']).toBeUndefined()
+    expect(incoming!.rawPayload['token']).toBeUndefined()
+  })
+
+  it('rawPayload contiene los campos de contenido del mensaje original (message_id, chat, from)', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeTelegramUpdate()
+    const incoming = await adapter.receive(update as Record<string, unknown>, telegramSecrets)
+
+    // rawPayload debe tener el update completo (sin secretos)
+    expect(incoming!.rawPayload['update_id']).toBe(1)
+    const msg = (incoming!.rawPayload['message'] as Record<string, unknown>)
+    expect(msg).toBeDefined()
+    expect(msg['message_id']).toBe(42)
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: dispatch() replyFn path
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('dispatch() replyFn path', () => {
+
+  it('Si incoming.replyFn está definida: se llama con el texto, adapter.send() NO se llama', async () => {
+    const replyFnMock  = vi.fn().mockResolvedValue(undefined)
+    const sendMock     = vi.fn().mockResolvedValue(undefined)
+    const recordMock   = vi.fn().mockResolvedValue(undefined)
+    const receiveUserMock = vi.fn().mockResolvedValue({
+      id:      'sess1',
+      agentId: 'agent1',
+      history: [],
+    })
+    const recordAssistantMock = vi.fn().mockResolvedValue(undefined)
+
+    const incoming: import('../channel-adapter.interface.js').IncomingMessage = {
+      externalId: 'chat1',
+      threadId:   'thread1',
+      senderId:   'user1',
+      text:       'hola',
+      type:       'text',
+      rawPayload: { message: 'hola' },
+      receivedAt: new Date().toISOString(),
+      replyFn:    replyFnMock,
+    }
+
+    // Simular lo que hace dispatch() internamente
+    if (incoming.replyFn) {
+      await incoming.replyFn('respuesta', { format: 'text', quoteOriginal: false })
+      await recordAssistantMock({ externalId: incoming.externalId, text: 'respuesta' })
+    } else {
+      await sendMock(incoming)
+      await recordMock(incoming)
+    }
+
+    expect(replyFnMock).toHaveBeenCalledOnce()
+    expect(replyFnMock).toHaveBeenCalledWith('respuesta', { format: 'text', quoteOriginal: false })
+    expect(sendMock).not.toHaveBeenCalled()
+    expect(recordAssistantMock).toHaveBeenCalledOnce()
+  })
+
+  it('Si incoming.replyFn es undefined: se invoca el path legacy (adapter.send y recordReply)', async () => {
+    const replyFnMock   = vi.fn()
+    const sendMock      = vi.fn().mockResolvedValue(undefined)
+    const recordMock    = vi.fn().mockResolvedValue(undefined)
+    const recordAssistantMock = vi.fn().mockResolvedValue(undefined)
+
+    const incoming: import('../channel-adapter.interface.js').IncomingMessage = {
+      externalId: 'chat2',
+      threadId:   'chat2',
+      senderId:   'user2',
+      text:       'hola',
+      type:       'text',
+      rawPayload: { message: 'hola' },
+      receivedAt: new Date().toISOString(),
+      replyFn:    undefined,  // sin replyFn → path legacy
+    }
+
+    if (incoming.replyFn) {
+      await replyFnMock('respuesta')
+      await recordAssistantMock({})
+    } else {
+      await sendMock(incoming)
+      await recordMock(incoming)
+    }
+
+    expect(replyFnMock).not.toHaveBeenCalled()
+    expect(sendMock).toHaveBeenCalledOnce()
+    expect(recordMock).toHaveBeenCalledOnce()
+  })
+
+})

--- a/apps/gateway/src/channels/__tests__/incoming-message.test.ts
+++ b/apps/gateway/src/channels/__tests__/incoming-message.test.ts
@@ -147,6 +147,27 @@ describe('IncomingMessage.replyFn', () => {
     expect(body.thread_ts).toBe('200')
   })
 
+  it('DiscordAdapter.receive() detecta INTERACTION_CREATE por token y construye replyFn', async () => {
+    const adapter = new DiscordAdapter()
+    const rawPayload = {
+      t: 'INTERACTION_CREATE',
+      d: {
+        id: 'interaction-1',
+        token: 'discord-token',
+        channel_id: 'C123',
+        user: { id: 'U123' },
+        data: { name: 'ping' },
+      },
+    }
+
+    const incoming = await adapter.receive(rawPayload as Record<string, unknown>, { botToken: 'BOT' })
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.type).toBe('command')
+    expect(incoming!.text).toBe('ping')
+    expect(typeof incoming!.replyFn).toBe('function')
+  })
+
   it('WebhookAdapter.receive() sin callbackUrl → replyFn undefined', async () => {
     const adapter    = new WebhookAdapter()
     const rawPayload = { sessionId: 'sess1', text: 'hola' }
@@ -230,6 +251,35 @@ describe('IncomingMessage.rawPayload', () => {
     expect(incoming!.rawPayload['bot_token']).toBeUndefined()
     expect(incoming!.rawPayload['access_token']).toBeUndefined()
     expect(incoming!.rawPayload['token']).toBeUndefined()
+  })
+
+  it('rawPayload elimina secretos anidados en objetos y arrays', async () => {
+    const adapter = new TelegramAdapter()
+    const dirtPayload = {
+      ...makeTelegramUpdate({
+        message: {
+          ...makeTelegramUpdate().message,
+          botToken: 'nested-secret',
+          nested: {
+            access_token: 'deep-secret',
+            items: [{ apiKey: 'array-secret' }],
+          },
+        },
+      }),
+    }
+
+    const incoming = await adapter.receive(dirtPayload as Record<string, unknown>, telegramSecrets)
+    const raw = incoming!.rawPayload as Record<string, unknown>
+    const message = raw.message as Record<string, unknown>
+    const nested = message.nested as Record<string, unknown>
+    const items = nested.items as Array<Record<string, unknown>>
+
+    expect(JSON.stringify(raw)).not.toContain('nested-secret')
+    expect(JSON.stringify(raw)).not.toContain('deep-secret')
+    expect(JSON.stringify(raw)).not.toContain('array-secret')
+    expect(message.botToken).toBeUndefined()
+    expect(nested.access_token).toBeUndefined()
+    expect(items[0].apiKey).toBeUndefined()
   })
 
   it('rawPayload contiene los campos de contenido del mensaje original (message_id, chat, from)', async () => {

--- a/apps/gateway/src/channels/__tests__/telegram.adapter.test.ts
+++ b/apps/gateway/src/channels/__tests__/telegram.adapter.test.ts
@@ -1,664 +1,675 @@
+/**
+ * telegram.adapter.test.ts
+ * [F3a-18] Tests for TelegramAdapter hardening:
+ *   long-polling, retry/backoff, circuit breaker,
+ *   replyFn/threadId/rawPayload (F3a-17 interface).
+ *
+ * All fetch() calls are mocked with vi.fn() — NO real network calls.
+ * vi.useFakeTimers() controls sleep() in retry/circuit-breaker tests.
+ */
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { TelegramAdapter, fetchWithRetry, sleep } from '../telegram.adapter.js'
-import type { IncomingMessage } from '../channel-adapter.interface.js'
 
-// ── Mock global fetch ───────────────────────────────────────────────────────
+// ── Global fetch mock ──────────────────────────────────────────────────────
 
-const fetchMock = vi.fn()
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
 
-beforeEach(() => {
-  vi.stubGlobal('fetch', fetchMock)
-  fetchMock.mockReset()
-})
-
-afterEach(() => {
-  vi.restoreAllMocks()
-})
-
-// ── Helpers ─────────────────────────────────────────────────────────────────
-
-function makeOkResponse(data: unknown = { ok: true }) {
+function makeFetchResponse(
+  body:    unknown,
+  status:  number  = 200,
+  headers: Record<string, string> = {},
+): Response {
   return {
-    ok:      true,
-    status:  200,
-    json:    async () => data,
-    text:    async () => JSON.stringify(data),
-    headers: { get: () => null },
-  } as unknown as Response
-}
-
-function makeErrorResponse(status: number, text = 'error') {
-  return {
-    ok:      false,
+    ok:      status >= 200 && status < 300,
     status,
-    json:    async () => ({ ok: false }),
-    text:    async () => text,
-    headers: { get: () => null },
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null } as unknown as Headers,
+    json:    async () => body,
+    text:    async () => JSON.stringify(body),
   } as unknown as Response
 }
 
-const SECRETS   = { botToken: 'BOT_SECRET' }
-const BOT_TOKEN = 'BOT_SECRET'
-
-function makeDMUpdate(overrides?: Record<string, unknown>) {
-  return {
-    update_id: 1,
-    message: {
-      message_id: 42,
-      chat:       { id: 100, type: 'private' },
-      from:       { id: 999, first_name: 'Alice', username: 'alice' },
-      text:       'hola',
-      date:       1700000000,
-      ...overrides,
-    },
-  }
+function makeUpdatesResponse(updates: unknown[] = []): Response {
+  return makeFetchResponse({ ok: true, result: updates })
 }
 
-function makeSupergroupUpdate(threadId: number) {
-  return {
-    update_id: 2,
-    message: {
-      message_id:        55,
-      message_thread_id: threadId,
-      chat:              { id: 200, type: 'supergroup' },
-      from:              { id: 888, first_name: 'Bob' },
-      text:              'thread message',
-      date:              1700000001,
-    },
-  }
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeAdapter(): TelegramAdapter {
+  return new TelegramAdapter()
 }
 
-function makeCallbackUpdate() {
-  return {
-    update_id: 3,
-    callback_query: {
-      id:      'cq_001',
-      from:    { id: 777 },
-      data:    'btn_1',
+async function setupAdapter(
+  adapter: TelegramAdapter,
+  mode: 'webhook' | 'polling' = 'webhook',
+): Promise<void> {
+  // In polling mode, setup() calls deleteWebhook() first
+  if (mode === 'polling') {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+  }
+  await adapter.setup(
+    { mode },
+    { botToken: 'test-token-123', webhookSecret: 'test-secret' },
+  )
+}
+
+// ── describe('receive()') ──────────────────────────────────────────────────
+
+describe('receive()', () => {
+  let adapter: TelegramAdapter
+
+  beforeEach(() => {
+    adapter = makeAdapter()
+  })
+
+  it('DM text message → externalId=chatId, threadId=chatId, type=text, rawPayload, replyFn', async () => {
+    const update = {
+      update_id: 1,
       message: {
         message_id: 10,
         chat:       { id: 100, type: 'private' },
-        text:       'choose:',
-        date:       1700000002,
+        from:       { id: 200, username: 'alice' },
+        text:       'hello',
       },
-    },
-  }
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// describe: receive()
-// ════════════════════════════════════════════════════════════════════════════
-
-describe('receive()', () => {
-
-  it('mensaje DM → externalId=chatId, threadId=chatId, type=text, replyFn definida', async () => {
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
-
-    expect(incoming).not.toBeNull()
-    expect(incoming!.externalId).toBe('100')
-    expect(incoming!.threadId).toBe('100')
-    expect(incoming!.type).toBe('text')
-    expect(incoming!.replyFn).toBeDefined()
-    expect(incoming!.rawPayload).toBeDefined()
+    }
+    const result = await adapter.receive(update, { botToken: 'tok' })
+    expect(result).not.toBeNull()
+    expect(result!.externalId).toBe('100')
+    expect(result!.threadId).toBe('100')
+    expect(result!.type).toBe('text')
+    expect(result!.rawPayload).toBeDefined()
+    expect(typeof result!.replyFn).toBe('function')
   })
 
-  it('supergrupo con message_thread_id=42 → threadId=42, externalId=200', async () => {
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(
-      makeSupergroupUpdate(42) as Record<string, unknown>,
-      SECRETS,
-    )
-
-    expect(incoming!.threadId).toBe('42')
-    expect(incoming!.externalId).toBe('200')
-    expect(incoming!.threadId).not.toBe(incoming!.externalId)
+  it('supergroup message with message_thread_id=42 → threadId=42, externalId=chatId (distinct)', async () => {
+    const update = {
+      update_id: 2,
+      message: {
+        message_id:        20,
+        chat:              { id: 300, type: 'supergroup' },
+        from:              { id: 400 },
+        text:              'in a topic',
+        message_thread_id: 42,
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'tok' })
+    expect(result!.externalId).toBe('300')
+    expect(result!.threadId).toBe('42')
+    expect(result!.externalId).not.toBe(result!.threadId)
   })
 
-  it('mensaje /start → type=command', async () => {
-    const adapter  = new TelegramAdapter()
-    const update   = makeDMUpdate({ text: '/start' })
-    const incoming = await adapter.receive(update as Record<string, unknown>, SECRETS)
-
-    expect(incoming!.type).toBe('command')
+  it('/start command → type=command', async () => {
+    const update = {
+      update_id: 3,
+      message: {
+        message_id: 30,
+        chat:       { id: 500, type: 'private' },
+        from:       { id: 600 },
+        text:       '/start',
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'tok' })
+    expect(result!.type).toBe('command')
   })
 
-  it('mensaje con photo → type=image', async () => {
-    const adapter  = new TelegramAdapter()
-    const update   = makeDMUpdate({ photo: [{ file_id: 'abc' }], text: undefined })
-    const incoming = await adapter.receive(update as Record<string, unknown>, SECRETS)
-
-    expect(incoming!.type).toBe('image')
+  it('message with photo → type=image', async () => {
+    const update = {
+      update_id: 4,
+      message: {
+        message_id: 40,
+        chat:       { id: 700, type: 'private' },
+        from:       { id: 800 },
+        photo:      [{ file_id: 'abc' }],
+        caption:    'look at this',
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'tok' })
+    expect(result!.type).toBe('image')
   })
 
-  it('callback_query con data=btn_1 → type=command, text=btn_1, replyFn definida', async () => {
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(
-      makeCallbackUpdate() as Record<string, unknown>,
-      SECRETS,
-    )
-
-    expect(incoming).not.toBeNull()
-    expect(incoming!.type).toBe('command')
-    expect(incoming!.text).toBe('btn_1')
-    expect(incoming!.replyFn).toBeDefined()
+  it('callback_query with data="btn_1" → type=command, text=btn_1, replyFn defined', async () => {
+    const update = {
+      update_id:      5,
+      callback_query: {
+        id:      'cq-123',
+        from:    { id: 900 },
+        data:    'btn_1',
+        message: { message_id: 50, chat: { id: 1000, type: 'private' } },
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'tok' })
+    expect(result!.type).toBe('command')
+    expect(result!.text).toBe('btn_1')
+    expect(typeof result!.replyFn).toBe('function')
   })
 
-  it('update sin message ni callback_query → null', async () => {
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive({ update_id: 99 }, SECRETS)
-
-    expect(incoming).toBeNull()
+  it('update without message or callback_query → returns null', async () => {
+    const update = { update_id: 6 }
+    const result = await adapter.receive(update, { botToken: 'tok' })
+    expect(result).toBeNull()
   })
 
-  it('rawPayload no contiene botToken ni webhookSecret', async () => {
-    const adapter  = new TelegramAdapter()
-    const dirty    = { ...makeDMUpdate(), botToken: 'LEAKING_SECRET', webhookSecret: 'ALSO_LEAK' }
-    const incoming = await adapter.receive(dirty as Record<string, unknown>, SECRETS)
-
-    expect(incoming!.rawPayload['botToken']).toBeUndefined()
-    expect(incoming!.rawPayload['webhookSecret']).toBeUndefined()
-    // el update_id sí debe estar
-    expect(incoming!.rawPayload['update_id']).toBe(1)
+  it('rawPayload does not contain botToken or webhookSecret', async () => {
+    const update = {
+      update_id: 7,
+      message: {
+        message_id: 70,
+        chat:       { id: 1100, type: 'private' },
+        from:       { id: 1200 },
+        text:       'secure?',
+        botToken:   'SHOULD_NOT_APPEAR',
+        webhookSecret: 'SHOULD_NOT_APPEAR',
+      },
+    }
+    const result = await adapter.receive(update, {
+      botToken:      'secret-token',
+      webhookSecret: 'secret-webhook',
+    })
+    const raw = JSON.stringify(result!.rawPayload)
+    expect(raw).not.toContain('SHOULD_NOT_APPEAR')
+    expect(raw).not.toContain('secret-token')
+    expect(raw).not.toContain('secret-webhook')
   })
-
 })
 
-// ════════════════════════════════════════════════════════════════════════════
-// describe: replyFn — texto normal
-// ════════════════════════════════════════════════════════════════════════════
+// ── describe('replyFn — text message') ────────────────────────────────────
 
-describe('replyFn — texto normal', () => {
+describe('replyFn — text message', () => {
+  let adapter: TelegramAdapter
 
-  it('replyFn() llama sendMessage con chat_id y texto correctos', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
-
-    await incoming!.replyFn!('hola usuario')
-
-    expect(fetchMock).toHaveBeenCalledOnce()
-    const [url, init] = fetchMock.mock.calls[0]
-    expect(url).toContain(`/bot${BOT_TOKEN}/sendMessage`)
-    const body = JSON.parse(init!.body as string)
-    expect(body.chat_id).toBe('100')
-    expect(body.text).toBe('hola usuario')
+  beforeEach(() => {
+    adapter = makeAdapter()
+    mockFetch.mockReset()
   })
 
-  it('replyFn con format=markdown → parse_mode=Markdown', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
+  it('replyFn() calls sendMessage with correct chat_id and text', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+    const update = {
+      update_id: 10,
+      message: {
+        message_id: 100,
+        chat: { id: 555, type: 'private' },
+        from: { id: 666 },
+        text: 'hello',
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('world')
 
-    await incoming!.replyFn!('**negrita**', { format: 'markdown' })
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, init] = mockFetch.mock.calls[0]!
+    expect(url).toContain('/bot my-token/sendMessage'.replace(' ', ''))
+    const body = JSON.parse(init.body as string)
+    expect(body.chat_id).toBe('555')
+    expect(body.text).toBe('world')
+  })
 
-    const [, init] = fetchMock.mock.calls[0]
-    const body = JSON.parse(init!.body as string)
+  it('replyFn(text, { format: "markdown" }) → parse_mode=Markdown', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+    const update = {
+      update_id: 11,
+      message: {
+        message_id: 110,
+        chat: { id: 777, type: 'private' },
+        from: { id: 888 },
+        text: 'hi',
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('**bold**', { format: 'markdown' })
+
+    const [, init] = mockFetch.mock.calls[0]!
+    const body = JSON.parse(init.body as string)
     expect(body.parse_mode).toBe('Markdown')
   })
 
-  it('replyFn con quoteOriginal=true → reply_parameters.message_id set', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
+  it('replyFn(text, { quoteOriginal: true }) → reply_parameters.message_id set', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+    const update = {
+      update_id: 12,
+      message: {
+        message_id: 120,
+        chat: { id: 999, type: 'private' },
+        from: { id: 111 },
+        text: 'quote me',
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('quoted reply', { quoteOriginal: true })
 
-    await incoming!.replyFn!('cita', { quoteOriginal: true })
-
-    const [, init] = fetchMock.mock.calls[0]
-    const body = JSON.parse(init!.body as string)
-    expect(body.reply_parameters).toEqual({ message_id: 42 })
+    const [, init] = mockFetch.mock.calls[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.reply_parameters).toEqual({ message_id: 120 })
   })
 
-  it('replyFn en supergrupo → body incluye message_thread_id', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(
-      makeSupergroupUpdate(42) as Record<string, unknown>,
-      SECRETS,
-    )
+  it('replyFn in supergroup → body includes message_thread_id', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+    const update = {
+      update_id: 13,
+      message: {
+        message_id:        130,
+        chat:              { id: 2000, type: 'supergroup' },
+        from:              { id: 2001 },
+        text:              'topic reply',
+        message_thread_id: 99,
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('response in topic')
 
-    await incoming!.replyFn!('respuesta en topic')
-
-    const [, init] = fetchMock.mock.calls[0]
-    const body = JSON.parse(init!.body as string)
-    expect(body.message_thread_id).toBe(42)
+    const [, init] = mockFetch.mock.calls[0]!
+    const body = JSON.parse(init.body as string)
+    expect(body.message_thread_id).toBe(99)
   })
-
 })
 
-// ════════════════════════════════════════════════════════════════════════════
-// describe: replyFn — callback_query
-// ════════════════════════════════════════════════════════════════════════════
+// ── describe('replyFn — callback_query') ──────────────────────────────────
 
 describe('replyFn — callback_query', () => {
+  let adapter: TelegramAdapter
 
-  it('replyFn llama answerCallbackQuery PRIMERO con callback_query_id correcto', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(
-      makeCallbackUpdate() as Record<string, unknown>,
-      SECRETS,
-    )
+  beforeEach(() => {
+    adapter = makeAdapter()
+    mockFetch.mockReset()
+  })
 
-    await incoming!.replyFn!('respuesta botones')
+  it('replyFn calls answerCallbackQuery FIRST with callback_query_id', async () => {
+    // Two calls: answerCallbackQuery + sendMessage
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true }))
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    const [firstUrl, firstInit] = fetchMock.mock.calls[0]
+    const update = {
+      update_id:      20,
+      callback_query: {
+        id:      'cq-999',
+        from:    { id: 3000 },
+        data:    'action',
+        message: { message_id: 200, chat: { id: 4000, type: 'private' } },
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('response')
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    const [firstUrl, firstInit] = mockFetch.mock.calls[0]!
     expect(firstUrl).toContain('answerCallbackQuery')
-    const firstBody = JSON.parse(firstInit!.body as string)
-    expect(firstBody.callback_query_id).toBe('cq_001')
+    const firstBody = JSON.parse(firstInit.body as string)
+    expect(firstBody.callback_query_id).toBe('cq-999')
   })
 
-  it('replyFn llama sendMessage SEGUNDO con el texto', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const adapter  = new TelegramAdapter()
-    const incoming = await adapter.receive(
-      makeCallbackUpdate() as Record<string, unknown>,
-      SECRETS,
-    )
+  it('replyFn calls sendMessage SECOND with the text', async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true }))
 
-    await incoming!.replyFn!('texto respuesta callback')
+    const update = {
+      update_id:      21,
+      callback_query: {
+        id:      'cq-888',
+        from:    { id: 5000 },
+        data:    'press',
+        message: { message_id: 210, chat: { id: 6000, type: 'private' } },
+      },
+    }
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('button pressed!')
 
-    const [secondUrl, secondInit] = fetchMock.mock.calls[1]
+    const [secondUrl, secondInit] = mockFetch.mock.calls[1]!
     expect(secondUrl).toContain('sendMessage')
-    const secondBody = JSON.parse(secondInit!.body as string)
-    expect(secondBody.text).toBe('texto respuesta callback')
-    expect(secondBody.chat_id).toBe('100')
+    const secondBody = JSON.parse(secondInit.body as string)
+    expect(secondBody.text).toBe('button pressed!')
   })
-
 })
 
-// ════════════════════════════════════════════════════════════════════════════
-// describe: send()
-// ════════════════════════════════════════════════════════════════════════════
+// ── describe('send()') ────────────────────────────────────────────────────
 
 describe('send()', () => {
+  let adapter: TelegramAdapter
 
-  it('threadId distinto de externalId → body incluye message_thread_id', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse({ ok: true, result: {} }))
+  beforeEach(async () => {
+    adapter = makeAdapter()
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue(makeFetchResponse({ ok: true }))
+    await setupAdapter(adapter, 'webhook')
+    mockFetch.mockReset()
+  })
 
-    // Crear adaptador con botToken seteado directamente
-    const adapter = new TelegramAdapter()
-    // @ts-expect-error acceso privado en tests
-    adapter['botToken'] = BOT_TOKEN
-
-    await adapter.send({ externalId: '200', threadId: '42', text: 'reply thread' })
-
-    const [, init] = fetchMock.mock.calls[0]
-    const body = JSON.parse(init!.body as string)
+  it('send() with threadId !== externalId → body includes message_thread_id', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true }))
+    await adapter.send({
+      externalId:  '1000',
+      threadId:    '42',
+      text:        'hello topic',
+      type:        'text',
+      channelId:   'telegram',
+      agentId:     'agent-1',
+      sessionId:   'session-1',
+    })
+    const [, init] = mockFetch.mock.calls[0]!
+    const body = JSON.parse(init.body as string)
     expect(body.message_thread_id).toBe(42)
   })
 
-  it('send() con HTTP 429 y Retry-After:2 → espera antes de reintentar', async () => {
-    const sleepMock = vi.spyOn({ sleep }, 'sleep').mockResolvedValue(undefined)
-    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+  it('send() with HTTP 429 and Retry-After: 2 → waits 2s before retry', async () => {
+    vi.useFakeTimers()
+    mockFetch
+      .mockResolvedValueOnce(
+        makeFetchResponse({ ok: false }, 429, { 'retry-after': '2' }),
+      )
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true }))
 
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: false, status: 429,
-        headers: { get: (h: string) => h === 'retry-after' ? '2' : null },
-        json: async () => ({}), text: async () => '',
-      } as unknown as Response)
-      .mockResolvedValueOnce(makeOkResponse({ ok: true, result: {} }))
-
-    const adapter = new TelegramAdapter()
-    // @ts-expect-error acceso privado en tests
-    adapter['botToken'] = BOT_TOKEN
-
-    await adapter.send({ externalId: '100', text: 'retry test' })
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('send() con 3 errores consecutivos (red) → lanza Error', async () => {
-    // Suprimir setTimeouts del backoff para que el test no espere
-    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
-    fetchMock.mockRejectedValue(new Error('Network error'))
-
-    const adapter = new TelegramAdapter()
-    // @ts-expect-error acceso privado en tests
-    adapter['botToken'] = BOT_TOKEN
-
-    await expect(adapter.send({ externalId: '100', text: 'fail' })).rejects.toThrow('Network error')
-    expect(fetchMock).toHaveBeenCalledTimes(3)
-  })
-
-})
-
-// ════════════════════════════════════════════════════════════════════════════
-// describe: long-polling loop
-// ════════════════════════════════════════════════════════════════════════════
-
-describe('long-polling loop', () => {
-
-  it('startPollingLoop() llama getUpdates con offset=0 y timeout=25', async () => {
-    // Respuesta inicial con updates, luego dispose
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true, status: 200,
-        headers: { get: () => null },
-        json: async () => ({ ok: true, result: [] }),
-        text: async () => '',
-      } as unknown as Response)
-
-    const adapter = new TelegramAdapter()
-    // @ts-expect-error acceso privado
-    adapter['botToken'] = BOT_TOKEN
-
-    // stubGlobal setTimeout para evitar espera real del sleep post-poll
-    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
-
-    // @ts-expect-error
-    adapter['pollingActive'] = true
-    // Llamar directamente a una sola iteración mockeando while
-    // @ts-expect-error
-    const originalActive = adapter['pollingActive']
-    // @ts-expect-error
-    adapter['pollingActive'] = false  // stop after first fetch check below
-
-    // Verificar directamente la llamada a getUpdates
-    // @ts-expect-error
-    adapter['pollingActive'] = true
-    // forzar que el loop haga una sola iteración
-    let calls = 0
-    const realFetch = fetchMock
-    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
-      calls++
-      if (calls === 1) {
-        // Detener el loop después del primer getUpdates
-        // @ts-expect-error
-        adapter['pollingActive'] = false
-        return {
-          ok: true, status: 200,
-          headers: { get: () => null },
-          json: async () => ({ ok: true, result: [] }),
-          text: async () => '',
-        } as unknown as Response
-      }
-      return makeOkResponse()
+    const sendPromise = adapter.send({
+      externalId: '1000',
+      text:       'test 429',
+      type:       'text',
+      channelId:  'telegram',
+      agentId:    'agent-1',
+      sessionId:  'session-1',
     })
 
-    // @ts-expect-error
-    adapter['pollingActive'] = true
-    // @ts-expect-error
-    await adapter['runPollingLoop']()
+    // Advance timers to simulate Retry-After wait
+    await vi.advanceTimersByTimeAsync(2100)
+    await sendPromise
 
-    const getUpdatesCalls = fetchMock.mock.calls.filter(([url]) =>
-      typeof url === 'string' && url.includes('getUpdates')
-    )
-    expect(getUpdatesCalls.length).toBeGreaterThanOrEqual(1)
-    const [, init] = getUpdatesCalls[0]
-    const body = JSON.parse(init!.body as string)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('send() with 3 consecutive errors → throws Error', async () => {
+    vi.useFakeTimers()
+    mockFetch.mockRejectedValue(new Error('network error'))
+
+    const sendPromise = adapter.send({
+      externalId: '1000',
+      text:       'fail',
+      type:       'text',
+      channelId:  'telegram',
+      agentId:    'agent-1',
+      sessionId:  'session-1',
+    })
+
+    // Advance timers past all backoff delays (500ms + 1000ms)
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(sendPromise).rejects.toThrow()
+    vi.useRealTimers()
+  })
+})
+
+// ── describe('long-polling loop') ─────────────────────────────────────────
+
+describe('long-polling loop', () => {
+  let adapter: TelegramAdapter
+
+  beforeEach(() => {
+    adapter = makeAdapter()
+    mockFetch.mockReset()
+  })
+
+  afterEach(async () => {
+    await adapter.dispose()
+  })
+
+  it('startPollingLoop → calls getUpdates with offset=0 and timeout=25', async () => {
+    // deleteWebhook + getUpdates (returns empty so loop pauses)
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true })) // deleteWebhook
+      .mockResolvedValueOnce(makeUpdatesResponse([]))          // getUpdates
+      .mockResolvedValue(makeUpdatesResponse([]))              // subsequent calls
+
+    await setupAdapter(adapter, 'polling')
+    // Give the loop a tick to run
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Second call is getUpdates (first was deleteWebhook)
+    const [url, init] = mockFetch.mock.calls[1]!
+    expect(url).toContain('getUpdates')
+    const body = JSON.parse(init.body as string)
     expect(body.offset).toBe(0)
     expect(body.timeout).toBe(25)
   })
 
-  it('update_id=100 recibido → pollingOffset = 101', async () => {
-    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+  it('receiving update_id=100 → pollingOffset updates to 101', async () => {
+    const processUpdateSpy = vi.spyOn(adapter as unknown as { processUpdate: () => Promise<void> }, 'processUpdate')
+      .mockResolvedValue()
 
-    const adapter = new TelegramAdapter()
-    // @ts-expect-error
-    adapter['botToken'] = BOT_TOKEN
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true })) // deleteWebhook
+      .mockResolvedValueOnce(makeUpdatesResponse([           // getUpdates with one update
+        { update_id: 100, message: { message_id: 1, chat: { id: 1, type: 'private' }, text: 'hi' } },
+      ]))
+      .mockResolvedValue(makeUpdatesResponse([]))             // subsequent calls
 
-    let callCount = 0
-    fetchMock.mockImplementation(async (url: string) => {
-      callCount++
-      if (callCount === 1 && url.includes('getUpdates')) {
-        // @ts-expect-error
-        adapter['pollingActive'] = false  // stop after processing
-        return {
-          ok: true, status: 200,
-          headers: { get: () => null },
-          json: async () => ({
-            ok: true,
-            result: [makeDMUpdate()],  // update_id=1
-          }),
-          text: async () => '',
-        } as unknown as Response
-      }
-      return makeOkResponse()
-    })
+    await setupAdapter(adapter, 'polling')
+    await new Promise((r) => setTimeout(r, 50))
 
-    // Mock processUpdate to avoid real receive()
-    // @ts-expect-error
-    adapter.processUpdate = vi.fn().mockResolvedValue(undefined)
+    // Verify processUpdate was called
+    expect(processUpdateSpy).toHaveBeenCalled()
 
-    // @ts-expect-error
-    adapter['pollingActive'] = true
-    // @ts-expect-error
-    await adapter['runPollingLoop']()
-
-    // @ts-expect-error
-    expect(adapter['pollingOffset']).toBe(2)  // update_id=1, so offset=2
+    // Next getUpdates call should have offset=101
+    const thirdCall = mockFetch.mock.calls[2]
+    if (thirdCall) {
+      const body = JSON.parse(thirdCall[1].body as string)
+      expect(body.offset).toBe(101)
+    }
   })
 
-  it('getUpdates retorna 401 → loop se detiene, errorHandler llamado', async () => {
-    fetchMock.mockResolvedValue(makeErrorResponse(401, 'Unauthorized'))
-
-    const adapter       = new TelegramAdapter()
-    const errorHandler  = vi.fn()
-    adapter.onError(errorHandler)
-    // @ts-expect-error
-    adapter['botToken'] = BOT_TOKEN
-    // @ts-expect-error
-    adapter['pollingActive'] = true
-    // @ts-expect-error
-    await adapter['runPollingLoop']()
-
-    // @ts-expect-error
-    expect(adapter['pollingActive']).toBe(false)
-    expect(errorHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('401') })
-    )
-  })
-
-  it('5 errores consecutivos → circuit breaker: errorHandler llamado', async () => {
-    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
-
-    let errorCount = 0
-    fetchMock.mockImplementation(async (url: string) => {
-      if (url.includes('getUpdates')) {
-        errorCount++
-        if (errorCount > 5) {
-          // Detener el loop después del circuit breaker
-          return {
-            ok: true, status: 200,
-            headers: { get: () => null },
-            json: async () => ({ ok: true, result: [] }),
-            text: async () => '',
-          } as unknown as Response
-        }
-        throw new Error('Network error')
-      }
-      return makeOkResponse()
-    })
-
-    const adapter      = new TelegramAdapter()
+  it('getUpdates returns 401 → loop stops and errorHandler called', async () => {
     const errorHandler = vi.fn()
     adapter.onError(errorHandler)
-    // @ts-expect-error
-    adapter['botToken']       = BOT_TOKEN
-    // @ts-expect-error
-    adapter['channelConfig']  = { maxConsecutiveErrors: 5, pollingInterval: 1 }
 
-    let calls = 0
-    const origImpl = fetchMock.getMockImplementation()
-    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
-      calls++
-      const resp = await origImpl!(url, init)
-      // Stop loop after circuit breaker fires and we get one success
-      if (calls > 6) {
-        // @ts-expect-error
-        adapter['pollingActive'] = false
-      }
-      return resp
-    })
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true }))         // deleteWebhook
+      .mockResolvedValueOnce(makeFetchResponse({ ok: false }, 401))   // getUpdates → 401
 
-    // @ts-expect-error
-    adapter['pollingActive'] = true
-    // @ts-expect-error
-    await adapter['runPollingLoop']()
+    await setupAdapter(adapter, 'polling')
+    await new Promise((r) => setTimeout(r, 50))
 
     expect(errorHandler).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('circuit breaker') })
+      expect.objectContaining({ message: expect.stringContaining('401') }),
     )
   })
 
-  it('dispose() → AbortController.abort() chiamado, loop termina', async () => {
-    const abortMock = vi.fn()
-    const adapter   = new TelegramAdapter()
-    // @ts-expect-error
-    adapter['pollingAbortCtrl'] = { abort: abortMock }
+  it('5 consecutive errors → circuit breaker: errorHandler called, loop pauses 60s', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const errorHandler = vi.fn()
+    adapter.onError(errorHandler)
 
+    const networkError = new Error('network failure')
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true })) // deleteWebhook
+      .mockRejectedValue(networkError)                        // all getUpdates fail
+
+    await setupAdapter(adapter, 'polling')
+
+    // Advance time to allow 5 errors + circuit breaker detection
+    await vi.advanceTimersByTimeAsync(20_000)
+
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('circuit breaker'),
+      }),
+    )
+
+    vi.useRealTimers()
+  })
+
+  it('dispose() → AbortController.abort() called, loop terminates cleanly', async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeFetchResponse({ ok: true })) // deleteWebhook
+      .mockImplementation(() => new Promise((_, reject) => {
+        // Simulate a long-running request that gets aborted
+        setTimeout(() => reject(Object.assign(new Error('AbortError'), { name: 'AbortError' })), 100)
+      }))
+
+    await setupAdapter(adapter, 'polling')
+    // Give loop a tick to start
+    await new Promise((r) => setTimeout(r, 10))
+
+    // dispose() should stop the loop
     await adapter.dispose()
 
-    expect(abortMock).toHaveBeenCalledOnce()
-    // @ts-expect-error
-    expect(adapter['pollingActive']).toBe(false)
+    // After dispose, the loop should not be active anymore
+    // (verified by no additional fetch calls after abort)
+    const callCountAfterDispose = mockFetch.mock.calls.length
+    await new Promise((r) => setTimeout(r, 200))
+    expect(mockFetch.mock.calls.length).toBe(callCountAfterDispose)
   })
-
 })
 
-// ════════════════════════════════════════════════════════════════════════════
-// describe: webhook handler
-// ════════════════════════════════════════════════════════════════════════════
+// ── describe('webhook handler') ───────────────────────────────────────────
 
 describe('webhook handler', () => {
+  let adapter: TelegramAdapter
 
-  function makeRouter(webhookSecret = '') {
-    const adapter = new TelegramAdapter()
-    // @ts-expect-error
-    adapter['botToken']       = BOT_TOKEN
-    // @ts-expect-error
-    adapter['webhookSecret']  = webhookSecret
-    return { adapter, router: adapter.getRouter() }
+  beforeEach(async () => {
+    adapter = makeAdapter()
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue(makeFetchResponse({ ok: true }))
+    await setupAdapter(adapter, 'webhook')
+    mockFetch.mockReset()
+  })
+
+  function simulateRequest(
+    body:    Record<string, unknown>,
+    headers: Record<string, string> = {},
+  ) {
+    const router  = adapter.getRouter()
+    const layer   = (router.stack as unknown as Array<{ route?: { path: string; stack: Array<{ handle: (req: unknown, res: unknown) => void }> } }>)
+      .find((l) => l.route?.path === '/webhook')
+    const handler = layer!.route!.stack[0]!.handle
+
+    const resMock = {
+      status:  vi.fn().mockReturnThis(),
+      json:    vi.fn().mockReturnThis(),
+    }
+    const reqMock = { body, headers: { 'x-telegram-bot-api-secret-token': headers['x-telegram-bot-api-secret-token'] } }
+    handler(reqMock, resMock)
+    return resMock
   }
 
-  function mockReqRes(headers: Record<string, string> = {}, body: unknown = {}) {
-    const res = {
-      json:   vi.fn().mockReturnThis(),
-      status: vi.fn().mockReturnThis(),
-    }
-    const req = {
-      headers,
-      body,
-    }
-    return { req: req as unknown as Request, res: res as unknown as Response }
-  }
-
-  it('POST /webhook sin secret header cuando webhookSecret configurado → 403', async () => {
-    const { adapter, router } = makeRouter('MY_SECRET')
-    const { req, res } = mockReqRes({}, makeDMUpdate())
-
-    // Invocar el handler directamente
-    const webhookRoute = router.stack.find(
-      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
-        layer.route?.path === '/webhook'
-    )
-    const handler = webhookRoute?.route?.stack[0]?.handle as (
-      req: Request,
-      res: Response,
-    ) => Promise<void>
-
-    await handler(req, res)
-
-    expect((res as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(403)
+  it('POST without correct secret header → 403', async () => {
+    const res = simulateRequest({ update_id: 1 }, {})
+    await new Promise((r) => setTimeout(r, 10))
+    expect(res.status).toHaveBeenCalledWith(403)
   })
 
-  it('POST /webhook con secret header correcto → 200 inmediato', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse())
-    const { adapter, router } = makeRouter('MY_SECRET')
-
-    // Mockear processUpdate para que no falle
-    // @ts-expect-error
-    adapter.processUpdate = vi.fn().mockResolvedValue(undefined)
-
-    const { req, res } = mockReqRes(
-      { 'x-telegram-bot-api-secret-token': 'MY_SECRET' },
-      makeDMUpdate(),
+  it('POST with correct secret header → 200 immediately, processUpdate async', async () => {
+    const res = simulateRequest(
+      { update_id: 1, message: { message_id: 1, chat: { id: 1, type: 'private' }, text: 'hi' } },
+      { 'x-telegram-bot-api-secret-token': 'test-secret' },
     )
-
-    const webhookRoute = router.stack.find(
-      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
-        layer.route?.path === '/webhook'
-    )
-    const handler = webhookRoute?.route?.stack[0]?.handle as (
-      req: Request,
-      res: Response,
-    ) => Promise<void>
-
-    await handler(req, res)
-
-    expect((res as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({ ok: true })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(res.json).toHaveBeenCalledWith({ ok: true })
+    // 200 was returned (no status() call = default 200)
+    expect(res.status).not.toHaveBeenCalledWith(403)
   })
 
-  it('POST /setup sin webhookUrl → 400', async () => {
-    const { router } = makeRouter()
-    const { req, res } = mockReqRes({}, {})
+  it('POST /setup without webhookUrl → 400', async () => {
+    const router = adapter.getRouter()
+    const layer  = (router.stack as unknown as Array<{ route?: { path: string; stack: Array<{ handle: (req: unknown, res: unknown) => void }> } }>)
+      .find((l) => l.route?.path === '/setup')
+    const handler = layer!.route!.stack[0]!.handle
 
-    const setupRoute = router.stack.find(
-      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
-        layer.route?.path === '/setup'
+    const resMock = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() }
+    await (handler as (req: unknown, res: unknown) => Promise<void>)(
+      { body: {} },
+      resMock,
     )
-    const handler = setupRoute?.route?.stack[0]?.handle as (
-      req: Request,
-      res: Response,
-    ) => Promise<void>
-
-    await handler(req, res)
-
-    expect((res as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(400)
+    expect(resMock.status).toHaveBeenCalledWith(400)
   })
 
-  it('POST /setup con webhookUrl → llama setWebhook en Telegram, retorna 200', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse({ ok: true, result: true }))
-    const { router } = makeRouter()
-    const { req, res } = mockReqRes({}, { webhookUrl: 'https://example.com' })
-
-    const setupRoute = router.stack.find(
-      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
-        layer.route?.path === '/setup'
+  it('POST /setup with webhookUrl → calls setWebhook and returns 200', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeFetchResponse({ ok: true, result: true }),
     )
-    const handler = setupRoute?.route?.stack[0]?.handle as (
-      req: Request,
-      res: Response,
-    ) => Promise<void>
 
-    await handler(req, res)
+    const router  = adapter.getRouter()
+    const layer   = (router.stack as unknown as Array<{ route?: { path: string; stack: Array<{ handle: (req: unknown, res: unknown) => void }> } }>)
+      .find((l) => l.route?.path === '/setup')
+    const handler = layer!.route!.stack[0]!.handle
 
-    const [url] = fetchMock.mock.calls[0]
+    const resMock = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() }
+    await (handler as (req: unknown, res: unknown) => Promise<void>)(
+      { body: { webhookUrl: 'https://example.com' } },
+      resMock,
+    )
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url] = mockFetch.mock.calls[0]!
     expect(url).toContain('setWebhook')
-    expect((res as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith(
-      expect.objectContaining({ ok: true })
+    expect(resMock.json).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true }),
     )
   })
 
-  it('DELETE /webhook → llama deleteWebhook en Telegram', async () => {
-    fetchMock.mockResolvedValue(makeOkResponse({ ok: true, result: true }))
-    const { router } = makeRouter()
-
-    const deleteRoute = router.stack.find(
-      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
-        layer.route?.path === '/webhook'
+  it('DELETE /webhook → calls deleteWebhook on Telegram', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeFetchResponse({ ok: true, result: true }),
     )
-    // find the DELETE handler specifically
-    const deleteHandler = deleteRoute?.route?.stack.find(
-      (s: { method?: string; handle: unknown }) => s.method === 'delete'
-    )?.handle as ((req: Request, res: Response) => Promise<void>) | undefined
 
-    if (deleteHandler) {
-      const { req, res } = mockReqRes()
-      await deleteHandler(req, res)
-      const [url] = fetchMock.mock.calls[0]
-      expect(url).toContain('deleteWebhook')
-    } else {
-      // Fallback: verify via adapter directly
-      const { adapter } = makeRouter()
+    const router  = adapter.getRouter()
+    const layer   = (router.stack as unknown as Array<{ route?: { path: string; stack: Array<{ handle: (req: unknown, res: unknown) => void }> } }>)
+      .find((l) => l.route?.path === '/webhook' && l.route.stack.length > 0)
+
+    // Get the DELETE handler specifically
+    const deleteHandler = (router.stack as unknown as Array<{ route?: { path: string; methods: Record<string, boolean>; stack: Array<{ handle: (req: unknown, res: unknown) => Promise<void> }> } }>)
+      .find((l) => l.route?.path === '/webhook' && l.route.methods['delete'])
+
+    if (!deleteHandler?.route) {
+      // Fallback: call deleteWebhook directly
+      mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: true, result: true }))
       await adapter.deleteWebhook()
-      expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('deleteWebhook'),
-        expect.anything(),
-      )
+      expect(mockFetch).toHaveBeenCalled()
+      const [url] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1]!
+      expect(url).toContain('deleteWebhook')
+      return
     }
+
+    const resMock = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() }
+    await deleteHandler.route.stack[0]!.handle({}, resMock)
+    expect(mockFetch).toHaveBeenCalled()
+  })
+})
+
+// ── describe('fetchWithRetry') ────────────────────────────────────────────
+
+describe('fetchWithRetry', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
   })
 
+  it('returns response on first success', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ data: 'ok' }))
+    const res = await fetchWithRetry('https://example.com', { method: 'GET' })
+    expect(res.ok).toBe(true)
+    expect(mockFetch).toHaveBeenCalledOnce()
+  })
+
+  it('retries on network error and succeeds on second attempt', async () => {
+    vi.useFakeTimers()
+    mockFetch
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(makeFetchResponse({ data: 'ok' }))
+
+    const promise = fetchWithRetry('https://example.com', { method: 'GET' })
+    await vi.advanceTimersByTimeAsync(1000)
+    const res = await promise
+
+    expect(res.ok).toBe(true)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('throws after maxTries exhausted', async () => {
+    vi.useFakeTimers()
+    mockFetch.mockRejectedValue(new Error('always fails'))
+
+    const promise = fetchWithRetry('https://example.com', { method: 'GET' }, 3)
+    await vi.advanceTimersByTimeAsync(5000)
+
+    await expect(promise).rejects.toThrow()
+    vi.useRealTimers()
+  })
 })

--- a/apps/gateway/src/channels/__tests__/telegram.adapter.test.ts
+++ b/apps/gateway/src/channels/__tests__/telegram.adapter.test.ts
@@ -321,6 +321,27 @@ describe('replyFn — callback_query', () => {
     const secondBody = JSON.parse(secondInit.body as string)
     expect(secondBody.text).toBe('button pressed!')
   })
+
+  it('replyFn stops when answerCallbackQuery fails', async () => {
+    mockFetch.mockResolvedValueOnce(makeFetchResponse({ ok: false, description: 'expired' }, 400))
+
+    const update = {
+      update_id:      22,
+      callback_query: {
+        id:      'cq-expired',
+        from:    { id: 6000 },
+        data:    'press',
+        message: { message_id: 220, chat: { id: 7000, type: 'private' } },
+      },
+    }
+
+    const result = await adapter.receive(update, { botToken: 'my-token' })
+    await result!.replyFn('should not send')
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url] = mockFetch.mock.calls[0]!
+    expect(url).toContain('answerCallbackQuery')
+  })
 })
 
 // ── describe('send()') ────────────────────────────────────────────────────

--- a/apps/gateway/src/channels/__tests__/telegram.adapter.test.ts
+++ b/apps/gateway/src/channels/__tests__/telegram.adapter.test.ts
@@ -1,0 +1,664 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { TelegramAdapter, fetchWithRetry, sleep } from '../telegram.adapter.js'
+import type { IncomingMessage } from '../channel-adapter.interface.js'
+
+// ── Mock global fetch ───────────────────────────────────────────────────────
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeOkResponse(data: unknown = { ok: true }) {
+  return {
+    ok:      true,
+    status:  200,
+    json:    async () => data,
+    text:    async () => JSON.stringify(data),
+    headers: { get: () => null },
+  } as unknown as Response
+}
+
+function makeErrorResponse(status: number, text = 'error') {
+  return {
+    ok:      false,
+    status,
+    json:    async () => ({ ok: false }),
+    text:    async () => text,
+    headers: { get: () => null },
+  } as unknown as Response
+}
+
+const SECRETS   = { botToken: 'BOT_SECRET' }
+const BOT_TOKEN = 'BOT_SECRET'
+
+function makeDMUpdate(overrides?: Record<string, unknown>) {
+  return {
+    update_id: 1,
+    message: {
+      message_id: 42,
+      chat:       { id: 100, type: 'private' },
+      from:       { id: 999, first_name: 'Alice', username: 'alice' },
+      text:       'hola',
+      date:       1700000000,
+      ...overrides,
+    },
+  }
+}
+
+function makeSupergroupUpdate(threadId: number) {
+  return {
+    update_id: 2,
+    message: {
+      message_id:        55,
+      message_thread_id: threadId,
+      chat:              { id: 200, type: 'supergroup' },
+      from:              { id: 888, first_name: 'Bob' },
+      text:              'thread message',
+      date:              1700000001,
+    },
+  }
+}
+
+function makeCallbackUpdate() {
+  return {
+    update_id: 3,
+    callback_query: {
+      id:      'cq_001',
+      from:    { id: 777 },
+      data:    'btn_1',
+      message: {
+        message_id: 10,
+        chat:       { id: 100, type: 'private' },
+        text:       'choose:',
+        date:       1700000002,
+      },
+    },
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: receive()
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('receive()', () => {
+
+  it('mensaje DM → externalId=chatId, threadId=chatId, type=text, replyFn definida', async () => {
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.externalId).toBe('100')
+    expect(incoming!.threadId).toBe('100')
+    expect(incoming!.type).toBe('text')
+    expect(incoming!.replyFn).toBeDefined()
+    expect(incoming!.rawPayload).toBeDefined()
+  })
+
+  it('supergrupo con message_thread_id=42 → threadId=42, externalId=200', async () => {
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(
+      makeSupergroupUpdate(42) as Record<string, unknown>,
+      SECRETS,
+    )
+
+    expect(incoming!.threadId).toBe('42')
+    expect(incoming!.externalId).toBe('200')
+    expect(incoming!.threadId).not.toBe(incoming!.externalId)
+  })
+
+  it('mensaje /start → type=command', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeDMUpdate({ text: '/start' })
+    const incoming = await adapter.receive(update as Record<string, unknown>, SECRETS)
+
+    expect(incoming!.type).toBe('command')
+  })
+
+  it('mensaje con photo → type=image', async () => {
+    const adapter  = new TelegramAdapter()
+    const update   = makeDMUpdate({ photo: [{ file_id: 'abc' }], text: undefined })
+    const incoming = await adapter.receive(update as Record<string, unknown>, SECRETS)
+
+    expect(incoming!.type).toBe('image')
+  })
+
+  it('callback_query con data=btn_1 → type=command, text=btn_1, replyFn definida', async () => {
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(
+      makeCallbackUpdate() as Record<string, unknown>,
+      SECRETS,
+    )
+
+    expect(incoming).not.toBeNull()
+    expect(incoming!.type).toBe('command')
+    expect(incoming!.text).toBe('btn_1')
+    expect(incoming!.replyFn).toBeDefined()
+  })
+
+  it('update sin message ni callback_query → null', async () => {
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive({ update_id: 99 }, SECRETS)
+
+    expect(incoming).toBeNull()
+  })
+
+  it('rawPayload no contiene botToken ni webhookSecret', async () => {
+    const adapter  = new TelegramAdapter()
+    const dirty    = { ...makeDMUpdate(), botToken: 'LEAKING_SECRET', webhookSecret: 'ALSO_LEAK' }
+    const incoming = await adapter.receive(dirty as Record<string, unknown>, SECRETS)
+
+    expect(incoming!.rawPayload['botToken']).toBeUndefined()
+    expect(incoming!.rawPayload['webhookSecret']).toBeUndefined()
+    // el update_id sí debe estar
+    expect(incoming!.rawPayload['update_id']).toBe(1)
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: replyFn — texto normal
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('replyFn — texto normal', () => {
+
+  it('replyFn() llama sendMessage con chat_id y texto correctos', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
+
+    await incoming!.replyFn!('hola usuario')
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toContain(`/bot${BOT_TOKEN}/sendMessage`)
+    const body = JSON.parse(init!.body as string)
+    expect(body.chat_id).toBe('100')
+    expect(body.text).toBe('hola usuario')
+  })
+
+  it('replyFn con format=markdown → parse_mode=Markdown', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
+
+    await incoming!.replyFn!('**negrita**', { format: 'markdown' })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.parse_mode).toBe('Markdown')
+  })
+
+  it('replyFn con quoteOriginal=true → reply_parameters.message_id set', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(makeDMUpdate() as Record<string, unknown>, SECRETS)
+
+    await incoming!.replyFn!('cita', { quoteOriginal: true })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.reply_parameters).toEqual({ message_id: 42 })
+  })
+
+  it('replyFn en supergrupo → body incluye message_thread_id', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(
+      makeSupergroupUpdate(42) as Record<string, unknown>,
+      SECRETS,
+    )
+
+    await incoming!.replyFn!('respuesta en topic')
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.message_thread_id).toBe(42)
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: replyFn — callback_query
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('replyFn — callback_query', () => {
+
+  it('replyFn llama answerCallbackQuery PRIMERO con callback_query_id correcto', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(
+      makeCallbackUpdate() as Record<string, unknown>,
+      SECRETS,
+    )
+
+    await incoming!.replyFn!('respuesta botones')
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0]
+    expect(firstUrl).toContain('answerCallbackQuery')
+    const firstBody = JSON.parse(firstInit!.body as string)
+    expect(firstBody.callback_query_id).toBe('cq_001')
+  })
+
+  it('replyFn llama sendMessage SEGUNDO con el texto', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const adapter  = new TelegramAdapter()
+    const incoming = await adapter.receive(
+      makeCallbackUpdate() as Record<string, unknown>,
+      SECRETS,
+    )
+
+    await incoming!.replyFn!('texto respuesta callback')
+
+    const [secondUrl, secondInit] = fetchMock.mock.calls[1]
+    expect(secondUrl).toContain('sendMessage')
+    const secondBody = JSON.parse(secondInit!.body as string)
+    expect(secondBody.text).toBe('texto respuesta callback')
+    expect(secondBody.chat_id).toBe('100')
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: send()
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('send()', () => {
+
+  it('threadId distinto de externalId → body incluye message_thread_id', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse({ ok: true, result: {} }))
+
+    // Crear adaptador con botToken seteado directamente
+    const adapter = new TelegramAdapter()
+    // @ts-expect-error acceso privado en tests
+    adapter['botToken'] = BOT_TOKEN
+
+    await adapter.send({ externalId: '200', threadId: '42', text: 'reply thread' })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.message_thread_id).toBe(42)
+  })
+
+  it('send() con HTTP 429 y Retry-After:2 → espera antes de reintentar', async () => {
+    const sleepMock = vi.spyOn({ sleep }, 'sleep').mockResolvedValue(undefined)
+    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false, status: 429,
+        headers: { get: (h: string) => h === 'retry-after' ? '2' : null },
+        json: async () => ({}), text: async () => '',
+      } as unknown as Response)
+      .mockResolvedValueOnce(makeOkResponse({ ok: true, result: {} }))
+
+    const adapter = new TelegramAdapter()
+    // @ts-expect-error acceso privado en tests
+    adapter['botToken'] = BOT_TOKEN
+
+    await adapter.send({ externalId: '100', text: 'retry test' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('send() con 3 errores consecutivos (red) → lanza Error', async () => {
+    // Suprimir setTimeouts del backoff para que el test no espere
+    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+    fetchMock.mockRejectedValue(new Error('Network error'))
+
+    const adapter = new TelegramAdapter()
+    // @ts-expect-error acceso privado en tests
+    adapter['botToken'] = BOT_TOKEN
+
+    await expect(adapter.send({ externalId: '100', text: 'fail' })).rejects.toThrow('Network error')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: long-polling loop
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('long-polling loop', () => {
+
+  it('startPollingLoop() llama getUpdates con offset=0 y timeout=25', async () => {
+    // Respuesta inicial con updates, luego dispose
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        headers: { get: () => null },
+        json: async () => ({ ok: true, result: [] }),
+        text: async () => '',
+      } as unknown as Response)
+
+    const adapter = new TelegramAdapter()
+    // @ts-expect-error acceso privado
+    adapter['botToken'] = BOT_TOKEN
+
+    // stubGlobal setTimeout para evitar espera real del sleep post-poll
+    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+
+    // @ts-expect-error
+    adapter['pollingActive'] = true
+    // Llamar directamente a una sola iteración mockeando while
+    // @ts-expect-error
+    const originalActive = adapter['pollingActive']
+    // @ts-expect-error
+    adapter['pollingActive'] = false  // stop after first fetch check below
+
+    // Verificar directamente la llamada a getUpdates
+    // @ts-expect-error
+    adapter['pollingActive'] = true
+    // forzar que el loop haga una sola iteración
+    let calls = 0
+    const realFetch = fetchMock
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      calls++
+      if (calls === 1) {
+        // Detener el loop después del primer getUpdates
+        // @ts-expect-error
+        adapter['pollingActive'] = false
+        return {
+          ok: true, status: 200,
+          headers: { get: () => null },
+          json: async () => ({ ok: true, result: [] }),
+          text: async () => '',
+        } as unknown as Response
+      }
+      return makeOkResponse()
+    })
+
+    // @ts-expect-error
+    adapter['pollingActive'] = true
+    // @ts-expect-error
+    await adapter['runPollingLoop']()
+
+    const getUpdatesCalls = fetchMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.includes('getUpdates')
+    )
+    expect(getUpdatesCalls.length).toBeGreaterThanOrEqual(1)
+    const [, init] = getUpdatesCalls[0]
+    const body = JSON.parse(init!.body as string)
+    expect(body.offset).toBe(0)
+    expect(body.timeout).toBe(25)
+  })
+
+  it('update_id=100 recibido → pollingOffset = 101', async () => {
+    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+
+    const adapter = new TelegramAdapter()
+    // @ts-expect-error
+    adapter['botToken'] = BOT_TOKEN
+
+    let callCount = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      callCount++
+      if (callCount === 1 && url.includes('getUpdates')) {
+        // @ts-expect-error
+        adapter['pollingActive'] = false  // stop after processing
+        return {
+          ok: true, status: 200,
+          headers: { get: () => null },
+          json: async () => ({
+            ok: true,
+            result: [makeDMUpdate()],  // update_id=1
+          }),
+          text: async () => '',
+        } as unknown as Response
+      }
+      return makeOkResponse()
+    })
+
+    // Mock processUpdate to avoid real receive()
+    // @ts-expect-error
+    adapter.processUpdate = vi.fn().mockResolvedValue(undefined)
+
+    // @ts-expect-error
+    adapter['pollingActive'] = true
+    // @ts-expect-error
+    await adapter['runPollingLoop']()
+
+    // @ts-expect-error
+    expect(adapter['pollingOffset']).toBe(2)  // update_id=1, so offset=2
+  })
+
+  it('getUpdates retorna 401 → loop se detiene, errorHandler llamado', async () => {
+    fetchMock.mockResolvedValue(makeErrorResponse(401, 'Unauthorized'))
+
+    const adapter       = new TelegramAdapter()
+    const errorHandler  = vi.fn()
+    adapter.onError(errorHandler)
+    // @ts-expect-error
+    adapter['botToken'] = BOT_TOKEN
+    // @ts-expect-error
+    adapter['pollingActive'] = true
+    // @ts-expect-error
+    await adapter['runPollingLoop']()
+
+    // @ts-expect-error
+    expect(adapter['pollingActive']).toBe(false)
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('401') })
+    )
+  })
+
+  it('5 errores consecutivos → circuit breaker: errorHandler llamado', async () => {
+    vi.stubGlobal('setTimeout', (fn: () => void) => { fn(); return 0 })
+
+    let errorCount = 0
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('getUpdates')) {
+        errorCount++
+        if (errorCount > 5) {
+          // Detener el loop después del circuit breaker
+          return {
+            ok: true, status: 200,
+            headers: { get: () => null },
+            json: async () => ({ ok: true, result: [] }),
+            text: async () => '',
+          } as unknown as Response
+        }
+        throw new Error('Network error')
+      }
+      return makeOkResponse()
+    })
+
+    const adapter      = new TelegramAdapter()
+    const errorHandler = vi.fn()
+    adapter.onError(errorHandler)
+    // @ts-expect-error
+    adapter['botToken']       = BOT_TOKEN
+    // @ts-expect-error
+    adapter['channelConfig']  = { maxConsecutiveErrors: 5, pollingInterval: 1 }
+
+    let calls = 0
+    const origImpl = fetchMock.getMockImplementation()
+    fetchMock.mockImplementation(async (url: string, init: RequestInit) => {
+      calls++
+      const resp = await origImpl!(url, init)
+      // Stop loop after circuit breaker fires and we get one success
+      if (calls > 6) {
+        // @ts-expect-error
+        adapter['pollingActive'] = false
+      }
+      return resp
+    })
+
+    // @ts-expect-error
+    adapter['pollingActive'] = true
+    // @ts-expect-error
+    await adapter['runPollingLoop']()
+
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('circuit breaker') })
+    )
+  })
+
+  it('dispose() → AbortController.abort() chiamado, loop termina', async () => {
+    const abortMock = vi.fn()
+    const adapter   = new TelegramAdapter()
+    // @ts-expect-error
+    adapter['pollingAbortCtrl'] = { abort: abortMock }
+
+    await adapter.dispose()
+
+    expect(abortMock).toHaveBeenCalledOnce()
+    // @ts-expect-error
+    expect(adapter['pollingActive']).toBe(false)
+  })
+
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// describe: webhook handler
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('webhook handler', () => {
+
+  function makeRouter(webhookSecret = '') {
+    const adapter = new TelegramAdapter()
+    // @ts-expect-error
+    adapter['botToken']       = BOT_TOKEN
+    // @ts-expect-error
+    adapter['webhookSecret']  = webhookSecret
+    return { adapter, router: adapter.getRouter() }
+  }
+
+  function mockReqRes(headers: Record<string, string> = {}, body: unknown = {}) {
+    const res = {
+      json:   vi.fn().mockReturnThis(),
+      status: vi.fn().mockReturnThis(),
+    }
+    const req = {
+      headers,
+      body,
+    }
+    return { req: req as unknown as Request, res: res as unknown as Response }
+  }
+
+  it('POST /webhook sin secret header cuando webhookSecret configurado → 403', async () => {
+    const { adapter, router } = makeRouter('MY_SECRET')
+    const { req, res } = mockReqRes({}, makeDMUpdate())
+
+    // Invocar el handler directamente
+    const webhookRoute = router.stack.find(
+      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
+        layer.route?.path === '/webhook'
+    )
+    const handler = webhookRoute?.route?.stack[0]?.handle as (
+      req: Request,
+      res: Response,
+    ) => Promise<void>
+
+    await handler(req, res)
+
+    expect((res as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(403)
+  })
+
+  it('POST /webhook con secret header correcto → 200 inmediato', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse())
+    const { adapter, router } = makeRouter('MY_SECRET')
+
+    // Mockear processUpdate para que no falle
+    // @ts-expect-error
+    adapter.processUpdate = vi.fn().mockResolvedValue(undefined)
+
+    const { req, res } = mockReqRes(
+      { 'x-telegram-bot-api-secret-token': 'MY_SECRET' },
+      makeDMUpdate(),
+    )
+
+    const webhookRoute = router.stack.find(
+      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
+        layer.route?.path === '/webhook'
+    )
+    const handler = webhookRoute?.route?.stack[0]?.handle as (
+      req: Request,
+      res: Response,
+    ) => Promise<void>
+
+    await handler(req, res)
+
+    expect((res as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith({ ok: true })
+  })
+
+  it('POST /setup sin webhookUrl → 400', async () => {
+    const { router } = makeRouter()
+    const { req, res } = mockReqRes({}, {})
+
+    const setupRoute = router.stack.find(
+      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
+        layer.route?.path === '/setup'
+    )
+    const handler = setupRoute?.route?.stack[0]?.handle as (
+      req: Request,
+      res: Response,
+    ) => Promise<void>
+
+    await handler(req, res)
+
+    expect((res as { status: ReturnType<typeof vi.fn> }).status).toHaveBeenCalledWith(400)
+  })
+
+  it('POST /setup con webhookUrl → llama setWebhook en Telegram, retorna 200', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse({ ok: true, result: true }))
+    const { router } = makeRouter()
+    const { req, res } = mockReqRes({}, { webhookUrl: 'https://example.com' })
+
+    const setupRoute = router.stack.find(
+      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
+        layer.route?.path === '/setup'
+    )
+    const handler = setupRoute?.route?.stack[0]?.handle as (
+      req: Request,
+      res: Response,
+    ) => Promise<void>
+
+    await handler(req, res)
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toContain('setWebhook')
+    expect((res as { json: ReturnType<typeof vi.fn> }).json).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true })
+    )
+  })
+
+  it('DELETE /webhook → llama deleteWebhook en Telegram', async () => {
+    fetchMock.mockResolvedValue(makeOkResponse({ ok: true, result: true }))
+    const { router } = makeRouter()
+
+    const deleteRoute = router.stack.find(
+      (layer: { route?: { path: string; stack: { handle: unknown }[] } }) =>
+        layer.route?.path === '/webhook'
+    )
+    // find the DELETE handler specifically
+    const deleteHandler = deleteRoute?.route?.stack.find(
+      (s: { method?: string; handle: unknown }) => s.method === 'delete'
+    )?.handle as ((req: Request, res: Response) => Promise<void>) | undefined
+
+    if (deleteHandler) {
+      const { req, res } = mockReqRes()
+      await deleteHandler(req, res)
+      const [url] = fetchMock.mock.calls[0]
+      expect(url).toContain('deleteWebhook')
+    } else {
+      // Fallback: verify via adapter directly
+      const { adapter } = makeRouter()
+      await adapter.deleteWebhook()
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('deleteWebhook'),
+        expect.anything(),
+      )
+    }
+  })
+
+})

--- a/apps/gateway/src/channels/__tests__/webchat.adapter.test.ts
+++ b/apps/gateway/src/channels/__tests__/webchat.adapter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { WebChatAdapter, type WebChatConnection } from '../webchat.adapter.js'
+
+function makeConnection() {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+  } satisfies WebChatConnection
+}
+
+describe('WebChatAdapter', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('broadcasts replyFn payload to every active connection for the session', async () => {
+    const adapter = new WebChatAdapter()
+    const connA = makeConnection()
+    const connB = makeConnection()
+
+    adapter.registerConnection('sess-1', connA)
+    adapter.registerConnection('sess-1', connB)
+
+    const incoming = await adapter.receive(
+      { sessionId: 'sess-1', text: 'hola' } as Record<string, unknown>,
+      {},
+    )
+
+    await incoming!.replyFn!('respuesta')
+
+    expect(connA.send).toHaveBeenCalledOnce()
+    expect(connB.send).toHaveBeenCalledOnce()
+  })
+
+  it('flushes queued replies when a session reconnects', async () => {
+    const adapter = new WebChatAdapter()
+
+    const incoming = await adapter.receive(
+      { sessionId: 'sess-2', text: 'hola' } as Record<string, unknown>,
+      {},
+    )
+
+    await incoming!.replyFn!('pendiente')
+
+    const conn = makeConnection()
+    adapter.registerConnection('sess-2', conn)
+
+    expect(conn.send).toHaveBeenCalledWith(JSON.stringify({ type: 'message', text: 'pendiente' }))
+  })
+})

--- a/apps/gateway/src/channels/channel-adapter.interface.ts
+++ b/apps/gateway/src/channels/channel-adapter.interface.ts
@@ -1,112 +1,226 @@
 /**
  * channel-adapter.interface.ts — Interfaz base de adaptadores de canal
- *
- * Todo canal (WebChat, Telegram, WhatsApp, Discord, Teams…) implementa
- * IChannelAdapter. El ChannelRouter del gateway instancia los adaptadores
- * registrados en ChannelConfig y los conecta al GatewayService.
- *
- * Inspirado en:
- * - n8n trigger nodes: initialize + dispose lifecycle
- * - Flowise ChatFlow: IncomingMessage normalizado
- * - CrewAI: task context passthrough en metadata
+ * [F3a-17] Añade replyFn, threadId, rawPayload a IncomingMessage
  */
 
-// ---------------------------------------------------------------------------
-// Tipos de mensajes
-// ---------------------------------------------------------------------------
+// ── Función de reply in-band ────────────────────────────────────────────────
+
+/**
+ * ReplyFn: closure que cada adaptador construye durante receive().
+ * Permite al dispatcher responder AL CANAL EXTERNO directamente, sin
+ * necesitar acceso al adapter o a las credenciales.
+ *
+ * - Es async: puede hacer HTTP, WebSocket o encolado.
+ * - Debe ser idempotente: llamarla 2 veces no debe crear 2 respuestas.
+ *   (el adaptador puede usar un flag 'replied' internamente)
+ * - Si el canal no admite reply in-band (ej: webhook genérico sin callback),
+ *   la función debe ser un no-op que loggea una advertencia.
+ */
+export type ReplyFn = (text: string, options?: ReplyOptions) => Promise<void>
+
+export interface ReplyOptions {
+  /** Si true, enviar como respuesta al mensaje original (quote/reply) */
+  quoteOriginal?: boolean
+  /** Tipo de formato del texto */
+  format?:        'text' | 'markdown' | 'html'
+  /** Adjuntos opcionales */
+  attachments?:   Array<{ type: string; url?: string; data?: unknown }>
+  /** Metadatos extra para el canal (ej: Telegram parse_mode) */
+  channelMeta?:   Record<string, unknown>
+}
+
+// ── IncomingMessage (REEMPLAZA el anterior) ────────────────────────────────
 
 export interface IncomingMessage {
-  /** ID de la conversación/thread en el canal externo */
-  externalId: string;
-  /** ID de quien envía (user ID del canal) */
-  senderId: string;
-  /** Texto plano del mensaje */
-  text: string;
+  // ── Identidad ──────────────────────────────────────────────────────────
+
+  /** ID de la conversación/chat en el canal externo (chat_id, channel_id…) */
+  externalId: string
+
+  /**
+   * [F3a-17] ID del hilo dentro de la conversación.
+   * En canales planos (WhatsApp DM, Telegram DM) === externalId.
+   * En canales con threads (Slack threads, Discord threads):
+   *   - Slack:   event.thread_ts ?? event.ts
+   *   - Discord: message.thread?.id ?? message.channelId
+   * El dispatcher usa threadId para agrupar mensajes de un mismo hilo.
+   */
+  threadId: string
+
+  /** ID del usuario que envía el mensaje */
+  senderId: string
+
+  // ── Contenido ──────────────────────────────────────────────────────────
+
+  /** Texto plano del mensaje (normalizado, sin markup del canal) */
+  text: string
+
   /** Tipo de mensaje */
-  type: 'text' | 'image' | 'audio' | 'file' | 'command';
-  /** Adjuntos opcionales (URLs u objetos) */
-  attachments?: Array<{ type: string; url?: string; data?: unknown }>;
-  /** Metadatos específicos del canal (raw payload) */
-  metadata?: Record<string, unknown>;
-  /** Timestamp ISO 8601 */
-  receivedAt: string;
+  type: 'text' | 'image' | 'audio' | 'file' | 'command'
+
+  /** Adjuntos opcionales */
+  attachments?: Array<{ type: string; url?: string; data?: unknown }>
+
+  // ── Reply in-band ──────────────────────────────────────────────────────
+
+  /**
+   * [F3a-17] Closure que envía la respuesta al canal externo.
+   *
+   * REGLA: el dispatcher SIEMPRE usa replyFn si está definida.
+   * Solo si replyFn es undefined (canal no lo soporta) debe usar
+   * la ruta antigua: adapter.send() + recordReply().
+   *
+   * Los adaptadores construyen replyFn en receive() capturando
+   * las credenciales y el chat/thread ID en el closure.
+   *
+   * Los adaptadores que no soportan reply in-band asignan:
+   *   replyFn: undefined
+   *
+   * NO usar null — undefined significa "no soportado".
+   */
+  replyFn?: ReplyFn
+
+  // ── Payload original ───────────────────────────────────────────────────
+
+  /**
+   * [F3a-17] Payload crudo del canal, tal como llegó al webhook.
+   * Garantizado non-null (los adaptadores deben pasarlo siempre).
+   *
+   * Uso:
+   *   - Logging y tracing de mensajes entrantes
+   *   - Auditoría (persistir en GatewaySession.rawPayloads)
+   *   - FlowExecutor puede acceder a campos específicos del canal
+   *     sin que IncomingMessage los tenga que exponer explícitamente
+   *
+   * NUNCA debe contener secretos (tokens, keys) — los adaptadores
+   * deben filtrar credentials del rawPayload antes de asignarlo.
+   */
+  rawPayload: Record<string, unknown>
+
+  // ── Metadatos adicionales ──────────────────────────────────────────────
+
+  /**
+   * Metadatos adicionales específicos del canal (campos que no caben
+   * en la interfaz normalizada).
+   * rawPayload es el payload completo; metadata son campos derivados
+   * que el adaptador quiere exponer de forma tipada.
+   */
+  metadata?: Record<string, unknown>
+
+  /** Timestamp ISO 8601 de recepción */
+  receivedAt: string
 }
 
+// ── OutgoingMessage (unificado — sustituye a OutboundMessage) ─────────────
+
+/**
+ * [F3a-17] OutgoingMessage reemplaza y consolida:
+ *   - OutgoingMessage (interfaz local anterior)
+ *   - OutboundMessage (gateway-sdk)
+ *
+ * A partir de F3a-17, TODO el código del gateway usa OutgoingMessage.
+ * OutboundMessage en gateway-sdk queda deprecado — ver nota al pie.
+ */
 export interface OutgoingMessage {
-  /** ID de la conversación de destino en el canal externo */
-  externalId: string;
+  /** ID de la conversación de destino (debe coincidir con IncomingMessage.externalId) */
+  externalId: string
+
+  /**
+   * ID del hilo de destino.
+   * Si es undefined, la respuesta va al chat raíz (sin thread).
+   * Los adaptadores usan este campo para hacer sendMessage en el
+   * thread correcto en Slack/Discord.
+   */
+  threadId?: string
+
   /** Texto de la respuesta */
-  text: string;
-  /** Tipo de contenido enriquecido opcional */
-  type?: 'text' | 'markdown' | 'card' | 'quick_replies';
-  /** Tarjetas, botones, opciones rápidas */
-  richContent?: unknown;
+  text: string
+
+  /** Tipo de contenido */
+  type?: 'text' | 'markdown' | 'card' | 'quick_replies'
+
+  /** Tarjetas, botones, quick replies (specific to channel) */
+  richContent?: unknown
+
   /** Metadatos adicionales para el canal */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown>
 }
 
-// ---------------------------------------------------------------------------
-// Interfaz del adaptador
-// ---------------------------------------------------------------------------
+// ── IChannelAdapter (actualizado) ─────────────────────────────────────────
 
 export interface IChannelAdapter {
-  /** Nombre único del canal: 'webchat' | 'telegram' | 'whatsapp' | 'discord' */
-  readonly channel: string;
+  readonly channel: string
+
+  initialize(channelConfigId: string): Promise<void>
+
+  onMessage(handler: (msg: IncomingMessage) => Promise<void>): void
 
   /**
-   * Inicializa el adaptador: carga credentials de ChannelConfig.credentials,
-   * registra webhooks o abre conexiones.
-   * @param channelConfigId ID del ChannelConfig en DB
+   * [F3a-17] send() recibe OutgoingMessage (no OutboundMessage).
+   * Debe usar outgoing.threadId si está definido para responder
+   * al thread correcto.
    */
-  initialize(channelConfigId: string): Promise<void>;
+  send(message: OutgoingMessage): Promise<void>
 
-  /**
-   * Registra el handler que se llama al recibir un mensaje.
-   * El gateway llama a este método para conectar el canal al dispatcher.
-   */
-  onMessage(
-    handler: (msg: IncomingMessage) => Promise<void>,
-  ): void;
-
-  /**
-   * Envía una respuesta al canal externo.
-   */
-  send(message: OutgoingMessage): Promise<void>;
-
-  /**
-   * Cierra conexiones, cancela webhooks, libera recursos.
-   */
-  dispose(): Promise<void>;
+  dispose(): Promise<void>
 }
 
-// ---------------------------------------------------------------------------
-// Base class con hooks opcionales
-// ---------------------------------------------------------------------------
+// ── BaseChannelAdapter (actualizado) ──────────────────────────────────────
 
 export abstract class BaseChannelAdapter implements IChannelAdapter {
-  abstract readonly channel: string;
+  abstract readonly channel: string
 
-  protected channelConfigId = '';
-  protected credentials: Record<string, unknown> = {};
-  protected messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null;
+  protected channelConfigId = ''
+  protected credentials: Record<string, unknown> = {}
+  protected messageHandler: ((msg: IncomingMessage) => Promise<void>) | null = null
 
-  abstract initialize(channelConfigId: string): Promise<void>;
-  abstract send(message: OutgoingMessage): Promise<void>;
-  abstract dispose(): Promise<void>;
+  abstract initialize(channelConfigId: string): Promise<void>
+  abstract send(message: OutgoingMessage): Promise<void>
+  abstract dispose(): Promise<void>
 
   onMessage(handler: (msg: IncomingMessage) => Promise<void>): void {
-    this.messageHandler = handler;
+    this.messageHandler = handler
   }
 
   protected async emit(msg: IncomingMessage): Promise<void> {
     if (this.messageHandler) {
-      await this.messageHandler(msg);
+      await this.messageHandler(msg)
     } else {
-      console.warn(`[${this.channel}] No message handler registered — message dropped`);
+      console.warn(`[${this.channel}] No message handler registered — message dropped`)
     }
   }
 
   protected makeTimestamp(): string {
-    return new Date().toISOString();
+    return new Date().toISOString()
+  }
+
+  /**
+   * [F3a-17] Helper que construye un rawPayload filtrado (sin secretos).
+   * Los adaptadores llaman esto antes de asignar incoming.rawPayload.
+   *
+   * Elimina automáticamente claves comunes de credentials del payload.
+   */
+  protected sanitizeRawPayload(
+    raw:        Record<string, unknown>,
+    secretKeys: string[] = [],
+  ): Record<string, unknown> {
+    const DEFAULT_SECRET_KEYS = [
+      'token', 'bot_token', 'access_token', 'secret',
+      'api_key', 'apiKey', 'password', 'credential',
+    ]
+    const keysToRemove = new Set([...DEFAULT_SECRET_KEYS, ...secretKeys])
+
+    return Object.fromEntries(
+      Object.entries(raw).filter(([k]) => !keysToRemove.has(k.toLowerCase())),
+    )
   }
 }
+
+// ── Nota sobre OutboundMessage deprecado ─────────────────────────────────
+// packages/gateway-sdk exporta OutboundMessage con campos
+// externalUserId / externalChatId (nomenclatura antigua).
+// A partir de F3a-17, el gateway usa OutgoingMessage (este archivo).
+// gateway-sdk se actualizará en F3b-01 para re-exportar OutgoingMessage
+// y deprecar OutboundMessage. Por ahora, gateway.service.ts hace:
+//   import type { OutgoingMessage } from './channels/channel-adapter.interface.js'
+// y NO importa OutboundMessage de gateway-sdk.

--- a/apps/gateway/src/channels/channel-adapter.interface.ts
+++ b/apps/gateway/src/channels/channel-adapter.interface.ts
@@ -204,15 +204,31 @@ export abstract class BaseChannelAdapter implements IChannelAdapter {
     raw:        Record<string, unknown>,
     secretKeys: string[] = [],
   ): Record<string, unknown> {
-    const DEFAULT_SECRET_KEYS = [
-      'token', 'bot_token', 'access_token', 'secret',
-      'api_key', 'apiKey', 'password', 'credential',
-    ]
-    const keysToRemove = new Set([...DEFAULT_SECRET_KEYS, ...secretKeys])
-
-    return Object.fromEntries(
-      Object.entries(raw).filter(([k]) => !keysToRemove.has(k.toLowerCase())),
+    const keysToRemove = new Set(
+      [
+        'token', 'bot_token', 'access_token', 'secret',
+        'api_key', 'apiKey', 'password', 'credential',
+        ...secretKeys,
+      ].map((key) => key.toLowerCase()),
     )
+
+    const scrub = (value: unknown): unknown => {
+      if (Array.isArray(value)) {
+        return value.map((item) => scrub(item))
+      }
+
+      if (!value || typeof value !== 'object') {
+        return value
+      }
+
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .filter(([k]) => !keysToRemove.has(k.toLowerCase()))
+          .map(([k, v]) => [k, scrub(v)]),
+      )
+    }
+
+    return scrub(raw) as Record<string, unknown>
   }
 }
 

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -44,7 +44,10 @@ export class DiscordAdapter extends BaseChannelAdapter {
     const eventType = String(rawPayload['type'] ?? rawPayload['t'] ?? '')
     const data      = (rawPayload['d'] ?? rawPayload) as Record<string, unknown>
 
-    if (eventType === 'INTERACTION_CREATE' || (rawPayload['type'] !== undefined && Number(rawPayload['type']) >= 1)) {
+    if (
+      eventType === 'INTERACTION_CREATE'
+      || typeof (data as { token?: unknown }).token === 'string'
+    ) {
       return this.receiveInteraction(rawPayload, data as unknown as DiscordInteraction, botToken)
     }
 

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -1,158 +1,168 @@
-/**
- * discord.adapter.ts — Adaptador Discord
- *
- * Recibe slash commands e interacciones via webhook de Discord.
- * Envía DMs y mensajes de canal usando Discord REST API.
- *
- * Credentials en ChannelConfig.credentials (cifrado en DB):
- *   { botToken, applicationId, publicKey }
- *
- * Endpoints:
- *   POST /gateway/discord/interactions — slash commands e interacciones
- *
- * Inspirado en n8n DiscordTrigger y Semantic Kernel DiscordPlugin.
- */
-
-import { createVerify } from 'node:crypto';
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const DISCORD_API = 'https://discord.com/api/v10';
-
-interface DiscordCredentials {
-  botToken:       string;
-  applicationId:  string;
-  publicKey:      string;
+interface DiscordMessage {
+  id:         string
+  channel_id: string
+  author?:    { id: string; username?: string; bot?: boolean }
+  content?:   string
+  timestamp?: string
+  thread?:    { id: string; name?: string }
 }
 
-const INTERACTION_TYPE          = { PING: 1, APPLICATION_COMMAND: 2, MESSAGE_COMPONENT: 3 };
-const INTERACTION_RESPONSE_TYPE = { PONG: 1, CHANNEL_MESSAGE_WITH_SOURCE: 4 };
+interface DiscordInteraction {
+  id:          string
+  type:        number
+  token:       string
+  channel_id:  string
+  user?:       { id: string }
+  member?:     { user: { id: string } }
+  data?:       { name?: string; options?: unknown[] }
+}
 
+/**
+ * DiscordAdapter — adaptador para la Discord API (mensajes y slash commands)
+ * [F3a-17] threadId = message.thread?.id ?? message.channelId
+ */
 export class DiscordAdapter extends BaseChannelAdapter {
-  readonly channel = 'discord';
-  private botToken      = '';
-  private applicationId = '';
-  private publicKey     = '';
-
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+  readonly channel = 'discord'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
+  }
 
-    const creds          = config.credentials as DiscordCredentials;
-    this.botToken        = creds.botToken;
-    this.applicationId   = creds.applicationId;
-    this.publicKey       = creds.publicKey;
-    this.credentials     = config.credentials as Record<string, unknown>;
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const botToken = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
 
-    console.info(`[discord] Initialized app ${this.applicationId}`);
+    // Determinar si es un message event o una interaction
+    const eventType = String(rawPayload['type'] ?? rawPayload['t'] ?? '')
+    const data      = (rawPayload['d'] ?? rawPayload) as Record<string, unknown>
+
+    if (eventType === 'INTERACTION_CREATE' || (rawPayload['type'] !== undefined && Number(rawPayload['type']) >= 1)) {
+      return this.receiveInteraction(rawPayload, data as unknown as DiscordInteraction, botToken)
+    }
+
+    return this.receiveMessage(rawPayload, data as unknown as DiscordMessage, botToken)
+  }
+
+  private async receiveMessage(
+    rawPayload: Record<string, unknown>,
+    message:    DiscordMessage,
+    botToken:   string,
+  ): Promise<IncomingMessage | null> {
+    if (!message.channel_id) return null
+    // Ignorar mensajes de bots
+    if (message.author?.bot) return null
+
+    const channelId = message.channel_id
+    // [F3a-17] threadId: thread.id si hay thread activo, sino channelId
+    const threadId  = message.thread?.id ?? channelId
+
+    let replied = false
+    const replyFn = async (replyText: string, opts?: { quoteOriginal?: boolean }) => {
+      if (replied) return
+      replied = true
+
+      // Responder al thread si hay thread activo, al canal si no
+      const targetId = message.thread?.id ?? channelId
+      const url = `https://discord.com/api/v10/channels/${targetId}/messages`
+      await fetch(url, {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bot ${botToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content:           replyText,
+          message_reference: opts?.quoteOriginal
+            ? { message_id: message.id }
+            : undefined,
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload, ['botToken', 'bot_token'])
+
+    return {
+      externalId: channelId,
+      threadId,
+      senderId:   message.author?.id ?? '',
+      text:       message.content ?? '',
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  private async receiveInteraction(
+    rawPayload:   Record<string, unknown>,
+    interaction:  DiscordInteraction,
+    _botToken:    string,
+  ): Promise<IncomingMessage | null> {
+    if (!interaction.channel_id) return null
+
+    const channelId = interaction.channel_id
+    const threadId  = channelId  // interactions no tienen threads propios
+
+    // Discord interactions tienen su propio endpoint de reply
+    let replied = false
+    const replyFn = async (replyText: string) => {
+      if (replied) return
+      replied = true
+
+      const url = `https://discord.com/api/v10/interactions/${interaction.id}/${interaction.token}/callback`
+      await fetch(url, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          type: 4,  // CHANNEL_MESSAGE_WITH_SOURCE
+          data: { content: replyText },
+        }),
+        signal: AbortSignal.timeout(3_000),  // Discord requiere reply en ≤3s
+      })
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload, ['botToken', 'bot_token'])
+    const senderId  = interaction.user?.id ?? interaction.member?.user.id ?? ''
+
+    return {
+      externalId: channelId,
+      threadId,
+      senderId,
+      text:       String(interaction.data?.name ?? ''),
+      type:       'command',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
+    const botToken = String(secrets?.['botToken'] ?? secrets?.['bot_token'] ?? '')
+    // Usar threadId si es distinto del channelId, sino usar externalId
+    const targetId = message.threadId && message.threadId !== message.externalId
+                       ? message.threadId
+                       : message.externalId
+    const url = `https://discord.com/api/v10/channels/${targetId}/messages`
+    await fetch(url, {
+      method:  'POST',
+      headers: {
+        Authorization:  `Bot ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: message.text }),
+    })
   }
 
   async dispose(): Promise<void> {
-    console.info('[discord] Adapter disposed');
-  }
-
-  // ── Send ────────────────────────────────────────────────────────────────────────
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${DISCORD_API}/channels/${message.externalId}/messages`;
-    const body: Record<string, unknown> = { content: message.text };
-    if (message.richContent) body.embeds = [message.richContent];
-
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bot ${this.botToken}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[discord] send failed: ${err}`);
-      throw new Error(`Discord send failed: ${err}`);
-    }
-  }
-
-  // ── Router ────────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.post('/interactions', async (req: Request, res: Response) => {
-      const timestamp = req.headers['x-signature-timestamp'] as string;
-      const sig       = req.headers['x-signature-ed25519']   as string;
-
-      if (!this._verifySignature(JSON.stringify(req.body), timestamp, sig)) {
-        res.status(401).json({ error: 'Invalid request signature' });
-        return;
-      }
-
-      const interaction = req.body as {
-        type:            number;
-        id:              string;
-        token:           string;
-        application_id:  string;
-        data?:           { name?: string; options?: Array<{ name: string; value: unknown }> };
-        member?:         { user?: { id: string; username?: string } };
-        user?:           { id: string; username?: string };
-        channel_id?:     string;
-      };
-
-      if (interaction.type === INTERACTION_TYPE.PING) {
-        res.json({ type: INTERACTION_RESPONSE_TYPE.PONG });
-        return;
-      }
-
-      if (interaction.type === INTERACTION_TYPE.APPLICATION_COMMAND) {
-        const commandName = interaction.data?.name ?? 'unknown';
-        const options     = interaction.data?.options ?? [];
-        const userInput   = (options.find((o) => o.name === 'prompt')?.value as string) ?? commandName;
-        const userId      = interaction.member?.user?.id ?? interaction.user?.id ?? interaction.id;
-        const channelId   = interaction.channel_id ?? interaction.id;
-
-        res.json({
-          type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-          data: { content: '⏳ Procesando...', flags: 64 },
-        });
-
-        const msg: IncomingMessage = {
-          externalId: channelId,
-          senderId:   userId,
-          text:       userInput,
-          type:       'command',
-          metadata:   { interactionId: interaction.id, interactionToken: interaction.token, commandName, raw: interaction },
-          receivedAt: this.makeTimestamp(),
-        };
-        this.emit(msg).catch((err) => console.error('[discord] emit error:', err));
-        return;
-      }
-
-      res.json({ type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-        data: { content: 'Interacción no soportada', flags: 64 } });
-    });
-
-    return router;
-  }
-
-  // ── Helpers ──────────────────────────────────────────────────────────────────────
-
-  private _verifySignature(body: string, timestamp: string, signature: string): boolean {
-    try {
-      const verify = createVerify('ed25519');
-      verify.update(timestamp + body);
-      return verify.verify(Buffer.from(this.publicKey, 'hex'), Buffer.from(signature, 'hex'));
-    } catch {
-      return false;
-    }
+    // noop
   }
 }

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -3,6 +3,7 @@ import {
   type IncomingMessage,
   type OutgoingMessage,
 } from './channel-adapter.interface.js'
+import { createHmac, timingSafeEqual } from 'crypto'
 
 interface SlackEvent {
   type:       string
@@ -29,6 +30,24 @@ interface SlackWebhookPayload {
  */
 export class SlackAdapter extends BaseChannelAdapter {
   readonly channel = 'slack'
+
+  static async verifySignature(
+    signingSecret: string,
+    timestamp: string,
+    signature: string,
+    rawBody: string,
+  ): Promise<boolean> {
+    if (!signingSecret || !timestamp || !signature) return false
+
+    const baseString = `v0:${timestamp}:${rawBody}`
+    const expected = `v0=${createHmac('sha256', signingSecret).update(baseString).digest('hex')}`
+
+    try {
+      return timingSafeEqual(Buffer.from(expected), Buffer.from(signature))
+    } catch {
+      return false
+    }
+  }
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -1,254 +1,116 @@
-/**
- * slack.adapter.ts — Canal Slack vía @slack/bolt
- *
- * Modo de operación: Socket Mode (no requiere URL pública) o HTTP mode.
- *   - Socket Mode: SLACK_SOCKET_MODE=true + SLACK_APP_TOKEN=xapp-...
- *   - HTTP Mode: recibe POST en /gateway/slack/:channelId
- *
- * Secrets esperados en ChannelConfig.credentials (cifrado en DB):
- *   {
- *     botToken:      "xoxb-...",
- *     signingSecret: "...",
- *     appToken?:     "xapp-..." (solo Socket Mode)
- *   }
- *
- * Patrón de integración:
- *   SlackAdapter extiende BaseChannelAdapter.
- *   En HTTP mode, receive() parsea el payload de Slack Events API.
- *   En Socket Mode, la App Bolt maneja internamente y llama onMessage handler.
- *
- * Ref: https://slack.dev/bolt-js/
- */
-
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-// Tipos Bolt importados dinámicamente para lazy-load
-type BoltApp = {
-  client: {
-    chat: {
-      postMessage: (args: { channel: string; text: string; mrkdwn?: boolean }) => Promise<unknown>;
-    };
-  };
-  start: () => Promise<void>;
-  stop:  () => Promise<void>;
-};
+interface SlackEvent {
+  type:       string
+  channel:    string
+  user?:      string
+  text?:      string
+  ts:         string
+  thread_ts?: string
+  bot_id?:    string
+}
 
-type SlackSecrets = {
-  botToken:       string;
-  signingSecret:  string;
-  appToken?:      string;
-  socketMode?:    boolean;
-};
+interface SlackWebhookPayload {
+  type:         string
+  challenge?:   string
+  token?:       string
+  team_id?:     string
+  event?:       SlackEvent
+  event_id?:    string
+}
 
-type SlackMessageEvent = {
-  type:     string;
-  user?:    string;
-  bot_id?:  string;
-  text?:    string;
-  channel?: string;
-  ts?:      string;
-};
-
-type SlackEventPayload = {
-  type:       string;
-  event?:     SlackMessageEvent;
-  challenge?: string;
-};
-
+/**
+ * SlackAdapter — adaptador para la Slack Events API
+ * [F3a-17] threadId = event.thread_ts ?? event.ts para preservar hilos
+ */
 export class SlackAdapter extends BaseChannelAdapter {
-  readonly channel = 'slack';
-
-  private boltApp:    BoltApp | null = null;
-  private socketMode = false;
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — initialize / dispose
-  // ---------------------------------------------------------------------------
+  readonly channel = 'slack'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
+    this.channelConfigId = channelConfigId
+  }
 
-    // Carga credenciales desde DB — mismo patrón que discord/telegram/whatsapp adapters
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const payload = rawPayload as unknown as SlackWebhookPayload
 
-    // Asignar credentials ANTES de cualquier uso (send/startSocketMode lo necesita)
-    this.credentials = config.credentials as Record<string, unknown>;
+    // Challenge de verificación de Slack
+    if (payload.type === 'url_verification') return null
 
-    const secrets = this.credentials as SlackSecrets;
-    this.socketMode =
-      secrets.socketMode ??
-      process.env.SLACK_SOCKET_MODE === 'true';
+    const event = payload.event
+    if (!event || event.type !== 'message') return null
 
-    if (this.socketMode) {
-      await this.startSocketMode();
+    // Ignorar mensajes de bots (evitar loops)
+    if (event.bot_id) return null
+
+    const botToken  = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
+    const channelId = event.channel
+
+    // [F3a-17] threadId: thread_ts si existe (es un reply en un hilo)
+    //          En DM o mensaje raíz: thread_ts no existe → usar ts
+    const threadId = event.thread_ts ?? event.ts
+
+    // [F3a-17] replyFn: closure con botToken y channelId
+    let replied = false
+    const replyFn = async (replyText: string) => {
+      if (replied) return
+      replied = true
+
+      await fetch('https://slack.com/api/chat.postMessage', {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bearer ${botToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          channel:   channelId,
+          text:      replyText,
+          thread_ts: threadId,  // siempre reply en el mismo thread
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
     }
-    // En HTTP mode no hay nada que iniciar — los mensajes llegan vía receive()
 
-    console.info(`[SlackAdapter] initialized (channelConfigId=${channelConfigId}, socketMode=${this.socketMode})`);
+    const sanitized = this.sanitizeRawPayload(
+      rawPayload,
+      ['botToken', 'bot_token', 'token'],
+    )
+
+    return {
+      externalId: channelId,
+      threadId,
+      senderId:   event.user ?? '',
+      text:       event.text ?? '',
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
+    const botToken = String(secrets?.['botToken'] ?? secrets?.['bot_token'] ?? '')
+    await fetch('https://slack.com/api/chat.postMessage', {
+      method:  'POST',
+      headers: {
+        Authorization:  `Bearer ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        channel:   message.externalId,
+        text:      message.text,
+        thread_ts: message.threadId,
+      }),
+    })
   }
 
   async dispose(): Promise<void> {
-    if (this.boltApp && this.socketMode) {
-      await this.boltApp.stop().catch((err: unknown) =>
-        console.warn('[SlackAdapter] stop error:', err),
-      );
-      this.boltApp = null;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Receive (HTTP mode) — parsea Slack Events API payload
-  // ---------------------------------------------------------------------------
-
-  /**
-   * HTTP mode: parsea el payload de Slack Events API.
-   * Retorna null para eventos que no son mensajes.
-   */
-  async receive(
-    rawPayload: Record<string, unknown>,
-  ): Promise<IncomingMessage | null> {
-    const payload = rawPayload as SlackEventPayload;
-
-    const event = payload.event;
-    if (!event || event.type !== 'message' || event.bot_id) {
-      return null;
-    }
-
-    if (!event.user || !event.channel) return null;
-
-    return {
-      externalId:  event.channel,
-      senderId:    event.user,
-      text:        event.text ?? '',
-      type:        'text',
-      receivedAt:  this.makeTimestamp(),
-      metadata:    rawPayload,
-    };
-  }
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — send
-  // ---------------------------------------------------------------------------
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const secrets = this.credentials as SlackSecrets;
-    const isMarkdown = message.type === 'markdown';
-
-    // Socket Mode: usar cliente Bolt
-    if (this.socketMode && this.boltApp) {
-      await this.boltApp.client.chat.postMessage({
-        channel: message.externalId,
-        text:    message.text,
-        mrkdwn:  isMarkdown,
-      });
-      return;
-    }
-
-    // HTTP mode: llamar directo a Slack Web API
-    const response = await fetch('https://slack.com/api/chat.postMessage', {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bearer ${secrets.botToken}`,
-        'Content-Type': 'application/json; charset=utf-8',
-      },
-      body: JSON.stringify({
-        channel: message.externalId,
-        text:    message.text,
-        mrkdwn:  isMarkdown,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`[SlackAdapter] send failed: HTTP ${response.status}`);
-    }
-
-    const body = (await response.json()) as { ok: boolean; error?: string };
-    if (!body.ok) {
-      throw new Error(`[SlackAdapter] Slack API error: ${body.error}`);
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Slack signature verification (HMAC-SHA256)
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Verifica la firma X-Slack-Signature del request.
-   * Llamar desde el router antes de dispatch().
-   */
-  static async verifySignature(
-    signingSecret: string,
-    timestamp:     string,
-    signature:     string,
-    rawBody:       string,
-  ): Promise<boolean> {
-    const ts = parseInt(timestamp, 10);
-    if (Math.abs(Date.now() / 1000 - ts) > 300) return false;
-
-    const { createHmac, timingSafeEqual } = await import('crypto');
-    const baseString  = `v0:${timestamp}:${rawBody}`;
-    const expectedSig = 'v0=' + createHmac('sha256', signingSecret).update(baseString).digest('hex');
-
-    try {
-      return timingSafeEqual(
-        Buffer.from(expectedSig, 'utf8'),
-        Buffer.from(signature,   'utf8'),
-      );
-    } catch {
-      return false;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Socket Mode interno
-  // ---------------------------------------------------------------------------
-
-  private async startSocketMode(): Promise<void> {
-    const secrets = this.credentials as SlackSecrets;
-
-    if (!secrets.appToken) {
-      throw new Error('[SlackAdapter] Socket Mode requires appToken (xapp-...)');
-    }
-
-    const { App, LogLevel } = await import('@slack/bolt').catch(() => {
-      throw new Error(
-        '[SlackAdapter] @slack/bolt not installed. Run: pnpm add @slack/bolt',
-      );
-    });
-
-    const app = new App({
-      token:         secrets.botToken,
-      signingSecret: secrets.signingSecret,
-      appToken:      secrets.appToken,
-      socketMode:    true,
-      logLevel:      LogLevel.WARN,
-    });
-
-    app.message(async ({ message }) => {
-      const msg = message as SlackMessageEvent;
-      if (!this.messageHandler || msg.bot_id || !msg.user) return;
-
-      const incoming: IncomingMessage = {
-        externalId: msg.channel ?? '',
-        senderId:   msg.user,
-        text:       msg.text ?? '',
-        type:       'text',
-        receivedAt: this.makeTimestamp(),
-        metadata:   message as unknown as Record<string, unknown>,
-      };
-
-      await this.emit(incoming);
-    });
-
-    await app.start();
-    this.boltApp = app as unknown as BoltApp;
-    console.info('[SlackAdapter] Socket Mode started');
+    // noop
   }
 }

--- a/apps/gateway/src/channels/telegram.adapter.ts
+++ b/apps/gateway/src/channels/telegram.adapter.ts
@@ -23,7 +23,7 @@
  *     alerta via onError() y espera 60s antes de reintentar
  */
 
-import { Router, type Request, type Response } from 'express'
+import { Router, type Request, type Response as ExpressResponse } from 'express'
 import {
   BaseChannelAdapter,
   type IncomingMessage,
@@ -82,7 +82,7 @@ export async function fetchWithRetry(
   url:      string,
   init:     RequestInit,
   maxTries: number = 3,
-): Promise<Response> {
+): Promise<globalThis.Response> {
   let lastError: unknown
   for (let attempt = 0; attempt < maxTries; attempt++) {
     try {
@@ -272,7 +272,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
      * Responde 200 inmediatamente — processing es async.
      * Telegram tiene timeout de 3s; si no recibe 200 reintenta.
      */
-    router.post('/webhook', async (req: Request, res: Response) => {
+    router.post('/webhook', async (req: Request, res: ExpressResponse) => {
       // 1. Validar secret token
       if (this.webhookSecret) {
         const secret = req.headers['x-telegram-bot-api-secret-token']
@@ -293,7 +293,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
     })
 
     /** POST /gateway/telegram/setup — registra el webhook en Telegram */
-    router.post('/setup', async (req: Request, res: Response) => {
+    router.post('/setup', async (req: Request, res: ExpressResponse) => {
       const { webhookUrl } = req.body as { webhookUrl?: string }
       if (!webhookUrl) {
         res.status(400).json({ ok: false, error: 'webhookUrl is required' })
@@ -309,7 +309,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
     })
 
     /** DELETE /gateway/telegram/webhook — elimina el webhook */
-    router.delete('/webhook', async (_req: Request, res: Response) => {
+    router.delete('/webhook', async (_req: Request, res: ExpressResponse) => {
       try {
         const result = await this.deleteWebhook()
         res.json({ ok: true, telegram: result })
@@ -320,7 +320,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
     })
 
     /** GET /gateway/telegram/info — verifica que el bot está activo */
-    router.get('/info', async (_req: Request, res: Response) => {
+    router.get('/info', async (_req: Request, res: ExpressResponse) => {
       try {
         const apiRes = await fetchWithRetry(
           `${TELEGRAM_API}/bot${this.botToken}/getMe`,
@@ -541,7 +541,7 @@ export class TelegramAdapter extends BaseChannelAdapter {
     // replyFn: answerCallbackQuery PRIMERO + sendMessage SEGUNDO
     const replyFn: ReplyFn = async (replyText: string, opts?: ReplyOptions) => {
       // 1. Responder al callback query (elimina el "loading" del botón)
-      await fetchWithRetry(
+      const ackRes = await fetchWithRetry(
         `${TELEGRAM_API}/bot${token}/answerCallbackQuery`,
         {
           method:  'POST',
@@ -549,6 +549,11 @@ export class TelegramAdapter extends BaseChannelAdapter {
           body:    JSON.stringify({ callback_query_id: callbackQuery.id }),
         },
       )
+      if (!ackRes.ok) {
+        const err = await ackRes.text().catch(() => `HTTP ${ackRes.status}`)
+        console.warn(`[telegram] answerCallbackQuery failed: ${err}`)
+        return
+      }
       // 2. Enviar respuesta visible al usuario
       const body: Record<string, unknown> = {
         chat_id:    chatId,

--- a/apps/gateway/src/channels/telegram.adapter.ts
+++ b/apps/gateway/src/channels/telegram.adapter.ts
@@ -1,145 +1,637 @@
+/**
+ * telegram.adapter.ts — Adaptador Telegram Bot API
+ * [F3a-18] Hardening: long-polling + webhook, retry/backoff,
+ *          circuit breaker, replyFn/threadId/rawPayload (F3a-17).
+ *
+ * MODOS:
+ *   webhook  — Telegram envía updates al POST /gateway/telegram/webhook
+ *   polling  — El adaptador llama getUpdates en loop (dev/staging)
+ *
+ * Selección de modo:
+ *   config.mode === 'polling'               → polling
+ *   config.mode === 'webhook' (o undefined) → webhook
+ *   Env override: TELEGRAM_MODE=polling|webhook
+ *
+ * Retry policy (aplica a send() y a cada ciclo de polling):
+ *   - 3 intentos máximo
+ *   - Backoff exponencial: 500ms → 1000ms → 2000ms
+ *   - En 429 (rate limit): usa Retry-After del header si presente
+ *
+ * Circuit breaker del polling loop:
+ *   - maxConsecutiveErrors: 5 (configurable vía config.maxConsecutiveErrors)
+ *   - Si se alcanzan 5 errores consecutivos → loop se detiene, emite
+ *     alerta via onError() y espera 60s antes de reintentar
+ */
+
+import { Router, type Request, type Response } from 'express'
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
+  type ReplyFn,
+  type ReplyOptions,
 } from './channel-adapter.interface.js'
 
-interface TelegramUpdate {
-  update_id: number
-  message?: {
-    message_id:        number
-    message_thread_id?: number
-    from?:             { id: number; username?: string; first_name?: string }
-    chat:              { id: number; type: string }
-    text?:             string
-    date:              number
-  }
-  callback_query?: {
-    id:      string
-    from:    { id: number }
-    message?: { chat: { id: number }; message_id: number }
-    data?:   string
-  }
+const TELEGRAM_API = 'https://api.telegram.org'
+
+// ── Tipos del Bot API ─────────────────────────────────────────────────────────
+
+interface TelegramMessage {
+  message_id:         number
+  chat:               { id: number; type: 'private' | 'group' | 'supergroup' | 'channel' }
+  from?:              { id: number; username?: string; first_name?: string }
+  text?:              string
+  caption?:           string
+  photo?:             unknown[]
+  document?:          unknown
+  voice?:             unknown
+  message_thread_id?: number    // presente en supergrupos con topics
+  reply_to_message?:  { message_id: number }
 }
 
-/**
- * TelegramAdapter — adaptador para Telegram Bot API
- * [F3a-17] Popula replyFn, threadId, rawPayload en receive()
- */
+interface TelegramCallbackQuery {
+  id:       string
+  from:     { id: number }
+  data?:    string
+  message?: TelegramMessage
+}
+
+interface TelegramUpdate {
+  update_id:       number
+  message?:        TelegramMessage
+  edited_message?: TelegramMessage
+  callback_query?: TelegramCallbackQuery
+}
+
+interface TelegramCredentials {
+  botToken:       string
+  webhookSecret?: string
+}
+
+interface TelegramChannelConfig {
+  mode?:                 'webhook' | 'polling'
+  pollingTimeout?:       number   // long-poll timeout in seconds (default: 25)
+  pollingInterval?:      number   // ms between polls on error (default: 1000)
+  maxConsecutiveErrors?: number   // circuit breaker threshold (default: 5)
+  allowedUpdates?:       string[] // Telegram allowed_updates filter
+}
+
+// ── Helpers de retry ────────────────────────────────────────────────────────────
+
+export async function fetchWithRetry(
+  url:      string,
+  init:     RequestInit,
+  maxTries: number = 3,
+): Promise<Response> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < maxTries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(15_000),
+      })
+
+      // 429 rate limit: respetar Retry-After
+      if (res.status === 429) {
+        const retryAfter = Number(res.headers.get('retry-after') ?? 5)
+        await sleep(retryAfter * 1000)
+        continue
+      }
+
+      // 5xx transitorios: backoff
+      if (res.status >= 500 && attempt < maxTries - 1) {
+        await sleep(500 * 2 ** attempt)
+        continue
+      }
+
+      return res
+    } catch (err) {
+      lastError = err
+      if (attempt < maxTries - 1) {
+        await sleep(500 * 2 ** attempt)
+      }
+    }
+  }
+  throw lastError ?? new Error('fetchWithRetry: max attempts reached')
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// ── TelegramAdapter ────────────────────────────────────────────────────────────
+
 export class TelegramAdapter extends BaseChannelAdapter {
   readonly channel = 'telegram'
 
-  private botToken = ''
+  // Estado del adaptador
+  private botToken      = ''
+  private webhookSecret = ''
+  private mode: 'webhook' | 'polling' = 'webhook'
+  private channelConfig: TelegramChannelConfig = {}
 
+  // Estado del polling loop
+  private pollingActive     = false
+  private pollingOffset     = 0
+  private consecutiveErrors = 0
+  private pollingAbortCtrl: AbortController | null = null
+
+  // Callback de error del caller
+  private errorHandler: ((err: Error) => void) | null = null
+
+  // ── Lifecycle ───────────────────────────────────────────────────────────────
+
+  /**
+   * [F3a-18] initialize() stub de compatibilidad.
+   * El flujo canónico es: GatewayService → adapter.setup(config, secrets).
+   * NO accede a Prisma — botToken llega por setup(), no por DB.
+   */
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
+    console.warn(
+      '[telegram] initialize() called without credentials — use setup(config, secrets) instead',
+    )
   }
 
   /**
-   * receive() parsea el webhook update de Telegram y construye IncomingMessage
-   * con los tres campos nuevos de F3a-17.
+   * Configura el adaptador con config + secrets descifrados.
+   * Llamado por GatewayService.activateChannel() (F3a-14 pattern).
+   */
+  async setup(
+    config:  Record<string, unknown>,
+    secrets: Record<string, unknown>,
+  ): Promise<void> {
+    this.botToken      = String(secrets['botToken']      ?? '')
+    this.webhookSecret = String(secrets['webhookSecret'] ?? '')
+    this.channelConfig = config as TelegramChannelConfig
+
+    // Determinar modo: env override > config > default (webhook)
+    const envMode = process.env['TELEGRAM_MODE'] as 'webhook' | 'polling' | undefined
+    this.mode     = envMode ?? this.channelConfig.mode ?? 'webhook'
+
+    if (!this.botToken) {
+      throw new Error('[TelegramAdapter] botToken is required in secrets')
+    }
+
+    if (this.mode === 'polling') {
+      // Asegurar que no hay webhook activo (conflicto con polling)
+      await this.deleteWebhook()
+      this.startPollingLoop()
+    }
+
+    console.info(
+      `[telegram] Adapter ready — mode=${this.mode}, channelConfigId=${this.channelConfigId}`,
+    )
+  }
+
+  async dispose(): Promise<void> {
+    this.pollingActive = false
+    this.pollingAbortCtrl?.abort()
+    this.pollingAbortCtrl = null
+    console.info('[telegram] Adapter disposed')
+  }
+
+  /** Registrar callback para errores del polling loop. */
+  onError(handler: (err: Error) => void): void {
+    this.errorHandler = handler
+  }
+
+  // ── send() ────────────────────────────────────────────────────────────────────
+
+  async send(message: OutgoingMessage): Promise<void> {
+    const body: Record<string, unknown> = {
+      chat_id:    message.externalId,
+      text:       message.text,
+      parse_mode: message.type === 'markdown' ? 'Markdown' : undefined,
+    }
+
+    // [F3a-17] Si hay threadId y es distinto del chat, responder en el topic
+    if (message.threadId && message.threadId !== message.externalId) {
+      body['message_thread_id'] = Number(message.threadId)
+    }
+
+    if (message.richContent) {
+      body['reply_markup'] = message.richContent
+    }
+
+    const res = await fetchWithRetry(
+      `${TELEGRAM_API}/bot${this.botToken}/sendMessage`,
+      {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify(body),
+      },
+    )
+
+    if (!res.ok) {
+      const err = await res.text().catch(() => `HTTP ${res.status}`)
+      throw new Error(`[telegram] sendMessage failed: ${err}`)
+    }
+  }
+
+  // ── receive() ─────────────────────────────────────────────────────────────
+
+  /**
+   * Convierte un TelegramUpdate crudo en IncomingMessage normalizado.
+   * Construye replyFn, threadId y rawPayload.
+   * Retorna null si el update debe ignorarse.
    */
   async receive(
     rawPayload: Record<string, unknown>,
     secrets:    Record<string, unknown>,
   ): Promise<IncomingMessage | null> {
-    const update = rawPayload as unknown as TelegramUpdate
+    const token   = String(secrets['botToken'] ?? this.botToken)
+    const update  = rawPayload as unknown as TelegramUpdate
+    const message = update.message ?? update.edited_message
 
-    if (!update.message && !update.callback_query) return null
-
-    const botToken = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
-
-    // ── Extraer campos del mensaje ────────────────────────────────────────
-    let chatId:    string
-    let senderId:  string
-    let text:      string
-    let messageId: number
-    let threadId:  string
-
-    if (update.message) {
-      chatId    = String(update.message.chat.id)
-      senderId  = String(update.message.from?.id ?? '')
-      text      = update.message.text ?? ''
-      messageId = update.message.message_id
-
-      // [F3a-17] threadId: message_thread_id si es supergrupo, sino chatId
-      threadId  = update.message.message_thread_id
-                    ? String(update.message.message_thread_id)
-                    : chatId
-    } else {
-      // callback_query
-      chatId    = String(update.callback_query!.message?.chat.id ?? '')
-      senderId  = String(update.callback_query!.from.id)
-      text      = update.callback_query!.data ?? ''
-      messageId = update.callback_query!.message?.message_id ?? 0
-      threadId  = chatId
+    if (
+      message?.text ||
+      message?.caption ||
+      message?.photo ||
+      message?.voice ||
+      message?.document
+    ) {
+      return this.buildMessageIncoming(update, message, token)
     }
 
-    // ── [F3a-17] Construir replyFn ────────────────────────────────────────
-    // Closure: captura botToken, chatId, messageId, threadId de este scope.
-    let replied = false
-    const replyFn = async (replyText: string, opts?: { format?: string; quoteOriginal?: boolean }) => {
-      if (replied) return  // idempotente
-      replied = true
+    if (update.callback_query?.data) {
+      return this.buildCallbackQueryIncoming(update, update.callback_query, token)
+    }
 
-      const url  = `https://api.telegram.org/bot${botToken}/sendMessage`
+    return null
+  }
+
+  // ── Router (modo webhook) ─────────────────────────────────────────────────────
+
+  getRouter(): Router {
+    const router = Router()
+
+    /**
+     * POST /gateway/telegram/webhook
+     * Recibe updates de Telegram en modo webhook.
+     * Responde 200 inmediatamente — processing es async.
+     * Telegram tiene timeout de 3s; si no recibe 200 reintenta.
+     */
+    router.post('/webhook', async (req: Request, res: Response) => {
+      // 1. Validar secret token
+      if (this.webhookSecret) {
+        const secret = req.headers['x-telegram-bot-api-secret-token']
+        if (secret !== this.webhookSecret) {
+          res.status(403).json({ ok: false, error: 'Invalid secret token' })
+          return
+        }
+      }
+
+      // 2. Responder 200 a Telegram ANTES de procesar (timeout de Telegram: 3s)
+      res.json({ ok: true })
+
+      // 3. Procesar de forma async (no await)
+      const update = req.body as Record<string, unknown>
+      this.processUpdate(update).catch((err) => {
+        console.error('[telegram] webhook processUpdate error:', err)
+      })
+    })
+
+    /** POST /gateway/telegram/setup — registra el webhook en Telegram */
+    router.post('/setup', async (req: Request, res: Response) => {
+      const { webhookUrl } = req.body as { webhookUrl?: string }
+      if (!webhookUrl) {
+        res.status(400).json({ ok: false, error: 'webhookUrl is required' })
+        return
+      }
+      try {
+        const result = await this.registerWebhook(webhookUrl)
+        res.json({ ok: true, telegram: result })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        res.status(500).json({ ok: false, error: msg })
+      }
+    })
+
+    /** DELETE /gateway/telegram/webhook — elimina el webhook */
+    router.delete('/webhook', async (_req: Request, res: Response) => {
+      try {
+        const result = await this.deleteWebhook()
+        res.json({ ok: true, telegram: result })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        res.status(500).json({ ok: false, error: msg })
+      }
+    })
+
+    /** GET /gateway/telegram/info — verifica que el bot está activo */
+    router.get('/info', async (_req: Request, res: Response) => {
+      try {
+        const apiRes = await fetchWithRetry(
+          `${TELEGRAM_API}/bot${this.botToken}/getMe`,
+          { method: 'GET' },
+        )
+        const data = await apiRes.json()
+        res.json({ ok: true, mode: this.mode, bot: data })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        res.status(500).json({ ok: false, error: msg })
+      }
+    })
+
+    return router
+  }
+
+  // ── Long-polling loop ────────────────────────────────────────────────────────────
+
+  private startPollingLoop(): void {
+    if (this.pollingActive) return
+    this.pollingActive     = true
+    this.consecutiveErrors = 0
+    console.info('[telegram] Long-polling loop started')
+    void this.runPollingLoop()
+  }
+
+  private async runPollingLoop(): Promise<void> {
+    const pollingTimeout  = this.channelConfig.pollingTimeout       ?? 25
+    const pollingInterval = this.channelConfig.pollingInterval      ?? 1_000
+    const maxErrors       = this.channelConfig.maxConsecutiveErrors ?? 5
+    const allowedUpdates  = this.channelConfig.allowedUpdates
+      ?? ['message', 'edited_message', 'callback_query']
+
+    while (this.pollingActive) {
+      this.pollingAbortCtrl = new AbortController()
+
+      try {
+        const url = `${TELEGRAM_API}/bot${this.botToken}/getUpdates`
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            offset:          this.pollingOffset,
+            timeout:         pollingTimeout,
+            allowed_updates: allowedUpdates,
+          }),
+          signal: this.pollingAbortCtrl.signal,
+        })
+
+        // 401 Unauthorized → bot token inválido → detener loop
+        if (res.status === 401) {
+          console.error('[telegram] Bot token invalid (401) — stopping polling loop')
+          this.pollingActive = false
+          this.errorHandler?.(new Error('TelegramAdapter: invalid bot token (401)'))
+          return
+        }
+
+        if (!res.ok) {
+          throw new Error(`getUpdates failed: HTTP ${res.status}`)
+        }
+
+        const data = await res.json() as { ok: boolean; result: TelegramUpdate[] }
+
+        if (!data.ok) {
+          throw new Error('getUpdates: ok=false')
+        }
+
+        // Resetear circuit breaker en éxito
+        this.consecutiveErrors = 0
+
+        for (const update of data.result) {
+          // Avanzar offset ANTES de procesar (no reprocesar si falla)
+          this.pollingOffset = update.update_id + 1
+
+          await this.processUpdate(update as unknown as Record<string, unknown>)
+            .catch((err) => {
+              console.error(`[telegram] Error processing update ${update.update_id}:`, err)
+            })
+        }
+
+      } catch (err) {
+        // AbortError = dispose() llamado → salir del loop limpiamente
+        if (err instanceof Error && err.name === 'AbortError') {
+          break
+        }
+
+        this.consecutiveErrors++
+        console.warn(
+          `[telegram] Polling error #${this.consecutiveErrors}/${maxErrors}:`,
+          err instanceof Error ? err.message : err,
+        )
+
+        // Circuit breaker
+        if (this.consecutiveErrors >= maxErrors) {
+          console.error(
+            `[telegram] Circuit breaker open after ${maxErrors} consecutive errors. ` +
+            `Pausing 60s before retry.`,
+          )
+          this.errorHandler?.(
+            new Error(
+              `TelegramAdapter: polling circuit breaker open after ${maxErrors} errors`,
+            ),
+          )
+          // Pausa larga antes de resetear
+          await sleep(60_000)
+          this.consecutiveErrors = 0
+        } else {
+          // Backoff normal entre errores: pollingInterval * 2^(n-1)
+          await sleep(pollingInterval * 2 ** (this.consecutiveErrors - 1))
+        }
+      }
+    }
+
+    console.info('[telegram] Long-polling loop stopped')
+  }
+
+  // ── Procesamiento de updates (compartido webhook + polling) ───────────────────────
+
+  async processUpdate(rawUpdate: Record<string, unknown>): Promise<void> {
+    const incoming = await this.receive(rawUpdate, { botToken: this.botToken })
+    if (!incoming) return
+    await this.emit(incoming)
+  }
+
+  // ── Builders de IncomingMessage ──────────────────────────────────────────────────────
+
+  private buildMessageIncoming(
+    update:  TelegramUpdate,
+    message: TelegramMessage,
+    token:   string,
+  ): IncomingMessage {
+    const chatId   = String(message.chat.id)
+    const threadId = message.message_thread_id
+      ? String(message.message_thread_id)
+      : chatId   // DM / grupo sin topics → threadId = chatId
+
+    const text = message.text ?? message.caption ?? ''
+    const type: IncomingMessage['type'] =
+      text.startsWith('/')  ? 'command'
+      : message.photo       ? 'image'
+      : message.voice       ? 'audio'
+      : message.document    ? 'file'
+      : 'text'
+
+    // replyFn — closure con chatId, threadId y token capturados
+    const replyFn: ReplyFn = async (replyText: string, opts?: ReplyOptions) => {
       const body: Record<string, unknown> = {
         chat_id:    chatId,
         text:       replyText,
         parse_mode: opts?.format === 'markdown' ? 'Markdown'
                   : opts?.format === 'html'     ? 'HTML'
                   : undefined,
-        reply_to_message_id: opts?.quoteOriginal ? messageId : undefined,
       }
 
-      // Si hay threadId de supergrupo, incluir message_thread_id
-      if (update.message?.message_thread_id) {
-        body['message_thread_id'] = update.message.message_thread_id
+      // reply en el mismo topic si aplica
+      if (message.message_thread_id) {
+        body['message_thread_id'] = message.message_thread_id
       }
 
-      await fetch(url, {
-        method:  'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body:    JSON.stringify(body),
-        signal:  AbortSignal.timeout(10_000),
-      })
+      // quote/reply al mensaje original
+      if (opts?.quoteOriginal) {
+        body['reply_parameters'] = { message_id: message.message_id }
+      }
+
+      // rich content
+      if (opts?.channelMeta?.['reply_markup']) {
+        body['reply_markup'] = opts.channelMeta['reply_markup']
+      }
+
+      const res = await fetchWithRetry(
+        `${TELEGRAM_API}/bot${token}/sendMessage`,
+        {
+          method:  'POST',
+          headers: { 'content-type': 'application/json' },
+          body:    JSON.stringify(body),
+        },
+      )
+
+      if (!res.ok) {
+        const errText = await res.text().catch(() => `HTTP ${res.status}`)
+        throw new Error(`[telegram] replyFn sendMessage failed: ${errText}`)
+      }
     }
-
-    // ── [F3a-17] Sanitizar rawPayload (eliminar token del bot) ────────────
-    const sanitized = this.sanitizeRawPayload(
-      rawPayload,
-      ['botToken', 'bot_token'],
-    )
 
     return {
-      externalId: chatId,
+      externalId:  chatId,
       threadId,
-      senderId,
+      senderId:    String(message.from?.id ?? message.chat.id),
       text,
-      type:       'text',
-      rawPayload: sanitized,
-      receivedAt: this.makeTimestamp(),
+      type,
+      rawPayload:  this.sanitizeRawPayload(
+        update as unknown as Record<string, unknown>,
+        ['botToken', 'webhookSecret'],
+      ),
+      metadata: {
+        updateId:        update.update_id,
+        messageId:       message.message_id,
+        chatType:        message.chat.type,
+        username:        message.from?.username,
+        hasThread:       !!message.message_thread_id,
+        isEditedMessage: !!update.edited_message,
+      },
       replyFn,
+      receivedAt: this.makeTimestamp(),
     }
   }
 
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `https://api.telegram.org/bot${this.botToken}/sendMessage`
+  private buildCallbackQueryIncoming(
+    update:        TelegramUpdate,
+    callbackQuery: TelegramCallbackQuery,
+    token:         string,
+  ): IncomingMessage {
+    const chatId   = String(callbackQuery.message?.chat.id ?? callbackQuery.from.id)
+    const threadId = callbackQuery.message?.message_thread_id
+      ? String(callbackQuery.message.message_thread_id)
+      : chatId
+
+    // replyFn: answerCallbackQuery PRIMERO + sendMessage SEGUNDO
+    const replyFn: ReplyFn = async (replyText: string, opts?: ReplyOptions) => {
+      // 1. Responder al callback query (elimina el "loading" del botón)
+      await fetchWithRetry(
+        `${TELEGRAM_API}/bot${token}/answerCallbackQuery`,
+        {
+          method:  'POST',
+          headers: { 'content-type': 'application/json' },
+          body:    JSON.stringify({ callback_query_id: callbackQuery.id }),
+        },
+      )
+      // 2. Enviar respuesta visible al usuario
+      const body: Record<string, unknown> = {
+        chat_id:    chatId,
+        text:       replyText,
+        parse_mode: opts?.format === 'markdown' ? 'Markdown' : undefined,
+      }
+      if (callbackQuery.message?.message_thread_id) {
+        body['message_thread_id'] = callbackQuery.message.message_thread_id
+      }
+      await fetchWithRetry(
+        `${TELEGRAM_API}/bot${token}/sendMessage`,
+        {
+          method:  'POST',
+          headers: { 'content-type': 'application/json' },
+          body:    JSON.stringify(body),
+        },
+      )
+    }
+
+    return {
+      externalId:  chatId,
+      threadId,
+      senderId:    String(callbackQuery.from.id),
+      text:        callbackQuery.data ?? '',
+      type:        'command',
+      rawPayload:  this.sanitizeRawPayload(
+        update as unknown as Record<string, unknown>,
+        ['botToken', 'webhookSecret'],
+      ),
+      metadata: {
+        updateId:        update.update_id,
+        callbackQueryId: callbackQuery.id,
+        callbackData:    callbackQuery.data,
+      },
+      replyFn,
+      receivedAt: this.makeTimestamp(),
+    }
+  }
+
+  // ── Webhook management ─────────────────────────────────────────────────────────────
+
+  async registerWebhook(webhookUrl: string): Promise<unknown> {
+    const normalizedUrl = webhookUrl.endsWith('/webhook')
+      ? webhookUrl
+      : `${webhookUrl}/gateway/telegram/webhook`
+
     const body: Record<string, unknown> = {
-      chat_id:   message.externalId,
-      text:      message.text,
+      url:             normalizedUrl,
+      allowed_updates: this.channelConfig.allowedUpdates
+                         ?? ['message', 'edited_message', 'callback_query'],
+      drop_pending_updates: false,
     }
-    if (message.threadId && message.threadId !== message.externalId) {
-      body['message_thread_id'] = message.threadId
+    if (this.webhookSecret) {
+      body['secret_token'] = this.webhookSecret
     }
-    await fetch(url, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify(body),
-    })
+
+    const res = await fetchWithRetry(
+      `${TELEGRAM_API}/bot${this.botToken}/setWebhook`,
+      {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify(body),
+      },
+    )
+    return res.json()
   }
 
-  async dispose(): Promise<void> {
-    // noop
+  async deleteWebhook(): Promise<unknown> {
+    const res = await fetchWithRetry(
+      `${TELEGRAM_API}/bot${this.botToken}/deleteWebhook`,
+      {
+        method:  'POST',
+        headers: { 'content-type': 'application/json' },
+        body:    JSON.stringify({ drop_pending_updates: false }),
+      },
+    )
+    return res.json()
+  }
+
+  async autoSetupWebhook(): Promise<void> {
+    const webhookUrl = process.env['TELEGRAM_WEBHOOK_URL']
+    if (!webhookUrl) return
+    await this.registerWebhook(webhookUrl)
+    console.info(`[telegram] Webhook auto-registered at ${webhookUrl}`)
   }
 }

--- a/apps/gateway/src/channels/telegram.adapter.ts
+++ b/apps/gateway/src/channels/telegram.adapter.ts
@@ -1,172 +1,145 @@
-/**
- * telegram.adapter.ts — Adaptador Telegram Bot API
- *
- * Recibe updates via webhook (POST /gateway/telegram/webhook).
- * El token del bot y el webhook secret se leen de ChannelConfig.credentials
- * (cifrado AES-256-GCM en DB).
- *
- * Endpoints:
- *   POST /gateway/telegram/webhook  — updates de Telegram
- *   POST /gateway/telegram/setup    — registra el webhook en Telegram
- *
- * Inspirado en n8n TelegramTriggerNode y Flowise TelegramChatModel.
- */
-
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const TELEGRAM_API = 'https://api.telegram.org';
-
-interface TelegramCredentials {
-  botToken:       string;
-  webhookSecret?: string;
+interface TelegramUpdate {
+  update_id: number
+  message?: {
+    message_id:        number
+    message_thread_id?: number
+    from?:             { id: number; username?: string; first_name?: string }
+    chat:              { id: number; type: string }
+    text?:             string
+    date:              number
+  }
+  callback_query?: {
+    id:      string
+    from:    { id: number }
+    message?: { chat: { id: number }; message_id: number }
+    data?:   string
+  }
 }
 
+/**
+ * TelegramAdapter — adaptador para Telegram Bot API
+ * [F3a-17] Popula replyFn, threadId, rawPayload en receive()
+ */
 export class TelegramAdapter extends BaseChannelAdapter {
-  readonly channel      = 'telegram';
-  private botToken      = '';
-  private webhookSecret = '';
+  readonly channel = 'telegram'
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+  private botToken = ''
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-
-    const creds          = config.credentials as TelegramCredentials;
-    this.botToken        = creds.botToken;
-    this.webhookSecret   = creds.webhookSecret ?? '';
-    this.credentials     = config.credentials as Record<string, unknown>;
-
-    console.info(`[telegram] Initialized bot for config ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
   }
 
-  async dispose(): Promise<void> {
-    console.info('[telegram] Adapter disposed');
-  }
+  /**
+   * receive() parsea el webhook update de Telegram y construye IncomingMessage
+   * con los tres campos nuevos de F3a-17.
+   */
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const update = rawPayload as unknown as TelegramUpdate
 
-  // ── Send ────────────────────────────────────────────────────────────────────────
+    if (!update.message && !update.callback_query) return null
 
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${TELEGRAM_API}/bot${this.botToken}/sendMessage`;
-    const body: Record<string, unknown> = {
-      chat_id:    message.externalId,
-      text:       message.text,
-      parse_mode: 'Markdown',
-    };
-    if (message.richContent) body.reply_markup = message.richContent;
+    const botToken = String(secrets['botToken'] ?? secrets['bot_token'] ?? '')
 
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: { 'content-type': 'application/json' },
-      body:    JSON.stringify(body),
-    });
+    // ── Extraer campos del mensaje ────────────────────────────────────────
+    let chatId:    string
+    let senderId:  string
+    let text:      string
+    let messageId: number
+    let threadId:  string
 
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[telegram] sendMessage failed: ${err}`);
-      throw new Error(`Telegram sendMessage failed: ${err}`);
+    if (update.message) {
+      chatId    = String(update.message.chat.id)
+      senderId  = String(update.message.from?.id ?? '')
+      text      = update.message.text ?? ''
+      messageId = update.message.message_id
+
+      // [F3a-17] threadId: message_thread_id si es supergrupo, sino chatId
+      threadId  = update.message.message_thread_id
+                    ? String(update.message.message_thread_id)
+                    : chatId
+    } else {
+      // callback_query
+      chatId    = String(update.callback_query!.message?.chat.id ?? '')
+      senderId  = String(update.callback_query!.from.id)
+      text      = update.callback_query!.data ?? ''
+      messageId = update.callback_query!.message?.message_id ?? 0
+      threadId  = chatId
+    }
+
+    // ── [F3a-17] Construir replyFn ────────────────────────────────────────
+    // Closure: captura botToken, chatId, messageId, threadId de este scope.
+    let replied = false
+    const replyFn = async (replyText: string, opts?: { format?: string; quoteOriginal?: boolean }) => {
+      if (replied) return  // idempotente
+      replied = true
+
+      const url  = `https://api.telegram.org/bot${botToken}/sendMessage`
+      const body: Record<string, unknown> = {
+        chat_id:    chatId,
+        text:       replyText,
+        parse_mode: opts?.format === 'markdown' ? 'Markdown'
+                  : opts?.format === 'html'     ? 'HTML'
+                  : undefined,
+        reply_to_message_id: opts?.quoteOriginal ? messageId : undefined,
+      }
+
+      // Si hay threadId de supergrupo, incluir message_thread_id
+      if (update.message?.message_thread_id) {
+        body['message_thread_id'] = update.message.message_thread_id
+      }
+
+      await fetch(url, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(body),
+        signal:  AbortSignal.timeout(10_000),
+      })
+    }
+
+    // ── [F3a-17] Sanitizar rawPayload (eliminar token del bot) ────────────
+    const sanitized = this.sanitizeRawPayload(
+      rawPayload,
+      ['botToken', 'bot_token'],
+    )
+
+    return {
+      externalId: chatId,
+      threadId,
+      senderId,
+      text,
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
     }
   }
 
-  // ── Router ────────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.post('/webhook', async (req: Request, res: Response) => {
-      if (this.webhookSecret) {
-        const secret = req.headers['x-telegram-bot-api-secret-token'];
-        if (secret !== this.webhookSecret) {
-          res.status(403).json({ ok: false, error: 'Invalid secret' });
-          return;
-        }
-      }
-
-      const update = req.body as {
-        update_id:       number;
-        message?:        {
-          message_id: number;
-          chat:       { id: number };
-          from?:      { id: number; username?: string };
-          text?:      string;
-        };
-        callback_query?: { id: string; data?: string; message?: { chat: { id: number } } };
-      };
-
-      const message       = update.message;
-      const callbackQuery = update.callback_query;
-
-      if (message?.text) {
-        const msg: IncomingMessage = {
-          externalId: String(message.chat.id),
-          senderId:   String(message.from?.id ?? message.chat.id),
-          text:       message.text,
-          type:       message.text.startsWith('/') ? 'command' : 'text',
-          metadata:   { updateId: update.update_id, raw: message },
-          receivedAt: this.makeTimestamp(),
-        };
-        await this.emit(msg);
-      } else if (callbackQuery?.data) {
-        const chatId = callbackQuery.message?.chat.id;
-        const msg: IncomingMessage = {
-          externalId: String(chatId),
-          senderId:   String(chatId),
-          text:       callbackQuery.data,
-          type:       'command',
-          metadata:   { callbackQueryId: callbackQuery.id, raw: callbackQuery },
-          receivedAt: this.makeTimestamp(),
-        };
-        await this.emit(msg);
-        await fetch(`${TELEGRAM_API}/bot${this.botToken}/answerCallbackQuery`, {
-          method:  'POST',
-          headers: { 'content-type': 'application/json' },
-          body:    JSON.stringify({ callback_query_id: callbackQuery.id }),
-        });
-      }
-
-      res.json({ ok: true });
-    });
-
-    router.post('/setup', async (req: Request, res: Response) => {
-      const { webhookUrl } = req.body as { webhookUrl: string };
-      if (!webhookUrl) {
-        res.status(400).json({ ok: false, error: 'webhookUrl required' });
-        return;
-      }
-      const body: Record<string, unknown> = { url: webhookUrl };
-      if (this.webhookSecret) body.secret_token = this.webhookSecret;
-
-      const apiRes = await fetch(`${TELEGRAM_API}/bot${this.botToken}/setWebhook`, {
-        method:  'POST',
-        headers: { 'content-type': 'application/json' },
-        body:    JSON.stringify(body),
-      });
-      const data = await apiRes.json();
-      res.json({ ok: true, telegram: data });
-    });
-
-    return router;
+  async send(message: OutgoingMessage): Promise<void> {
+    const url  = `https://api.telegram.org/bot${this.botToken}/sendMessage`
+    const body: Record<string, unknown> = {
+      chat_id:   message.externalId,
+      text:      message.text,
+    }
+    if (message.threadId && message.threadId !== message.externalId) {
+      body['message_thread_id'] = message.threadId
+    }
+    await fetch(url, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(body),
+    })
   }
 
-  async autoSetupWebhook(): Promise<void> {
-    const webhookUrl = process.env.TELEGRAM_WEBHOOK_URL;
-    if (!webhookUrl) return;
-    await fetch(`${TELEGRAM_API}/bot${this.botToken}/setWebhook`, {
-      method:  'POST',
-      headers: { 'content-type': 'application/json' },
-      body:    JSON.stringify({
-        url:          `${webhookUrl}/gateway/telegram/webhook`,
-        secret_token: this.webhookSecret || undefined,
-      }),
-    });
-    console.info(`[telegram] Webhook registered at ${webhookUrl}/gateway/telegram/webhook`);
+  async dispose(): Promise<void> {
+    // noop
   }
 }

--- a/apps/gateway/src/channels/webchat.adapter.ts
+++ b/apps/gateway/src/channels/webchat.adapter.ts
@@ -1,135 +1,125 @@
-/**
- * webchat.adapter.ts — Adaptador WebChat (SSE + HTTP)
- *
- * Expone dos endpoints que el frontend puede consumir:
- *   POST /gateway/webchat/:sessionId/message  → mensaje entrante
- *   GET  /gateway/webchat/:sessionId/stream   → SSE de respuestas
- *
- * Inspirado en Flowise ChatFlow y n8n WebhookNode.
- */
-
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
+/**
+ * Conexión WebSocket/SSE activa para una sesión de WebChat.
+ */
+export interface WebChatConnection {
+  send(data: string): void
+  close(): void
+}
+
+/**
+ * WebChatAdapter — adaptador para el canal WebChat (WebSocket / SSE)
+ * [F3a-17] replyFn emite al WebSocket/SSE de la sesión activa.
+ *          Si la sesión no está conectada, encola el reply.
+ */
 export class WebChatAdapter extends BaseChannelAdapter {
-  readonly channel = 'webchat';
+  readonly channel = 'webchat'
 
-  private readonly sseClients = new Map<string, Response[]>();
+  /** Conexiones WebSocket/SSE activas, por sessionId */
+  protected readonly activeConnections = new Map<string, WebChatConnection>()
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+  /** Replies pendientes para sesiones desconectadas, por sessionId */
+  protected readonly pendingReplies = new Map<string, string[]>()
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-    this.credentials = config.credentials as Record<string, unknown>;
-    console.info(`[webchat] Initialized for config ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
+  }
+
+  /**
+   * Registra una conexión WebSocket/SSE activa para una sesión.
+   * Llamado por el WebChat controller cuando el cliente conecta.
+   */
+  registerConnection(sessionId: string, connection: WebChatConnection): void {
+    this.activeConnections.set(sessionId, connection)
+    // Vaciar replies pendientes que se acumularon mientras estaba desconectado
+    const pending = this.pendingReplies.get(sessionId)
+    if (pending?.length) {
+      for (const text of pending) {
+        connection.send(JSON.stringify({ type: 'message', text }))
+      }
+      this.pendingReplies.delete(sessionId)
+    }
+  }
+
+  /**
+   * Elimina la conexión cuando el cliente desconecta.
+   */
+  unregisterConnection(sessionId: string): void {
+    this.activeConnections.delete(sessionId)
+  }
+
+  async receive(
+    rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const sessionId = String(rawPayload['sessionId'] ?? rawPayload['session_id'] ?? '')
+    if (!sessionId) return null
+
+    const text     = String(rawPayload['text'] ?? rawPayload['message'] ?? '')
+    const senderId = String(rawPayload['userId'] ?? rawPayload['user_id'] ?? sessionId)
+
+    // WebChat: sessionId = externalId = threadId (1 sesión = 1 hilo)
+    const externalId = sessionId
+    const threadId   = sessionId
+
+    // [F3a-17] replyFn: emite al WebSocket/SSE activo o encola
+    let replied = false
+    const replyFn = async (replyText: string) => {
+      if (replied) return
+      replied = true
+
+      const connection = this.activeConnections.get(sessionId)
+      if (connection) {
+        connection.send(JSON.stringify({ type: 'message', text: replyText }))
+      } else {
+        // Sesión desconectada → encolar para cuando reconecte
+        const queue = this.pendingReplies.get(sessionId)
+        if (queue) {
+          queue.push(replyText)
+        } else {
+          this.pendingReplies.set(sessionId, [replyText])
+        }
+      }
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload)
+
+    return {
+      externalId,
+      threadId,
+      senderId,
+      text,
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage): Promise<void> {
+    const connection = this.activeConnections.get(message.externalId)
+    if (connection) {
+      connection.send(JSON.stringify({ type: 'message', text: message.text }))
+    } else {
+      const queue = this.pendingReplies.get(message.externalId)
+      if (queue) {
+        queue.push(message.text)
+      } else {
+        this.pendingReplies.set(message.externalId, [message.text])
+      }
+    }
   }
 
   async dispose(): Promise<void> {
-    for (const [sessionId, clients] of this.sseClients) {
-      clients.forEach((res) => res.end());
-      console.info(`[webchat] Closed ${clients.length} SSE streams for session ${sessionId}`);
+    for (const conn of this.activeConnections.values()) {
+      conn.close()
     }
-    this.sseClients.clear();
-  }
-
-  // ── Send ────────────────────────────────────────────────────────────────────────
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const db      = getPrisma();
-    const clients = this.sseClients.get(message.externalId) ?? [];
-    const payload = JSON.stringify({
-      type:        'message',
-      text:        message.text,
-      richContent: message.richContent ?? null,
-      metadata:    message.metadata    ?? {},
-      ts:          new Date().toISOString(),
-    });
-
-    if (clients.length === 0) {
-      await db.gatewaySession.update({
-        where: {
-          channelConfigId_externalId: {
-            channelConfigId: this.channelConfigId,
-            externalId:      message.externalId,
-          },
-        },
-        data: {
-          contextWindow:  { push: { role: 'assistant', content: message.text } } as any,
-          lastActivityAt: new Date(),
-        },
-      });
-      return;
-    }
-
-    clients.forEach((res) => { res.write(`data: ${payload}\n\n`); });
-  }
-
-  // ── Express Router ────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.post('/:sessionId/message', async (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-      const { text, metadata } = req.body as { text: string; metadata?: Record<string, unknown> };
-
-      if (!text?.trim()) {
-        res.status(400).json({ ok: false, error: 'text is required' });
-        return;
-      }
-
-      const msg: IncomingMessage = {
-        externalId: sessionId,
-        senderId:   sessionId,
-        text:       text.trim(),
-        type:       'text',
-        metadata,
-        receivedAt: this.makeTimestamp(),
-      };
-
-      await this.emit(msg);
-      res.json({ ok: true });
-    });
-
-    router.get('/:sessionId/stream', (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-
-      res.setHeader('Content-Type',    'text/event-stream');
-      res.setHeader('Cache-Control',   'no-cache');
-      res.setHeader('Connection',      'keep-alive');
-      res.setHeader('X-Accel-Buffering', 'no');
-      res.flushHeaders();
-
-      if (!this.sseClients.has(sessionId)) this.sseClients.set(sessionId, []);
-      this.sseClients.get(sessionId)!.push(res);
-
-      const heartbeat = setInterval(() => { res.write(': heartbeat\n\n'); }, 25_000);
-
-      req.on('close', () => {
-        clearInterval(heartbeat);
-        const list = this.sseClients.get(sessionId) ?? [];
-        const idx  = list.indexOf(res);
-        if (idx !== -1) list.splice(idx, 1);
-      });
-    });
-
-    router.get('/:sessionId/history', async (req: Request, res: Response) => {
-      const { sessionId } = req.params;
-      const db      = getPrisma();
-      const session = await db.gatewaySession.findFirst({
-        where: { channelConfigId: this.channelConfigId, externalId: sessionId },
-      });
-      res.json({ ok: true, history: (session?.contextWindow as unknown[]) ?? [] });
-    });
-
-    return router;
+    this.activeConnections.clear()
+    this.pendingReplies.clear()
   }
 }

--- a/apps/gateway/src/channels/webchat.adapter.ts
+++ b/apps/gateway/src/channels/webchat.adapter.ts
@@ -21,10 +21,14 @@ export class WebChatAdapter extends BaseChannelAdapter {
   readonly channel = 'webchat'
 
   /** Conexiones WebSocket/SSE activas, por sessionId */
-  protected readonly activeConnections = new Map<string, WebChatConnection>()
+  protected readonly activeConnections = new Map<string, Set<WebChatConnection>>()
 
   /** Replies pendientes para sesiones desconectadas, por sessionId */
-  protected readonly pendingReplies = new Map<string, string[]>()
+  protected readonly pendingReplies = new Map<string, { messages: string[]; lastTouchedAt: number }>()
+
+  private static readonly MAX_PENDING_SESSIONS = 500
+  private static readonly MAX_PENDING_MESSAGES_PER_SESSION = 50
+  private static readonly PENDING_TTL_MS = 60 * 60 * 1000
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
@@ -35,11 +39,17 @@ export class WebChatAdapter extends BaseChannelAdapter {
    * Llamado por el WebChat controller cuando el cliente conecta.
    */
   registerConnection(sessionId: string, connection: WebChatConnection): void {
-    this.activeConnections.set(sessionId, connection)
+    let connections = this.activeConnections.get(sessionId)
+    if (!connections) {
+      connections = new Set<WebChatConnection>()
+      this.activeConnections.set(sessionId, connections)
+    }
+    connections.add(connection)
+
     // Vaciar replies pendientes que se acumularon mientras estaba desconectado
     const pending = this.pendingReplies.get(sessionId)
-    if (pending?.length) {
-      for (const text of pending) {
+    if (pending?.messages.length) {
+      for (const text of pending.messages) {
         connection.send(JSON.stringify({ type: 'message', text }))
       }
       this.pendingReplies.delete(sessionId)
@@ -49,8 +59,18 @@ export class WebChatAdapter extends BaseChannelAdapter {
   /**
    * Elimina la conexión cuando el cliente desconecta.
    */
-  unregisterConnection(sessionId: string): void {
-    this.activeConnections.delete(sessionId)
+  unregisterConnection(sessionId: string, connection?: WebChatConnection): void {
+    if (!connection) {
+      this.activeConnections.delete(sessionId)
+      return
+    }
+
+    const connections = this.activeConnections.get(sessionId)
+    if (!connections) return
+    connections.delete(connection)
+    if (connections.size === 0) {
+      this.activeConnections.delete(sessionId)
+    }
   }
 
   async receive(
@@ -73,17 +93,13 @@ export class WebChatAdapter extends BaseChannelAdapter {
       if (replied) return
       replied = true
 
-      const connection = this.activeConnections.get(sessionId)
-      if (connection) {
-        connection.send(JSON.stringify({ type: 'message', text: replyText }))
-      } else {
-        // Sesión desconectada → encolar para cuando reconecte
-        const queue = this.pendingReplies.get(sessionId)
-        if (queue) {
-          queue.push(replyText)
-        } else {
-          this.pendingReplies.set(sessionId, [replyText])
+      const connections = this.activeConnections.get(sessionId)
+      if (connections && connections.size > 0) {
+        for (const connection of connections) {
+          connection.send(JSON.stringify({ type: 'message', text: replyText }))
         }
+      } else {
+        this.enqueuePendingReply(sessionId, replyText)
       }
     }
 
@@ -102,24 +118,61 @@ export class WebChatAdapter extends BaseChannelAdapter {
   }
 
   async send(message: OutgoingMessage): Promise<void> {
-    const connection = this.activeConnections.get(message.externalId)
-    if (connection) {
-      connection.send(JSON.stringify({ type: 'message', text: message.text }))
-    } else {
-      const queue = this.pendingReplies.get(message.externalId)
-      if (queue) {
-        queue.push(message.text)
-      } else {
-        this.pendingReplies.set(message.externalId, [message.text])
+    const connections = this.activeConnections.get(message.externalId)
+    if (connections && connections.size > 0) {
+      for (const connection of connections) {
+        connection.send(JSON.stringify({ type: 'message', text: message.text }))
       }
+    } else {
+      this.enqueuePendingReply(message.externalId, message.text)
     }
   }
 
   async dispose(): Promise<void> {
     for (const conn of this.activeConnections.values()) {
-      conn.close()
+      for (const connection of conn) {
+        connection.close()
+      }
     }
     this.activeConnections.clear()
     this.pendingReplies.clear()
+  }
+
+  private enqueuePendingReply(sessionId: string, replyText: string): void {
+    this.prunePendingReplies()
+
+    const now = Date.now()
+    const queue = this.pendingReplies.get(sessionId) ?? { messages: [], lastTouchedAt: now }
+    queue.messages.push(replyText)
+    queue.lastTouchedAt = now
+
+    if (queue.messages.length > WebChatAdapter.MAX_PENDING_MESSAGES_PER_SESSION) {
+      queue.messages.splice(
+        0,
+        queue.messages.length - WebChatAdapter.MAX_PENDING_MESSAGES_PER_SESSION,
+      )
+    }
+
+    this.pendingReplies.set(sessionId, queue)
+  }
+
+  private prunePendingReplies(now = Date.now()): void {
+    for (const [sessionId, queue] of this.pendingReplies.entries()) {
+      if (now - queue.lastTouchedAt > WebChatAdapter.PENDING_TTL_MS) {
+        this.pendingReplies.delete(sessionId)
+      }
+    }
+
+    if (this.pendingReplies.size <= WebChatAdapter.MAX_PENDING_SESSIONS) {
+      return
+    }
+
+    const oldest = [...this.pendingReplies.entries()]
+      .sort((a, b) => a[1].lastTouchedAt - b[1].lastTouchedAt)
+      .slice(0, this.pendingReplies.size - WebChatAdapter.MAX_PENDING_SESSIONS)
+
+    for (const [sessionId] of oldest) {
+      this.pendingReplies.delete(sessionId)
+    }
   }
 }

--- a/apps/gateway/src/channels/webhook.adapter.ts
+++ b/apps/gateway/src/channels/webhook.adapter.ts
@@ -12,6 +12,19 @@ import {
 export class WebhookAdapter extends BaseChannelAdapter {
   readonly channel = 'webhook'
 
+  static verifySecret(
+    config: { webhookSecret?: string },
+    authHeader?: string,
+    xWebhookSecret?: string,
+  ): boolean {
+    const expected = config.webhookSecret ?? ''
+    if (!expected) return true
+
+    const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : ''
+    const provided = xWebhookSecret ?? bearer
+    return provided === expected
+  }
+
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
   }

--- a/apps/gateway/src/channels/webhook.adapter.ts
+++ b/apps/gateway/src/channels/webhook.adapter.ts
@@ -1,159 +1,70 @@
-/**
- * webhook.adapter.ts — Canal Webhook HTTP genérico
- *
- * Permite recibir mensajes vía HTTP POST desde cualquier sistema externo:
- *   n8n, Zapier, Make, formularios web, pipelines CI/CD, etc.
- *
- * Endpoint montado en: POST /gateway/webhook/:channelId
- *
- * Formato del payload entrante (flexible):
- *   {
- *     userId:  string,                       // ID del usuario/origen (requerido)
- *     text?:   string,                       // Mensaje de texto
- *     data?:   Record<string, unknown>,      // Payload arbitrario
- *     source?: string                        // Identificador del sistema origen
- *   }
- *
- * Autenticación:
- *   Opcional — si credentials.webhookSecret está configurado, se valida
- *   el header Authorization: Bearer <secret> o X-Webhook-Secret: <secret>.
- *
- * Respuesta:
- *   El adapter envía la respuesta del agente como JSON en el reply del mismo POST:
- *   { ok: true, reply: "..." }
- *
- * Outbound (send):
- *   Si credentials.replyWebhookUrl está configurado, hace POST a esa URL
- *   con la respuesta del agente (push mode).
- */
-
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-type WebhookCredentials = {
-  webhookSecret?:   string;   // Opcional: valida Authorization header
-  replyWebhookUrl?: string;   // URL a la que enviar la respuesta (push mode)
-  source?:          string;   // Identificador de origen para logging
-};
-
-type WebhookPayload = {
-  userId:  string;
-  text?:   string;
-  data?:   Record<string, unknown>;
-  source?: string;
-};
-
+/**
+ * WebhookAdapter — adaptador para webhooks genéricos (cualquier HTTP callback)
+ * [F3a-17] replyFn hace POST al callbackUrl si está en el payload.
+ *          Sin callbackUrl → replyFn = undefined → path legacy.
+ */
 export class WebhookAdapter extends BaseChannelAdapter {
-  readonly channel = 'webhook';
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — initialize / dispose
-  // ---------------------------------------------------------------------------
+  readonly channel = 'webhook'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-
-    // Carga credenciales desde DB — mismo patrón que discord/telegram/whatsapp adapters
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
-
-    this.credentials = config.credentials as Record<string, unknown>;
-
-    // Canal HTTP stateless — no hay conexión persistente que iniciar
-    console.info(`[WebhookAdapter] ready (channelConfigId=${channelConfigId})`);
+    this.channelConfigId = channelConfigId
   }
-
-  async dispose(): Promise<void> {
-    // Nada que cerrar — canal HTTP stateless
-  }
-
-  // ---------------------------------------------------------------------------
-  // Receive — parsea payload entrante
-  // ---------------------------------------------------------------------------
 
   async receive(
     rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
   ): Promise<IncomingMessage | null> {
-    const payload = rawPayload as WebhookPayload;
+    const text        = String(rawPayload['text'] ?? rawPayload['message'] ?? rawPayload['body'] ?? '')
+    const externalId  = String(rawPayload['sessionId'] ?? rawPayload['id'] ?? rawPayload['chatId'] ?? 'unknown')
+    const threadId    = String(rawPayload['threadId'] ?? externalId)
+    const senderId    = String(rawPayload['userId'] ?? rawPayload['senderId'] ?? externalId)
+    const callbackUrl = rawPayload['callbackUrl'] as string | undefined
 
-    if (!payload.userId) {
-      console.warn('[WebhookAdapter] received payload without userId — ignoring');
-      return null;
-    }
+    // [F3a-17] replyFn solo si hay callbackUrl en el payload
+    let replied = false
+    const replyFn = callbackUrl
+      ? async (replyText: string) => {
+          if (replied) return
+          replied = true
 
-    let text = payload.text ?? '';
-    if (!text && payload.data) {
-      text = JSON.stringify(payload.data);
-    }
-    if (!text) {
-      console.warn('[WebhookAdapter] no text or data in payload — ignoring');
-      return null;
-    }
+          await fetch(callbackUrl, {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body:    JSON.stringify({ reply: replyText, externalId }),
+            signal:  AbortSignal.timeout(10_000),
+          })
+        }
+      : undefined   // sin callbackUrl → replyFn undefined → path legacy en dispatch()
+
+    const sanitized = this.sanitizeRawPayload(rawPayload)
 
     return {
-      externalId:  payload.userId,
-      senderId:    payload.userId,
+      externalId,
+      threadId,
+      senderId,
       text,
       type:       'text',
+      rawPayload: sanitized,
       receivedAt: this.makeTimestamp(),
-      metadata:   rawPayload,
-    };
-  }
-
-  // ---------------------------------------------------------------------------
-  // IChannelAdapter — send
-  // ---------------------------------------------------------------------------
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const creds = this.credentials as WebhookCredentials;
-
-    if (creds.replyWebhookUrl) {
-      const response = await fetch(creds.replyWebhookUrl, {
-        method:  'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          userId: message.externalId,
-          reply:  message.text,
-          ts:     new Date().toISOString(),
-        }),
-      });
-
-      if (!response.ok) {
-        console.error(
-          `[WebhookAdapter] push reply failed: HTTP ${response.status} → ${creds.replyWebhookUrl}`,
-        );
-      }
+      replyFn,
     }
-    // Sin replyWebhookUrl: la respuesta se retorna en el body del POST original
-    // (manejado por el router webhook.ts)
   }
 
-  // ---------------------------------------------------------------------------
-  // Verificación de secreto (llamar desde el router antes de dispatch)
-  // ---------------------------------------------------------------------------
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, _secrets?: Record<string, unknown>): Promise<void> {
+    // Webhook genérico no tiene un endpoint de envío fijo.
+    // El callbackUrl solo existe en el contexto de receive().
+    // Este método solo se invoca en el path legacy (sin replyFn).
+    console.warn('[WebhookAdapter] send() called on legacy path — no callbackUrl available')
+    console.warn(`[WebhookAdapter] Dropping outgoing message for externalId=${message.externalId}`)
+  }
 
-  /**
-   * Valida Authorization: Bearer <secret> o X-Webhook-Secret contra
-   * credentials.webhookSecret.
-   * Retorna true si la validación pasa o si no hay secreto configurado.
-   */
-  static verifySecret(
-    credentials:  Record<string, unknown>,
-    authHeader?:  string,
-    xSecret?:     string,
-  ): boolean {
-    const expected = (credentials as WebhookCredentials).webhookSecret;
-    if (!expected) return true;
-
-    const provided =
-      authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : xSecret;
-
-    if (!provided) return false;
-    return provided === expected;
+  async dispose(): Promise<void> {
+    // noop
   }
 }

--- a/apps/gateway/src/channels/whatsapp.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp.adapter.ts
@@ -60,7 +60,7 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
       if (replied) return
       replied = true
 
-      const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`
+      const url = `https://graph.facebook.com/v23.0/${phoneNumberId}/messages`
       await fetch(url, {
         method:  'POST',
         headers: {
@@ -95,7 +95,7 @@ export class WhatsAppAdapter extends BaseChannelAdapter {
   async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
     const accessToken   = String(secrets?.['accessToken'] ?? secrets?.['access_token'] ?? '')
     const phoneNumberId = String(secrets?.['phoneNumberId'] ?? '')
-    const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`
+    const url = `https://graph.facebook.com/v23.0/${phoneNumberId}/messages`
     await fetch(url, {
       method:  'POST',
       headers: {

--- a/apps/gateway/src/channels/whatsapp.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp.adapter.ts
@@ -1,167 +1,117 @@
-/**
- * whatsapp.adapter.ts — Adaptador WhatsApp Cloud API (Meta)
- *
- * Recibe mensajes via webhook de Meta Webhooks.
- * Envía respuestas via WhatsApp Cloud API.
- *
- * Credentials en ChannelConfig.credentials (cifrado en DB):
- *   { accessToken, phoneNumberId, verifyToken, appSecret }
- *
- * Endpoints:
- *   GET  /gateway/whatsapp/webhook — verificación de Meta
- *   POST /gateway/whatsapp/webhook — mensajes entrantes
- *
- * Inspirado en n8n WhatsAppTrigger y Flowise WhatsAppChannel.
- */
-
-import { createHmac } from 'node:crypto';
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
-} from './channel-adapter.interface';
+} from './channel-adapter.interface.js'
 
-const WHATSAPP_API = 'https://graph.facebook.com/v19.0';
-
-interface WhatsAppCredentials {
-  accessToken:   string;
-  phoneNumberId: string;
-  verifyToken:   string;
-  appSecret?:    string;
+interface WhatsAppMessage {
+  id:        string
+  from:      string
+  type:      string
+  timestamp: string
+  text?:     { body: string }
 }
 
-export class WhatsAppAdapter extends BaseChannelAdapter {
-  readonly channel   = 'whatsapp';
-  private accessToken   = '';
-  private phoneNumberId = '';
-  private verifyToken   = '';
-  private appSecret     = '';
+interface WhatsAppWebhookPayload {
+  object: string
+  entry?: Array<{
+    changes?: Array<{
+      value?: {
+        messages?:      WhatsAppMessage[]
+        contacts?:      Array<{ profile: { name: string }; wa_id: string }>
+        phone_number_id?: string
+      }
+    }>
+  }>
+}
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+/**
+ * WhatsAppAdapter — adaptador para la WhatsApp Cloud API (Meta)
+ * [F3a-17] Popula replyFn, threadId (=externalId, sin threads nativos), rawPayload
+ */
+export class WhatsAppAdapter extends BaseChannelAdapter {
+  readonly channel = 'whatsapp'
 
   async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+    this.channelConfigId = channelConfigId
+  }
 
-    const creds          = config.credentials as WhatsAppCredentials;
-    this.accessToken     = creds.accessToken;
-    this.phoneNumberId   = creds.phoneNumberId;
-    this.verifyToken     = creds.verifyToken;
-    this.appSecret       = creds.appSecret ?? '';
-    this.credentials     = config.credentials as Record<string, unknown>;
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets:    Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    const payload     = rawPayload as unknown as WhatsAppWebhookPayload
+    const change      = payload.entry?.[0]?.changes?.[0]
+    const value       = change?.value
+    const message     = value?.messages?.[0]
 
-    console.info(`[whatsapp] Initialized for phoneNumberId ${this.phoneNumberId}`);
+    if (!message) return null
+
+    const phoneNumberId = String(value?.phone_number_id ?? secrets['phoneNumberId'] ?? '')
+    const accessToken   = String(secrets['accessToken'] ?? secrets['access_token'] ?? '')
+
+    // WhatsApp no tiene threads nativos → threadId = externalId (número del remitente)
+    const to       = message.from
+    const threadId = to
+
+    // [F3a-17] replyFn: closure con accessToken y phoneNumberId
+    let replied = false
+    const replyFn = async (replyText: string, opts?: { quoteOriginal?: boolean }) => {
+      if (replied) return
+      replied = true
+
+      const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`
+      await fetch(url, {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          messaging_product: 'whatsapp',
+          to,
+          type: 'text',
+          text: { body: replyText },
+          context: opts?.quoteOriginal ? { message_id: message.id } : undefined,
+        }),
+        signal: AbortSignal.timeout(10_000),
+      })
+    }
+
+    const sanitized = this.sanitizeRawPayload(rawPayload, ['accessToken', 'access_token'])
+
+    return {
+      externalId: to,
+      threadId,
+      senderId:   message.from,
+      text:       message.text?.body ?? '',
+      type:       'text',
+      rawPayload: sanitized,
+      receivedAt: this.makeTimestamp(),
+      replyFn,
+    }
+  }
+
+  async send(message: OutgoingMessage, _config?: Record<string, unknown>, secrets?: Record<string, unknown>): Promise<void> {
+    const accessToken   = String(secrets?.['accessToken'] ?? secrets?.['access_token'] ?? '')
+    const phoneNumberId = String(secrets?.['phoneNumberId'] ?? '')
+    const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`
+    await fetch(url, {
+      method:  'POST',
+      headers: {
+        Authorization:  `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to:   message.externalId,
+        type: 'text',
+        text: { body: message.text },
+      }),
+    })
   }
 
   async dispose(): Promise<void> {
-    console.info('[whatsapp] Adapter disposed');
-  }
-
-  // ── Send ────────────────────────────────────────────────────────────────────────
-
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${WHATSAPP_API}/${this.phoneNumberId}/messages`;
-    const body: Record<string, unknown> = {
-      messaging_product: 'whatsapp',
-      to:   message.externalId,
-      type: 'text',
-      text: { body: message.text },
-    };
-
-    if (message.richContent) {
-      body.type        = 'interactive';
-      body.interactive = message.richContent;
-      delete body.text;
-    }
-
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bearer ${this.accessToken}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[whatsapp] send failed: ${err}`);
-      throw new Error(`WhatsApp send failed: ${err}`);
-    }
-  }
-
-  // ── Router ────────────────────────────────────────────────────────────────────
-
-  getRouter(): Router {
-    const router = Router();
-
-    router.get('/webhook', (req: Request, res: Response) => {
-      const mode      = req.query['hub.mode'];
-      const token     = req.query['hub.verify_token'];
-      const challenge = req.query['hub.challenge'];
-
-      if (mode === 'subscribe' && token === this.verifyToken) {
-        console.info('[whatsapp] Webhook verified by Meta');
-        res.status(200).send(challenge);
-      } else {
-        res.status(403).json({ ok: false, error: 'Verification failed' });
-      }
-    });
-
-    router.post('/webhook', async (req: Request, res: Response) => {
-      if (this.appSecret) {
-        const signature = req.headers['x-hub-signature-256'] as string | undefined;
-        if (!this._validateSignature(JSON.stringify(req.body), signature)) {
-          res.status(403).json({ ok: false, error: 'Invalid signature' });
-          return;
-        }
-      }
-
-      res.json({ ok: true });
-
-      const entry   = (req.body as any)?.entry?.[0];
-      const changes = entry?.changes?.[0]?.value;
-      const messages = changes?.messages ?? [];
-
-      for (const waMsgRaw of messages) {
-        const waMsg = waMsgRaw as {
-          id:        string;
-          from:      string;
-          type:      string;
-          text?:     { body: string };
-          timestamp: string;
-        };
-
-        if (waMsg.type === 'text' && waMsg.text?.body) {
-          const msg: IncomingMessage = {
-            externalId: waMsg.from,
-            senderId:   waMsg.from,
-            text:       waMsg.text.body,
-            type:       'text',
-            metadata:   { messageId: waMsg.id, raw: waMsg },
-            receivedAt: this.makeTimestamp(),
-          };
-          await this.emit(msg).catch((err) =>
-            console.error('[whatsapp] emit error:', err),
-          );
-        }
-      }
-    });
-
-    return router;
-  }
-
-  // ── Helpers ──────────────────────────────────────────────────────────────────────
-
-  private _validateSignature(rawBody: string, signature?: string): boolean {
-    if (!signature) return false;
-    const expected =
-      'sha256=' +
-      createHmac('sha256', this.appSecret).update(rawBody, 'utf8').digest('hex');
-    return signature === expected;
+    // noop
   }
 }

--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -1,222 +1,128 @@
+import { Injectable } from '@nestjs/common'
+import { registry, SessionManager } from '@agent-vs/gateway-sdk'
+import type {
+  IncomingMessage,
+  OutgoingMessage,
+} from './channels/channel-adapter.interface.js'
+
 /**
- * gateway.service.ts — Dispatcher central del Gateway
- *
- * Responsabilidades:
- *   1. Cargar y cachear ChannelConfig desde Prisma
- *   2. Resolver el IChannelAdapter correcto para cada canal
- *   3. Coordinar receive() → SessionManager → AgentRunner → FlowExecutor
- *   4. Coordinar FlowEngine reply → SessionManager → adapter.send()
- *   5. Ciclo de vida: activateChannel() / deactivateChannel()
- *
- * Encriptación de secretos:
- *   ChannelConfig.secretsEncrypted: JSON encriptado con AES-256-GCM.
- *   Llave: GATEWAY_ENCRYPTION_KEY (hex 64 chars = 32 bytes).
- *   Formato del buffer encriptado:
- *     [12 bytes IV][16 bytes auth tag][N bytes ciphertext]
+ * GatewayService — orquesta recepción, procesamiento y envío de mensajes.
+ * [F3a-17] dispatch() usa replyFn fast path cuando está disponible.
  */
-
-import { Injectable }      from '@nestjs/common';
-import { createDecipheriv } from 'crypto';
-import type { PrismaClient }  from '@prisma/client';
-import {
-  registry,
-  SessionManager,
-  type IncomingMessage,
-  type OutboundMessage,
-} from '@agent-vs/gateway-sdk';
-import { AgentRunner }        from '@agent-vs/flow-engine';
-import type { IChannelAdapter } from './channels/channel-adapter.interface';
-import { PrismaService }       from './prisma/prisma.service';
-
-// ---------------------------------------------------------------------------
-// Tipos internos
-// ---------------------------------------------------------------------------
-
-interface DecryptedChannelConfig {
-  id:      string;
-  agentId: string;
-  type:    string;
-  config:  Record<string, unknown>;
-  secrets: Record<string, unknown>;
-}
-
-// ---------------------------------------------------------------------------
-// GatewayService
-// ---------------------------------------------------------------------------
-
 @Injectable()
 export class GatewayService {
-  /** Exposed for webchat reply route (needs findSession) */
-  readonly sessions:    SessionManager;
-  private readonly agentRunner:   AgentRunner;
-  private readonly configCache  = new Map<string, DecryptedChannelConfig>();
-  private readonly encKey:       Buffer;
+  constructor(
+    private readonly sessions:    SessionManager,
+    private readonly agentRunner: { run(agentId: string, history: unknown[]): Promise<{ reply?: string }> },
+  ) {}
 
-  constructor(private readonly db: PrismaService) {
-    this.sessions    = new SessionManager(db);
-    this.agentRunner = new AgentRunner({ db });
+  // ── Helpers privados ────────────────────────────────────────────────────
 
-    const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? '';
-    if (!keyHex) {
-      console.warn(
-        '[GatewayService] GATEWAY_ENCRYPTION_KEY not set — secrets decryption disabled',
-      );
-    }
-    this.encKey = Buffer.from(keyHex || '0'.repeat(64), 'hex');
+  private async loadChannelConfig(channelConfigId: string) {
+    const cfg = await registry.getChannelConfig(channelConfigId)
+    if (!cfg) throw new Error(`ChannelConfig not found: ${channelConfigId}`)
+    return cfg
   }
 
-  // -------------------------------------------------------------------------
-  // Public: lifecycle
-  // -------------------------------------------------------------------------
-
-  async activateChannel(channelConfigId: string): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
-    await (adapter as unknown as {
-      setup: (c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).setup(cfg.config, cfg.secrets);
-    console.info(`[GatewayService] channel ${channelConfigId} (${cfg.type}) activated`);
+  private resolveAdapter(channelType: string) {
+    const adapter = registry.getAdapter(channelType)
+    if (!adapter) throw new Error(`No adapter registered for channel type: ${channelType}`)
+    return adapter
   }
 
-  async deactivateChannel(channelConfigId: string): Promise<void> {
-    const cached = this.configCache.get(channelConfigId);
-    if (!cached) return;
-    const adapter = this.resolveAdapter(cached.type);
-    await (adapter as unknown as {
-      teardown: (c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).teardown(cached.config, cached.secrets).catch((err: unknown) => {
-      console.warn(`[GatewayService] teardown error for channel ${channelConfigId}:`, err);
-    });
-    this.configCache.delete(channelConfigId);
-    console.info(`[GatewayService] channel ${channelConfigId} deactivated`);
-  }
-
-  // -------------------------------------------------------------------------
-  // Public: message flow
-  // -------------------------------------------------------------------------
+  // ── dispatch() ──────────────────────────────────────────────────────────
 
   /**
-   * Entry point for every inbound webhook.
+   * Procesa un mensaje entrante de un canal.
    *
-   * Flow:
-   *   rawPayload
-   *     → adapter.receive()       parse channel format → IncomingMessage
-   *     → SessionManager           upsert GatewaySession, append user turn
-   *     → AgentRunner.run()        load Agent+FlowVersion, execute FlowExecutor
-   *     → recordReply()            append assistant turn, adapter.send()
+   * [F3a-17] Fast path: si incoming.replyFn está definida, la usamos
+   * directamente para responder in-band (crítico para canales con timeout
+   * de webhook como Telegram/WhatsApp, que requieren reply en ≤30s).
+   *
+   * Legacy path: si replyFn es undefined, usa la ruta antigua a través
+   * de recordReply() → adapter.send().
    */
   async dispatch(
     channelConfigId: string,
     rawPayload:      Record<string, unknown>,
   ): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
+    const cfg     = await this.loadChannelConfig(channelConfigId)
+    const adapter = this.resolveAdapter(cfg.type)
 
-    // 1. Parse inbound message
+    // 1. Parse inbound — receive() devuelve IncomingMessage con
+    //    replyFn, threadId y rawPayload ya populados por el adaptador
     const incoming = await (adapter as unknown as {
-      receive: (p: Record<string, unknown>, s: Record<string, unknown>) => Promise<IncomingMessage | null>;
-    }).receive(rawPayload, cfg.secrets);
+      receive: (p: Record<string, unknown>, s: Record<string, unknown>) => Promise<IncomingMessage | null>
+    }).receive(rawPayload, cfg.secrets)
 
-    if (!incoming) return;
+    if (!incoming) return
 
     // 2. Persist user turn + upsert session
     const session = await this.sessions.receiveUserMessage(
       channelConfigId,
       cfg.agentId,
       incoming,
-    );
+    )
 
     // 3. Run agent via FlowExecutor
-    let replyText: string;
+    let replyText: string
     try {
       const result = await this.agentRunner.run(
         session.agentId,
         session.history,
-      );
-      replyText = result.reply || '(sin respuesta)';
+      )
+      replyText = result.reply || '(sin respuesta)'
     } catch (err) {
-      console.error('[GatewayService] AgentRunner error:', err);
-      replyText = '(ocurrió un error al procesar tu mensaje)';
+      console.error('[GatewayService] AgentRunner error:', err)
+      replyText = '(ocurrió un error al procesar tu mensaje)'
     }
 
     // 4. Build outbound message
-    const outbound: OutboundMessage = {
-      externalUserId: incoming.externalUserId,
-      text: replyText,
-    };
+    const outgoing: OutgoingMessage = {
+      externalId: incoming.externalId,
+      threadId:   incoming.threadId !== incoming.externalId
+                    ? incoming.threadId   // preserva el thread si es distinto del chat
+                    : undefined,
+      text:       replyText,
+    }
 
-    // 5. Persist assistant turn + send to channel
-    await this.recordReply(channelConfigId, session.id, outbound);
+    // 5a. PATH RÁPIDO: replyFn disponible → reply in-band directo
+    //     El adaptador ya tiene las credenciales capturadas en el closure.
+    //     NO llamamos adapter.send() → evitamos double-send.
+    if (incoming.replyFn) {
+      await incoming.replyFn(replyText, {
+        format:        'text',
+        quoteOriginal: false,
+      })
+      // Persistir solo el texto (el envío ya ocurrió)
+      await this.sessions.recordAssistantReply(session.id, outgoing)
+      return
+    }
+
+    // 5b. PATH LEGACY: sin replyFn → ruta antigua (adapter.send() en recordReply)
+    await this.recordReply(channelConfigId, session.id, outgoing)
   }
 
+  // ── recordReply() ───────────────────────────────────────────────────────
+
   /**
-   * Called by the internal /api/webchat/:channelId/reply endpoint.
+   * [F3a-17] Actualizado para usar OutgoingMessage (era OutboundMessage).
+   *
+   * Sigue existiendo para:
+   *   1. El path legacy (canales sin replyFn)
+   *   2. El endpoint POST /webchat/:channelId/reply
    */
   async recordReply(
     channelConfigId: string,
     sessionId:       string,
-    outbound:        OutboundMessage,
+    outgoing:        OutgoingMessage,
   ): Promise<void> {
-    const cfg     = await this.loadChannelConfig(channelConfigId);
-    const adapter = this.resolveAdapter(cfg.type);
+    const cfg     = await this.loadChannelConfig(channelConfigId)
+    const adapter = this.resolveAdapter(cfg.type)
 
-    await this.sessions.recordAssistantReply(sessionId, outbound);
+    await this.sessions.recordAssistantReply(sessionId, outgoing)
     await (adapter as unknown as {
-      send: (m: OutboundMessage, c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>;
-    }).send(outbound, cfg.config, cfg.secrets);
-  }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
-
-  private async loadChannelConfig(
-    channelConfigId: string,
-  ): Promise<DecryptedChannelConfig> {
-    const cached = this.configCache.get(channelConfigId);
-    if (cached) return cached;
-
-    const row = await this.db.channelConfig.findUniqueOrThrow({
-      where: { id: channelConfigId },
-    });
-
-    const secrets = this.decrypt(row.secretsEncrypted as string | null);
-    const cfg: DecryptedChannelConfig = {
-      id:      row.id,
-      agentId: row.agentId,
-      type:    row.type,
-      config:  (row.config as Record<string, unknown>) ?? {},
-      secrets,
-    };
-    this.configCache.set(channelConfigId, cfg);
-    return cfg;
-  }
-
-  private resolveAdapter(type: string): IChannelAdapter {
-    if (registry.has(type)) {
-      return registry.get(type) as unknown as IChannelAdapter;
-    }
-    throw new Error(
-      `GatewayService: no adapter registered for channel type '${type}'. ` +
-      `Registered: ${registry.registeredTypes().join(', ') || '(none)'}`,
-    );
-  }
-
-  private decrypt(secretsEncrypted: string | null): Record<string, unknown> {
-    if (!secretsEncrypted) return {};
-    try {
-      const buf     = Buffer.from(secretsEncrypted, 'hex');
-      const iv      = buf.subarray(0, 12);
-      const authTag = buf.subarray(12, 28);
-      const cipher  = buf.subarray(28);
-
-      const decipher = createDecipheriv('aes-256-gcm', this.encKey, iv);
-      decipher.setAuthTag(authTag);
-      const decrypted = Buffer.concat([decipher.update(cipher), decipher.final()]);
-      return JSON.parse(decrypted.toString('utf8')) as Record<string, unknown>;
-    } catch (err) {
-      console.error('[GatewayService] Failed to decrypt secrets:', err);
-      return {};
-    }
+      send: (m: OutgoingMessage, c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>
+    }).send(outgoing, cfg.config, cfg.secrets)
   }
 }

--- a/apps/gateway/src/gateway.service.ts
+++ b/apps/gateway/src/gateway.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common'
-import { registry, SessionManager } from '@agent-vs/gateway-sdk'
+import { PrismaClient } from '@prisma/client'
+import {
+  registry,
+  SessionManager,
+  type IncomingMessage as SessionIncomingMessage,
+  type OutboundMessage as SessionOutboundMessage,
+} from '@agent-vs/gateway-sdk'
 import type {
   IncomingMessage,
   OutgoingMessage,
@@ -11,10 +17,22 @@ import type {
  */
 @Injectable()
 export class GatewayService {
+  public readonly sessions: SessionManager
+  private readonly agentRunner: { run(agentId: string, history: unknown[]): Promise<{ reply?: string }> }
+
   constructor(
-    private readonly sessions:    SessionManager,
-    private readonly agentRunner: { run(agentId: string, history: unknown[]): Promise<{ reply?: string }> },
-  ) {}
+    dbOrSessions: PrismaClient | SessionManager,
+    agentRunner?: { run(agentId: string, history: unknown[]): Promise<{ reply?: string }> },
+  ) {
+    this.sessions = dbOrSessions instanceof SessionManager
+      ? dbOrSessions
+      : new SessionManager(dbOrSessions)
+    this.agentRunner = agentRunner ?? {
+      async run() {
+        return { reply: '(sin respuesta)' }
+      },
+    }
+  }
 
   // ── Helpers privados ────────────────────────────────────────────────────
 
@@ -25,9 +43,49 @@ export class GatewayService {
   }
 
   private resolveAdapter(channelType: string) {
-    const adapter = registry.getAdapter(channelType)
+    const adapter = registry.get(channelType)
     if (!adapter) throw new Error(`No adapter registered for channel type: ${channelType}`)
     return adapter
+  }
+
+  async activateChannel(channelConfigId: string): Promise<void> {
+    const cfg = await this.loadChannelConfig(channelConfigId)
+    const adapter = this.resolveAdapter(cfg.type) as unknown as {
+      setup?: (config: Record<string, unknown>, secrets: Record<string, unknown>) => Promise<void>
+      initialize?: (channelConfigId: string) => Promise<void>
+    }
+
+    if (typeof adapter.setup === 'function') {
+      await adapter.setup(cfg.config, cfg.secrets)
+      return
+    }
+
+    if (typeof adapter.initialize === 'function') {
+      await adapter.initialize(channelConfigId)
+      return
+    }
+
+    throw new Error(`Adapter for channel type "${cfg.type}" does not support activation`)
+  }
+
+  async deactivateChannel(channelConfigId: string): Promise<void> {
+    const cfg = await this.loadChannelConfig(channelConfigId)
+    const adapter = this.resolveAdapter(cfg.type) as unknown as {
+      teardown?: () => Promise<void>
+      dispose?: () => Promise<void>
+    }
+
+    if (typeof adapter.teardown === 'function') {
+      await adapter.teardown()
+      return
+    }
+
+    if (typeof adapter.dispose === 'function') {
+      await adapter.dispose()
+      return
+    }
+
+    throw new Error(`Adapter for channel type "${cfg.type}" does not support deactivation`)
   }
 
   // ── dispatch() ──────────────────────────────────────────────────────────
@@ -58,10 +116,34 @@ export class GatewayService {
     if (!incoming) return
 
     // 2. Persist user turn + upsert session
+    if (!cfg.agentId) {
+      throw new Error(`ChannelConfig missing agentId in registry cache: ${channelConfigId}`)
+    }
+
+    const sessionAttachments = (incoming.attachments ?? [])
+      .flatMap((attachment) => {
+        const url = attachment.url ?? (typeof attachment.data === 'string' ? attachment.data : '')
+        if (!url) return []
+        return [{
+          mimeType: attachment.type,
+          url,
+          name:    undefined,
+          size:    undefined,
+        }]
+      })
+
+    const sessionIncoming: SessionIncomingMessage = {
+      externalUserId: incoming.externalId,
+      text:           incoming.text,
+      attachments:    sessionAttachments,
+      metadata:       incoming.metadata ?? {},
+      ts:             incoming.receivedAt,
+    }
+
     const session = await this.sessions.receiveUserMessage(
       channelConfigId,
       cfg.agentId,
-      incoming,
+      sessionIncoming,
     )
 
     // 3. Run agent via FlowExecutor
@@ -95,12 +177,18 @@ export class GatewayService {
         quoteOriginal: false,
       })
       // Persistir solo el texto (el envío ya ocurrió)
-      await this.sessions.recordAssistantReply(session.id, outgoing)
+      await this.sessions.recordAssistantReply(session.sessionId, {
+        externalUserId: outgoing.externalId,
+        text:           outgoing.text,
+        attachments:    [],
+        options:        outgoing.richContent ? { richContent: outgoing.richContent } : undefined,
+        buttons:        undefined,
+      } satisfies SessionOutboundMessage)
       return
     }
 
     // 5b. PATH LEGACY: sin replyFn → ruta antigua (adapter.send() en recordReply)
-    await this.recordReply(channelConfigId, session.id, outgoing)
+    await this.recordReply(channelConfigId, session.sessionId, outgoing)
   }
 
   // ── recordReply() ───────────────────────────────────────────────────────
@@ -120,7 +208,13 @@ export class GatewayService {
     const cfg     = await this.loadChannelConfig(channelConfigId)
     const adapter = this.resolveAdapter(cfg.type)
 
-    await this.sessions.recordAssistantReply(sessionId, outgoing)
+    await this.sessions.recordAssistantReply(sessionId, {
+      externalUserId: outgoing.externalId,
+      text:           outgoing.text,
+      attachments:    [],
+      options:        outgoing.richContent ? { richContent: outgoing.richContent } : undefined,
+      buttons:        undefined,
+    } satisfies SessionOutboundMessage)
     await (adapter as unknown as {
       send: (m: OutgoingMessage, c: Record<string, unknown>, s: Record<string, unknown>) => Promise<void>
     }).send(outgoing, cfg.config, cfg.secrets)

--- a/apps/gateway/src/routes/channels.ts
+++ b/apps/gateway/src/routes/channels.ts
@@ -45,6 +45,7 @@ import { randomBytes, createCipheriv } from 'crypto';
 import { Router, type Request, type Response } from 'express';
 import type { PrismaClient } from '@prisma/client';
 import type { GatewayService } from '../gateway.service';
+import { registry } from '@agent-vs/gateway-sdk';
 
 // ---------------------------------------------------------------------------
 // Encrypt helper (mirrors GatewayService.decrypt)
@@ -133,7 +134,7 @@ export function channelsApiRouter(
       );
 
       // Create ChannelConfig + ChannelBinding in a transaction
-      const result = await db.$transaction(async (tx) => {
+      const result = await db.$transaction(async (tx: PrismaClient) => {
         const channel = await tx.channelConfig.create({
           data: {
             type:             body.type,
@@ -155,6 +156,14 @@ export function channelsApiRouter(
         });
 
         return { channel, binding };
+      });
+
+      registry.setChannelConfig({
+        id:     result.channel.id,
+        type:   result.channel.type,
+        config: result.channel.config as Record<string, unknown>,
+        secrets: body.secrets ?? {},
+        agentId: body.agentId,
       });
 
       res.status(201).json({
@@ -237,6 +246,7 @@ export function channelsApiRouter(
     try {
       const existing = await db.channelConfig.findUnique({
         where: { id: req.params.id },
+        include: { bindings: true },
       });
       if (!existing) {
         res.status(404).json({ ok: false, error: 'ChannelConfig not found' });
@@ -253,6 +263,14 @@ export function channelsApiRouter(
       const updated = await db.channelConfig.update({
         where: { id: req.params.id },
         data:  updateData,
+      });
+
+      registry.setChannelConfig({
+        id:     updated.id,
+        type:   updated.type,
+        config: updated.config as Record<string, unknown>,
+        secrets: body.secrets ?? registry.getChannelConfig(updated.id)?.secrets ?? {},
+        agentId: existing.bindings[0]?.agentId,
       });
 
       res.json({ ok: true, data: sanitizeChannel(updated) });
@@ -280,6 +298,7 @@ export function channelsApiRouter(
         await gatewayService.deactivateChannel(req.params.id).catch(() => {});
       }
 
+      registry.deleteChannelConfig(req.params.id);
       await db.channelConfig.delete({ where: { id: req.params.id } });
       res.json({ ok: true });
     } catch (err) {

--- a/apps/gateway/src/routes/webchat.ts
+++ b/apps/gateway/src/routes/webchat.ts
@@ -222,10 +222,10 @@ export function webchatApiRouter(gatewayService: GatewayService): Router {
         return;
       }
 
-      await gatewayService.recordReply(channelId, session.id, {
-        externalUserId: body.sessionId,
+      await gatewayService.recordReply(channelId, session.sessionId, {
+        externalId: body.sessionId,
         text:           body.text,
-        buttons:        body.buttons,
+        richContent:    body.buttons ? { buttons: body.buttons } : undefined,
       });
 
       res.json({ ok: true });

--- a/apps/gateway/src/routes/webhook.ts
+++ b/apps/gateway/src/routes/webhook.ts
@@ -111,7 +111,7 @@ export function webhookRouter(gatewayService: GatewayService): Router {
       res.status(200).json({
         ok: true,
         reply: lastAssistant?.content ?? '',
-        sessionId: session?.id ?? null,
+        sessionId: session?.sessionId ?? null,
       });
     } catch (err) {
       console.error(`[webhook] dispatch error for channel ${channelId}:`, err);

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -1,16 +1,22 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite":               true,
     "experimentalDecorators":  true,
     "emitDecoratorMetadata":   true,
     "outDir":                  "dist",
-    "rootDir":                 "../..",
+    "rootDir":                 "src",
+    "declarationDir":          "dist",
     "baseUrl":                 ".",
+    "lib":                     ["ES2022"],
     "paths": {
-      "@gateway/*": ["src/*"],
-      "@agent-vs/gateway-sdk": ["../../packages/gateway-sdk/src/index.ts"]
+      "@gateway/*":             ["src/*"],
+      "@agent-vs/gateway-sdk":  ["../../packages/gateway-sdk/src/index.ts"]
     }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+  "include":  ["src/**/*"],
+  "exclude":  ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "**/__tests__/**"],
+  "references": [
+    { "path": "../../packages/gateway-sdk" }
+  ]
 }

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -4,10 +4,11 @@
     "experimentalDecorators":  true,
     "emitDecoratorMetadata":   true,
     "outDir":                  "dist",
-    "rootDir":                 "src",
+    "rootDir":                 "../..",
     "baseUrl":                 ".",
     "paths": {
-      "@gateway/*": ["src/*"]
+      "@gateway/*": ["src/*"],
+      "@agent-vs/gateway-sdk": ["../../packages/gateway-sdk/src/index.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/gateway-sdk/src/adapters/telegram.ts
+++ b/packages/gateway-sdk/src/adapters/telegram.ts
@@ -72,7 +72,7 @@ export class TelegramAdapter implements IChannelAdapter {
     rawPayload: Record<string, unknown>,
     secrets:    Record<string, unknown>,
   ): Promise<IncomingMessage | null> {
-    const update = rawPayload as TelegramUpdate;
+    const update = rawPayload as unknown as TelegramUpdate;
     const token  = secrets.botToken as string;
 
     // ── callback_query (inline button press) ─────────────────────────

--- a/packages/gateway-sdk/src/channel-adapter.ts
+++ b/packages/gateway-sdk/src/channel-adapter.ts
@@ -132,6 +132,14 @@ export interface IChannelAdapter {
   ): Promise<void>;
 }
 
+export interface ChannelConfigSnapshot {
+  id: string;
+  type: string;
+  config: Record<string, unknown>;
+  secrets: Record<string, unknown>;
+  agentId?: string;
+}
+
 // ─── Registry ─────────────────────────────────────────────────────────────────
 
 /**
@@ -149,6 +157,7 @@ export interface IChannelAdapter {
  */
 export class ChannelAdapterRegistry {
   private readonly adapters = new Map<string, IChannelAdapter>();
+  private readonly channelConfigs = new Map<string, ChannelConfigSnapshot>();
 
   register(adapter: IChannelAdapter): void {
     if (this.adapters.has(adapter.type)) {
@@ -173,6 +182,18 @@ export class ChannelAdapterRegistry {
       );
     }
     return adapter;
+  }
+
+  setChannelConfig(channelConfig: ChannelConfigSnapshot): void {
+    this.channelConfigs.set(channelConfig.id, channelConfig);
+  }
+
+  getChannelConfig(channelConfigId: string): ChannelConfigSnapshot | null {
+    return this.channelConfigs.get(channelConfigId) ?? null;
+  }
+
+  deleteChannelConfig(channelConfigId: string): void {
+    this.channelConfigs.delete(channelConfigId);
   }
 
   has(type: string): boolean {

--- a/packages/gateway-sdk/src/index.ts
+++ b/packages/gateway-sdk/src/index.ts
@@ -17,6 +17,8 @@ export type {
 } from './session-manager.js'
 
 export { SessionManager } from './session-manager.js'
+export { TelegramAdapter } from './adapters/telegram.js'
+export { WebChatAdapter } from './adapters/webchat.js'
 
 // Gateway methods — exported here so consumers can import from '@agent-vs/gateway-sdk'
 // instead of reaching into the internal methods.ts file directly.

--- a/packages/gateway-sdk/src/session-manager.ts
+++ b/packages/gateway-sdk/src/session-manager.ts
@@ -274,7 +274,13 @@ export class SessionManager {
     })
 
     // Invertir para orden cronológico asc (más antiguo primero)
-    return rows.reverse().map((r) => ({
+    return rows.reverse().map((r: {
+      role: string
+      contentText: string | null
+      toolName: string | null
+      toolCallId: string | null
+      createdAt: Date
+    }) => ({
       role:       r.role as SessionHistoryEntry['role'],
       content:    r.contentText ?? '',
       ts:         r.createdAt.toISOString(),

--- a/packages/gateway-sdk/tsconfig.json
+++ b/packages/gateway-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite":     true,
+    "outDir":        "dist",
+    "rootDir":       "src",
+    "declarationDir": "dist",
+    "baseUrl":       ".",
+    "lib":           ["ES2022"],
+    "paths": {
+      "@agent-vs/gateway-sdk": ["src/index.ts"]
+    }
+  },
+  "include":  ["src/**/*"],
+  "exclude":  ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "**/__tests__/**"]
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El commit fue exitoso. Aquí está el resumen completo de la implementación:</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="implementacin-f3a-18--telegramadapter-hardening">Implementación F3a-18 — TelegramAdapter Hardening ✅</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El commit fue realizado en la rama <code>feat/F3a-18-telegram-adapter-hardening</code> del repositorio <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio"><span class="text-box-trim-both">lssmanager/agent-visualstudio</span></a>.</p><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>🔢 Commit SHA:</strong> <code>8cf802d0fa2a017f37294a74f7d935d42d6491b9</code></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-entregados">Archivos entregados</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>1. <code>apps/gateway/src/channels/__tests__/telegram.adapter.test.ts</code></strong> (nuevo)<br>Suite completa de tests con <strong>≥22 casos</strong> cubriendo todos los escenarios del plan:</p><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised">
Grupo | Tests
-- | --
receive() | DM/supergrupo/command/image/callback_query/null/rawPayload sanitizado
replyFn — text | chat_id, parse_mode Markdown, quoteOriginal, message_thread_id
replyFn — callback_query | answerCallbackQuery primero, sendMessage segundo
send() | message_thread_id, 429 Retry-After, maxTries agotados
long-polling loop | offset inicial, update_id+1, 401→stop, circuit breaker 5 errores, dispose()
webhook handler | 403 sin secret, 200 con secret, 400 sin URL, setWebhook, deleteWebhook
fetchWithRetry | éxito, retry en error, falla tras maxTries

</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>2. <code>apps/gateway/.env.example</code></strong> (nuevo)<br>Documenta <code>TELEGRAM_MODE</code> y <code>TELEGRAM_WEBHOOK_URL</code> con comentarios explicativos sobre webhook vs. polling.</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="problemas-resueltos">Problemas resueltos</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El <code>telegram.adapter.ts</code> ya estaba en la rama desde una iteración anterior con todos los 7 problemas del plan resueltos: long-polling con circuit breaker, retry/backoff en <code>fetchWithRetry</code>, <code>receive()</code> con <code>replyFn</code>/<code>threadId</code>/<code>rawPayload</code>, <code>message_thread_id</code> en supergrupos, <code>answerCallbackQuery</code> en <code>replyFn</code> de callbacks, y desacoplamiento de Prisma vía <code>setup(config, secrets)</code>.</p></div></body></html><!--EndFragment-->
</body>
</html>El commit fue exitoso. Aquí está el resumen completo de la implementación:

***

## Implementación F3a-18 — TelegramAdapter Hardening ✅

El commit fue realizado en la rama `feat/F3a-18-telegram-adapter-hardening` del repositorio [[lssmanager/agent-visualstudio](https://github.com/lssmanager/agent-visualstudio)](https://github.com/lssmanager/agent-visualstudio).

**🔢 Commit SHA:** `8cf802d0fa2a017f37294a74f7d935d42d6491b9`

***

### Archivos entregados

**1. `apps/gateway/src/channels/__tests__/telegram.adapter.test.ts`** (nuevo)
Suite completa de tests con **≥22 casos** cubriendo todos los escenarios del plan:

| Grupo | Tests |
|---|---|
| `receive()` | DM/supergrupo/command/image/callback_query/null/rawPayload sanitizado |
| `replyFn — text` | chat_id, parse_mode Markdown, quoteOriginal, message_thread_id |
| `replyFn — callback_query` | answerCallbackQuery primero, sendMessage segundo |
| `send()` | message_thread_id, 429 Retry-After, maxTries agotados |
| `long-polling loop` | offset inicial, update_id+1, 401→stop, circuit breaker 5 errores, dispose() |
| `webhook handler` | 403 sin secret, 200 con secret, 400 sin URL, setWebhook, deleteWebhook |
| `fetchWithRetry` | éxito, retry en error, falla tras maxTries |

**2. `apps/gateway/.env.example`** (nuevo)
Documenta `TELEGRAM_MODE` y `TELEGRAM_WEBHOOK_URL` con comentarios explicativos sobre webhook vs. polling.

***

### Problemas resueltos

El `telegram.adapter.ts` ya estaba en la rama desde una iteración anterior con todos los 7 problemas del plan resueltos: long-polling con circuit breaker, retry/backoff en `fetchWithRetry`, `receive()` con `replyFn`/`threadId`/`rawPayload`, `message_thread_id` en supergrupos, `answerCallbackQuery` en `replyFn` de callbacks, y desacoplamiento de Prisma vía `setup(config, secrets)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel lifecycle endpoints: provision, start, stop, restart, status.
  * In-band immediate replies, improved thread/topic handling and quoting across adapters.
  * Telegram: webhook + long-polling modes; WebChat: connection buffering, session broadcast and pending-reply queue.
  * Adapters updated for Discord, Slack, WhatsApp, Webhook with unified send/receive contracts.

* **Tests**
  * Extensive unit/integration tests covering lifecycle and all channel adapters.

* **Refactor**
  * Unified gateway dispatch flow and expanded gateway SDK registry/exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->