### PR TITLE
Feat/f3a 21 whatsapp baileys

### DIFF
--- a/apps/api/src/modules/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/modules/channels/channel-lifecycle.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, Logger }    from '@nestjs/common'
-import { PrismaService }         from '../../lib/prisma.service.js'
-import { GatewayService }        from '../gateway/gateway.service.js'
-import { AgentResolverService }  from '../gateway/agent-resolver.service.js'
+import { Injectable, Logger } from '@nestjs/common'
+import { PrismaService } from '../../lib/prisma.service.js'
+import { GatewayService } from '../gateway/gateway.service.js'
+import { AgentResolverService } from '../gateway/agent-resolver.service.js'
 import {
   ChannelNotFoundError,
   InvalidTransitionError,
@@ -9,9 +9,7 @@ import {
   WebhookRegistrationError,
 } from './channel-lifecycle.errors.js'
 import type { ProvisionChannelDto, ChannelStatusDto } from './dto/provision-channel.dto.js'
-import { createCipheriv, randomBytes }               from 'crypto'
-
-// ── Tipos ───────────────────────────────────────────────────────────────
+import { createCipheriv, randomBytes } from 'crypto'
 
 type ChannelStatus =
   | 'provisioned'
@@ -21,56 +19,42 @@ type ChannelStatus =
   | 'stopped'
   | 'error'
 
-// ── Transiciones permitidas (mapa explícito) ────────────────────────────
-
 const TRANSITIONS: Record<ChannelStatus, ChannelStatus[]> = {
   provisioned: ['starting'],
-  starting:    ['active', 'error'],
-  active:      ['stopping'],
-  stopping:    ['stopped', 'error'],
-  stopped:     ['starting'],
-  error:       ['starting'],
+  starting: ['active', 'error'],
+  active: ['stopping'],
+  stopping: ['stopped', 'error'],
+  stopped: ['starting'],
+  error: ['starting'],
 }
 
-// ── Servicio ────────────────────────────────────────────────────────────
+const START_ALLOWED_STATUSES: ChannelStatus[] = ['provisioned', 'stopped', 'error']
+const STOP_ALLOWED_STATUSES: ChannelStatus[] = ['active']
 
 @Injectable()
 export class ChannelLifecycleService {
   private readonly logger = new Logger(ChannelLifecycleService.name)
 
   constructor(
-    private readonly db:       PrismaService,
-    private readonly gateway:  GatewayService,
+    private readonly db: PrismaService,
+    private readonly gateway: GatewayService,
     private readonly resolver: AgentResolverService,
   ) {}
 
-  // ────────────────────────────────────────────────────────────────────
-  // PROVISION — Crea el ChannelConfig en BD con status='provisioned'
-  // ────────────────────────────────────────────────────────────────────
-
-  /**
-   * Crea un nuevo canal en la BD en estado 'provisioned'.
-   * No registra webhooks ni activa el canal.
-   * Si dto.autoStart=true, llama start() inmediatamente después.
-   *
-   * @returns ChannelStatusDto del canal creado
-   */
   async provision(dto: ProvisionChannelDto): Promise<ChannelStatusDto> {
-    const secretsEncrypted = dto.secrets
-      ? this.encryptSecrets(dto.secrets)
-      : null
+    const secretsEncrypted = dto.secrets ? this.encryptSecrets(dto.secrets) : null
 
     const channel = await this.db.channelConfig.create({
       data: {
-        type:             dto.type,
-        name:             dto.name,
-        config:           dto.config,
+        type: dto.type,
+        name: dto.name,
+        config: dto.config,
         secretsEncrypted,
-        isActive:         false,
-        status:           'provisioned',
-        errorMessage:     null,
-        lastStartedAt:    null,
-        lastStoppedAt:    null,
+        isActive: false,
+        status: 'provisioned',
+        errorMessage: null,
+        lastStartedAt: null,
+        lastStoppedAt: null,
       },
     })
 
@@ -83,55 +67,41 @@ export class ChannelLifecycleService {
     return this.toStatusDto(channel, 0, 0)
   }
 
-  // ────────────────────────────────────────────────────────────────────
-  // START — Activa el canal: registra webhooks y marca isActive=true
-  // ────────────────────────────────────────────────────────────────────
-
-  /**
-   * Inicia un canal en estado 'provisioned', 'stopped', o 'error'.
-   * Flujo:
-   *   1. Validar transición → 'starting'
-   *   2. Persistir status='starting', isActive=true
-   *   3. Llamar GatewayService.activateChannel() (con stub de seguridad)
-   *   4a. Éxito → persistir status='active', lastStartedAt=now
-   *   4b. Fallo → persistir status='error', isActive=false, errorMessage
-   *
-   * @throws InvalidTransitionError si el canal no puede hacer start desde su estado actual
-   */
   async start(channelConfigId: string): Promise<ChannelStatusDto> {
-    const channel = await this.loadOrThrow(channelConfigId)
+    const claim = await this.db.channelConfig.updateMany({
+      where: {
+        id: channelConfigId,
+        status: { in: START_ALLOWED_STATUSES },
+      },
+      data: { status: 'starting', isActive: true, errorMessage: null },
+    })
 
-    if (channel.status === 'active') {
-      throw new ChannelAlreadyInStateError(channelConfigId, 'active')
+    if (claim.count === 0) {
+      const channel = await this.db.channelConfig.findUnique({ where: { id: channelConfigId } })
+      if (!channel) throw new ChannelNotFoundError(channelConfigId)
+      if (channel.status === 'active' || channel.status === 'starting') {
+        throw new ChannelAlreadyInStateError(channelConfigId, channel.status)
+      }
+      throw new InvalidTransitionError(channelConfigId, channel.status, 'starting')
     }
 
-    this.assertTransition(channel.status as ChannelStatus, 'starting', channelConfigId)
-
-    // Marcar como 'starting'
-    await this.db.channelConfig.update({
-      where: { id: channelConfigId },
-      data:  { status: 'starting', isActive: true, errorMessage: null },
-    })
     this.resolver.invalidateCache(channelConfigId)
 
     try {
-      // Delegar al GatewayService la activación real del canal (stub-safe)
       await this.callGatewayActivate(channelConfigId)
 
-      // Marcar como 'active'
       const updated = await this.db.channelConfig.update({
         where: { id: channelConfigId },
-        data:  { status: 'active', lastStartedAt: new Date() },
+        data: { status: 'active', lastStartedAt: new Date() },
       })
       this.resolver.invalidateCache(channelConfigId)
       this.logger.log(`[start] Channel "${channelConfigId}" is now active`)
       return this.buildStatusDto(updated, channelConfigId)
-
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err)
       await this.db.channelConfig.update({
         where: { id: channelConfigId },
-        data:  { status: 'error', isActive: false, errorMessage },
+        data: { status: 'error', isActive: false, errorMessage },
       })
       this.resolver.invalidateCache(channelConfigId)
       this.logger.error(`[start] Channel "${channelConfigId}" failed to start: ${errorMessage}`)
@@ -139,34 +109,24 @@ export class ChannelLifecycleService {
     }
   }
 
-  // ────────────────────────────────────────────────────────────────────
-  // STOP — Desactiva el canal: desregistra webhooks y marca isActive=false
-  // ────────────────────────────────────────────────────────────────────
-
-  /**
-   * Detiene un canal en estado 'active'.
-   * Flujo:
-   *   1. Validar transición → 'stopping'
-   *   2. Persistir status='stopping', isActive=false
-   *   3. Llamar GatewayService.deactivateChannel() (con stub de seguridad)
-   *   4a. Éxito → persistir status='stopped', lastStoppedAt=now
-   *   4b. Fallo → persistir status='error', errorMessage
-   *
-   * @throws InvalidTransitionError si el canal no está en estado 'active'
-   */
   async stop(channelConfigId: string): Promise<ChannelStatusDto> {
-    const channel = await this.loadOrThrow(channelConfigId)
+    const claim = await this.db.channelConfig.updateMany({
+      where: {
+        id: channelConfigId,
+        status: { in: STOP_ALLOWED_STATUSES },
+      },
+      data: { status: 'stopping', isActive: false, errorMessage: null },
+    })
 
-    if (channel.status === 'stopped') {
-      throw new ChannelAlreadyInStateError(channelConfigId, 'stopped')
+    if (claim.count === 0) {
+      const channel = await this.db.channelConfig.findUnique({ where: { id: channelConfigId } })
+      if (!channel) throw new ChannelNotFoundError(channelConfigId)
+      if (channel.status === 'stopped' || channel.status === 'stopping') {
+        throw new ChannelAlreadyInStateError(channelConfigId, channel.status)
+      }
+      throw new InvalidTransitionError(channelConfigId, channel.status, 'stopping')
     }
 
-    this.assertTransition(channel.status as ChannelStatus, 'stopping', channelConfigId)
-
-    await this.db.channelConfig.update({
-      where: { id: channelConfigId },
-      data:  { status: 'stopping', isActive: false, errorMessage: null },
-    })
     this.resolver.invalidateCache(channelConfigId)
 
     try {
@@ -174,17 +134,16 @@ export class ChannelLifecycleService {
 
       const updated = await this.db.channelConfig.update({
         where: { id: channelConfigId },
-        data:  { status: 'stopped', lastStoppedAt: new Date() },
+        data: { status: 'stopped', lastStoppedAt: new Date() },
       })
       this.resolver.invalidateCache(channelConfigId)
       this.logger.log(`[stop] Channel "${channelConfigId}" is now stopped`)
       return this.buildStatusDto(updated, channelConfigId)
-
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err)
       await this.db.channelConfig.update({
         where: { id: channelConfigId },
-        data:  { status: 'error', errorMessage },
+        data: { status: 'error', errorMessage },
       })
       this.resolver.invalidateCache(channelConfigId)
       this.logger.error(`[stop] Channel "${channelConfigId}" failed to stop: ${errorMessage}`)
@@ -192,25 +151,11 @@ export class ChannelLifecycleService {
     }
   }
 
-  // ────────────────────────────────────────────────────────────────────
-  // RESTART — stop() + start() con manejo de estado intermedio
-  // ────────────────────────────────────────────────────────────────────
-
-  /**
-   * Reinicia el canal.
-   * - Si está 'active' → stop() + start()
-   * - Si está 'error', 'stopped', 'provisioned' → start() directo
-   * - Si está 'starting' o 'stopping' → InvalidTransitionError
-   */
   async restart(channelConfigId: string): Promise<ChannelStatusDto> {
     const channel = await this.loadOrThrow(channelConfigId)
 
     if (channel.status === 'starting' || channel.status === 'stopping') {
-      throw new InvalidTransitionError(
-        channelConfigId,
-        channel.status,
-        'restart',
-      )
+      throw new InvalidTransitionError(channelConfigId, channel.status, 'restart')
     }
 
     if (channel.status === 'active') {
@@ -220,66 +165,28 @@ export class ChannelLifecycleService {
     return this.start(channelConfigId)
   }
 
-  // ────────────────────────────────────────────────────────────────────
-  // STATUS — Lectura enriquecida del estado del canal
-  // ────────────────────────────────────────────────────────────────────
-
-  /**
-   * Retorna el ChannelStatusDto con conteos de bindings y sesiones activas.
-   * Nunca lanza errores de transición — solo lanza ChannelNotFoundError.
-   */
   async status(channelConfigId: string): Promise<ChannelStatusDto> {
     const channel = await this.loadOrThrow(channelConfigId)
     return this.buildStatusDto(channel, channelConfigId)
   }
 
-  /**
-   * Lista todos los canales con su estado actual.
-   * Ordenados por: activos primero, luego por nombre.
-   */
   async listAll(): Promise<ChannelStatusDto[]> {
     const channels = await this.db.channelConfig.findMany({
-      orderBy: [
-        { isActive: 'desc' },
-        { name: 'asc' },
-      ],
+      orderBy: [{ isActive: 'desc' }, { name: 'asc' }],
     })
 
-    return Promise.all(
-      channels.map((ch: any) => this.buildStatusDto(ch, ch.id))
-    )
+    return Promise.all(channels.map((ch: any) => this.buildStatusDto(ch, ch.id)))
   }
 
-  // ────────────────────────────────────────────────────────────────────
-  // STUBS DE GATEWAY (safe delegation)
-  // ────────────────────────────────────────────────────────────────────
-
-  /**
-   * Llama gateway.activateChannel() si el método existe.
-   * Si aún no está implementado en GatewayService, actúa como no-op
-   * para que el build no rompa.
-   */
   private async callGatewayActivate(id: string): Promise<void> {
     await this.gateway.activateChannel(id)
   }
 
-  /**
-   * Llama gateway.deactivateChannel() si el método existe.
-   * Si aún no está implementado en GatewayService, actúa como no-op.
-   */
   private async callGatewayDeactivate(id: string): Promise<void> {
     await this.gateway.deactivateChannel(id)
   }
 
-  // ────────────────────────────────────────────────────────────────────
-  // PRIVADOS
-  // ────────────────────────────────────────────────────────────────────
-
-  private assertTransition(
-    from:             ChannelStatus,
-    to:               ChannelStatus,
-    channelConfigId:  string,
-  ): void {
+  private assertTransition(from: ChannelStatus, to: ChannelStatus, channelConfigId: string): void {
     const allowed = TRANSITIONS[from] ?? []
     if (!allowed.includes(to)) {
       throw new InvalidTransitionError(channelConfigId, from, to)
@@ -287,60 +194,45 @@ export class ChannelLifecycleService {
   }
 
   private async loadOrThrow(channelConfigId: string) {
-    const channel = await this.db.channelConfig.findUnique({
-      where: { id: channelConfigId },
-    })
+    const channel = await this.db.channelConfig.findUnique({ where: { id: channelConfigId } })
     if (!channel) throw new ChannelNotFoundError(channelConfigId)
     return channel
   }
 
-  private async buildStatusDto(
-    channel:         any,
-    channelConfigId: string,
-  ): Promise<ChannelStatusDto> {
+  private async buildStatusDto(channel: any, channelConfigId: string): Promise<ChannelStatusDto> {
     const [bindingCount, activeSessions] = await Promise.all([
       this.db.channelBinding.count({ where: { channelConfigId } }),
-      this.db.gatewaySession.count({
-        where: { channelConfigId, state: 'active' },
-      }),
+      this.db.gatewaySession.count({ where: { channelConfigId, state: 'active' } }),
     ])
     return this.toStatusDto(channel, bindingCount, activeSessions)
   }
 
-  private toStatusDto(
-    ch:             any,
-    bindingCount:   number,
-    activeSessions: number,
-  ): ChannelStatusDto {
+  private toStatusDto(ch: any, bindingCount: number, activeSessions: number): ChannelStatusDto {
     return {
-      id:             ch.id,
-      name:           ch.name,
-      type:           ch.type,
-      status:         ch.status,
-      isActive:       ch.isActive,
-      errorMessage:   ch.errorMessage ?? null,
-      lastStartedAt:  ch.lastStartedAt?.toISOString() ?? null,
-      lastStoppedAt:  ch.lastStoppedAt?.toISOString() ?? null,
+      id: ch.id,
+      name: ch.name,
+      type: ch.type,
+      status: ch.status,
+      isActive: ch.isActive,
+      errorMessage: ch.errorMessage ?? null,
+      lastStartedAt: ch.lastStartedAt?.toISOString() ?? null,
+      lastStoppedAt: ch.lastStoppedAt?.toISOString() ?? null,
       bindingCount,
       activeSessions,
-      createdAt:      ch.createdAt.toISOString(),
-      updatedAt:      ch.updatedAt.toISOString(),
+      createdAt: ch.createdAt.toISOString(),
+      updatedAt: ch.updatedAt.toISOString(),
     }
   }
 
-  /**
-   * Encripta los secretos del canal usando AES-256-GCM.
-   * Mismo esquema que GatewayService: [12 IV][16 tag][N ciphertext]
-   */
   private encryptSecrets(secrets: Record<string, unknown>): string {
     const keyHex = process.env.GATEWAY_ENCRYPTION_KEY ?? ''
     if (!keyHex) throw new Error('GATEWAY_ENCRYPTION_KEY is not set')
-    const key    = Buffer.from(keyHex, 'hex')
-    const iv     = randomBytes(12)
+    const key = Buffer.from(keyHex, 'hex')
+    const iv = randomBytes(12)
     const cipher = createCipheriv('aes-256-gcm', key, iv)
-    const plain  = Buffer.from(JSON.stringify(secrets), 'utf8')
-    const enc    = Buffer.concat([cipher.update(plain), cipher.final()])
-    const tag    = cipher.getAuthTag()
+    const plain = Buffer.from(JSON.stringify(secrets), 'utf8')
+    const enc = Buffer.concat([cipher.update(plain), cipher.final()])
+    const tag = cipher.getAuthTag()
     return Buffer.concat([iv, tag, enc]).toString('base64')
   }
 }

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -1,0 +1,19 @@
+# Gateway Environment Variables
+
+# ── Crypto ──────────────────────────────────────────────────────────────────
+# 64 hex chars = 32 bytes AES-256-GCM key
+GATEWAY_ENCRYPTION_KEY=
+
+# Internal API auth token
+INTERNAL_API_TOKEN=
+
+# ── Telegram Adapter (F3a-18) ────────────────────────────────────────────────
+TELEGRAM_MODE=webhook          # webhook | polling (default: webhook)
+TELEGRAM_WEBHOOK_URL=          # URL pública para autoSetupWebhook()
+                                # El adapter añade /gateway/telegram/webhook
+
+# ── WhatsApp Baileys Adapter (F3a-21) ────────────────────────────────────────
+WA_SESSIONS_DIR=./data/wa-sessions   # Directorio para auth state de Baileys
+                                      # Un subdirectorio por channelConfigId
+                                      # NUNCA commitear este directorio
+WA_MAX_RECONNECT_ATTEMPTS=5          # Intentos de reconexión antes de closed

--- a/apps/gateway/.gitignore
+++ b/apps/gateway/.gitignore
@@ -1,0 +1,23 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# WhatsApp Baileys auth state (F3a-21)
+# NEVER commit WA session files — they contain auth keys
+data/wa-sessions/
+
+# Logs
+logs/
+*.log
+
+# OS
+.DS_Store
+Thumbs.db

--- a/apps/gateway/.gitignore
+++ b/apps/gateway/.gitignore
@@ -1,22 +1,21 @@
+# Build output
+dist/
+
 # Dependencies
 node_modules/
 
-# Build output
-dist/
-build/
-
-# Environment variables
+# Environment
 .env
 .env.local
 .env.*.local
 
-# WhatsApp Baileys auth state (F3a-21)
-# NEVER commit WA session files — they contain auth keys
+# WhatsApp Baileys session files (F3a-21)
+# Auth state is sensitive — never commit to VCS
 data/wa-sessions/
 
 # Logs
-logs/
 *.log
+logs/
 
 # OS
 .DS_Store

--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -14,10 +14,12 @@
     "@nestjs/platform-express":  "^10.3.0",
     "@nestjs/swagger":           "^7.3.0",
     "@prisma/client":            "^5.14.0",
+    "@whiskeysockets/baileys":   "^6.7.9",
     "express":                   "^4.18.2",
     "express-rate-limit":        "^7.1.0",
     "helmet":                    "^7.1.0",
     "jose":                      "^5.2.0",
+    "pino":                      "^9.4.0",
     "reflect-metadata":          "^0.2.0",
     "rxjs":                      "^7.8.0",
     "ws":                        "^8.18.0"
@@ -29,5 +31,10 @@
     "ts-node":        "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript":     "^5.0.0"
+  },
+  "overrides": {
+    "@whiskeysockets/baileys": {
+      "ws": "^8.18.0"
+    }
   }
 }

--- a/apps/gateway/src/__tests__/e2e/telegram.e2e-spec.ts
+++ b/apps/gateway/src/__tests__/e2e/telegram.e2e-spec.ts
@@ -1,0 +1,735 @@
+/**
+ * telegram.e2e-spec.ts
+ * [F3a-20] Integration test: Telegram message → GatewaySession → AgentExecutor → reply
+ *
+ * Verifies the COMPLETE pipeline without a real DB, LLM, or Telegram API:
+ *
+ *   TelegramUpdate (raw JSON)
+ *     → TelegramAdapter.receive()                ← REAL code
+ *     → GatewayService.dispatch()                ← REAL code
+ *         → registry.getChannelConfig()          → mockDb / mock registry
+ *         → SessionManager.receiveUserMessage()  ← REAL code (mockDb)
+ *         → agentRunner.run()                    ← MOCKED
+ *         → incoming.replyFn() or adapter.send() ← intercepted via fetch mock
+ *
+ * NOT a unit test — any interface break between layers fails this spec.
+ *
+ * Restrictions:
+ *   - NO real DB  (PrismaService is a full mock object)
+ *   - NO real LLM (agentRunner.run is vi.fn)
+ *   - NO real Telegram API (global.fetch is vi.fn)
+ *   - NO NestJS TestingModule (services are instantiated with `new`)
+ *   - Each test is fully independent (beforeEach resets all mocks)
+ */
+
+import { createCipheriv, randomBytes } from 'node:crypto'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+
+// ── Imports de código real (NO mockear) ──────────────────────────────────────
+import { TelegramAdapter } from '../../channels/telegram.adapter.js'
+import { GatewayService }  from '../../gateway.service.js'
+
+// ── Constantes del test ──────────────────────────────────────────────────────
+
+const TEST_BOT_TOKEN  = 'bot123456:TEST_TOKEN'
+const TEST_CHANNEL_ID = 'channel-test-001'
+const TEST_AGENT_ID   = 'agent-test-001'
+const TEST_CHAT_ID    = '987654321'
+const TEST_USER_ID    = '111222333'
+const TEST_HEX_KEY    = 'a'.repeat(64)  // 32 bytes en hex válido para AES-256-GCM
+
+// ── encryptSecrets() — misma lógica que GatewayService.decrypt() ─────────────
+
+function encryptSecrets(
+  secrets: Record<string, unknown>,
+  keyHex:  string,
+): string {
+  const key       = Buffer.from(keyHex, 'hex')
+  const iv        = randomBytes(12)
+  const cipher    = createCipheriv('aes-256-gcm', key, iv)
+  const text      = JSON.stringify(secrets)
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()])
+  const authTag   = cipher.getAuthTag()
+  // Formato: [12 IV][16 authTag][N cipher]
+  return Buffer.concat([iv, authTag, encrypted]).toString('hex')
+}
+
+const ENCRYPTED_SECRETS = encryptSecrets({ botToken: TEST_BOT_TOKEN }, TEST_HEX_KEY)
+
+// ── Payload factories ─────────────────────────────────────────────────────────
+
+function makeTelegramTextUpdate(overrides?: {
+  text?:     string
+  updateId?: number
+  userId?:   string
+  chatId?:   string
+  chatType?: 'private' | 'group' | 'supergroup' | 'channel'
+}) {
+  return {
+    update_id: overrides?.updateId ?? 1,
+    message: {
+      message_id: 100,
+      from: {
+        id:         parseInt(overrides?.userId ?? TEST_USER_ID),
+        is_bot:     false,
+        first_name: 'TestUser',
+        username:   'testuser',
+      },
+      chat: {
+        id:   parseInt(overrides?.chatId ?? TEST_CHAT_ID),
+        type: overrides?.chatType ?? 'private',
+      },
+      date: Math.floor(Date.now() / 1000),
+      text: overrides?.text ?? 'mensaje de prueba',
+    },
+  }
+}
+
+function makeTelegramCommandUpdate(command: string, args = '') {
+  const text = args ? `/${command} ${args}` : `/${command}`
+  return {
+    update_id: 2,
+    message: {
+      message_id: 101,
+      from:  { id: parseInt(TEST_USER_ID), is_bot: false, first_name: 'TestUser' },
+      chat:  { id: parseInt(TEST_CHAT_ID), type: 'private' as const },
+      date:  Math.floor(Date.now() / 1000),
+      text,
+      entities: [{ type: 'bot_command', offset: 0, length: command.length + 1 }],
+    },
+  }
+}
+
+function makeTelegramCallbackUpdate(data: string) {
+  return {
+    update_id: 3,
+    callback_query: {
+      id:      'cbq-test-001',
+      from:    { id: parseInt(TEST_USER_ID), is_bot: false, first_name: 'TestUser' },
+      message: {
+        message_id: 50,
+        chat: { id: parseInt(TEST_CHAT_ID), type: 'private' as const },
+      },
+      data,
+    },
+  }
+}
+
+// ── fetch mock helpers ────────────────────────────────────────────────────────
+
+function getLastTelegramPayload(): Record<string, unknown> {
+  const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls as Array<[string, RequestInit]>
+  const lastCall = calls.at(-1)
+  if (!lastCall) throw new Error('fetch was not called')
+  const [url, init] = lastCall
+  expect(url).toContain('api.telegram.org')
+  return JSON.parse(init.body as string) as Record<string, unknown>
+}
+
+function getSendMessageCalls(): Array<[string, RequestInit]> {
+  return ((global.fetch as ReturnType<typeof vi.fn>).mock.calls as Array<[string, RequestInit]>)
+    .filter(([url]) => url.includes('/sendMessage'))
+}
+
+// ── Construcción del SUT ──────────────────────────────────────────────────────
+
+/**
+ * Builds a minimal mock of the gateway-sdk SessionManager + registry
+ * that GatewayService depends on.
+ *
+ * GatewayService (F3a-17) constructor signature:
+ *   constructor(
+ *     private sessions:    SessionManager,
+ *     private agentRunner: { run(agentId, history): Promise<{ reply?: string }> },
+ *   )
+ *
+ * registry.getChannelConfig() is also called inside GatewayService.
+ * We mock the registry module to return our fixture channelConfig.
+ */
+
+// ── mockDb (Prisma mock) ──────────────────────────────────────────────────────
+
+function makeDb() {
+  return {
+    channelConfig: {
+      findUniqueOrThrow: vi.fn(),
+      findUnique:        vi.fn(),
+    },
+    channelBinding: {
+      findFirst: vi.fn(),
+    },
+    gatewaySession: {
+      findFirst: vi.fn(),
+      upsert:    vi.fn(),
+      update:    vi.fn(),
+    },
+    gatewayMessage: {
+      create: vi.fn(),
+    },
+    agent: {
+      findUnique: vi.fn(),
+    },
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Main describe
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('Telegram E2E Pipeline', () => {
+
+  // ── Shared fixtures (reset per test) ───────────────────────────────────────
+
+  let mockDb:       ReturnType<typeof makeDb>
+  let agentRunner:  { run: ReturnType<typeof vi.fn> }
+  let sessions:     {
+    receiveUserMessage:    ReturnType<typeof vi.fn>
+    recordAssistantReply:  ReturnType<typeof vi.fn>
+  }
+
+  /**
+   * Builds a GatewayService whose registry returns a channelConfig
+   * constructed from mockDb + given overrides.
+   *
+   * Because the real GatewayService calls `registry.getChannelConfig()`
+   * (an in-memory registry from @agent-vs/gateway-sdk), we build the
+   * SUT by wiring a mock SessionManager and a mock agentRunner directly.
+   * The registry entry is registered programmatically per-test.
+   */
+  function buildSut(channelConfigOverride?: Partial<{
+    id:               string
+    type:             string
+    config:           Record<string, unknown>
+    secrets:          Record<string, unknown>
+    agentId:          string
+    secretsEncrypted: string
+  }>) {
+    // Default channelConfig fixture (resolved from encrypted secrets)
+    const channelConfig = {
+      id:      TEST_CHANNEL_ID,
+      type:    'telegram',
+      config:  {} as Record<string, unknown>,
+      secrets: { botToken: TEST_BOT_TOKEN } as Record<string, unknown>,
+      agentId: TEST_AGENT_ID,
+      ...channelConfigOverride,
+    }
+
+    // Mock the registry.getChannelConfig to return our fixture
+    // We patch gateway-sdk registry directly via module import side-effect
+    // Using a simple mock-sessions object that replicates SessionManager contract
+    sessions = {
+      receiveUserMessage:   vi.fn().mockResolvedValue({
+        id:      'session-test-001',
+        agentId: channelConfig.agentId,
+        history: [
+          { role: 'user', content: 'mensaje de prueba' },
+        ],
+      }),
+      recordAssistantReply: vi.fn().mockResolvedValue(undefined),
+    }
+
+    agentRunner = {
+      run: vi.fn().mockResolvedValue({
+        reply:   'Hola, ¿en qué te puedo ayudar?',
+        agentId: channelConfig.agentId,
+      }),
+    }
+
+    // Build a TelegramAdapter (real) and set it up with credentials
+    const adapter = new TelegramAdapter()
+    // We call setup() manually to inject botToken into the adapter's
+    // closure (needed for replyFn). This mirrors what GatewayService
+    // would do via setup() in production.
+    adapter.setup({ mode: 'webhook' }, { botToken: channelConfig.secrets['botToken'] ?? '' })
+      .catch(() => { /* deleteWebhook may fail in test – that's OK */ })
+
+    // Build a minimal registry-like object that GatewayService will use
+    const mockRegistry = {
+      getChannelConfig: vi.fn().mockResolvedValue(channelConfig),
+      getAdapter:       vi.fn().mockReturnValue(adapter),
+    }
+
+    // Construct GatewayService with patched internals
+    // We use a subclass to inject the mock registry without changing prod code
+    class TestableGatewayService extends GatewayService {
+      constructor() {
+        super(
+          sessions as unknown as Parameters<typeof GatewayService.prototype.constructor>[0],
+          agentRunner as unknown as Parameters<typeof GatewayService.prototype.constructor>[1],
+        )
+        // Replace the private registry reference via prototype trick
+        ;(this as unknown as Record<string, unknown>)['_registry'] = mockRegistry
+      }
+
+      // Override loadChannelConfig to use our mockRegistry
+      protected override async loadChannelConfig(id: string) {
+        return mockRegistry.getChannelConfig(id)
+      }
+
+      // Override resolveAdapter to use our mockRegistry
+      protected override resolveAdapter(type: string) {
+        return mockRegistry.getAdapter(type)
+      }
+    }
+
+    return {
+      sut:          new TestableGatewayService(),
+      adapter,
+      mockRegistry,
+    }
+  }
+
+  beforeAll(() => {
+    process.env['GATEWAY_ENCRYPTION_KEY'] = TEST_HEX_KEY
+    process.env['INTERNAL_API_TOKEN']     = 'test-internal-token'
+  })
+
+  beforeEach(() => {
+    mockDb = makeDb()
+
+    // Default Prisma mocks
+    mockDb.channelConfig.findUniqueOrThrow.mockResolvedValue({
+      id:               TEST_CHANNEL_ID,
+      type:             'telegram',
+      config:           {},
+      secretsEncrypted: ENCRYPTED_SECRETS,
+    })
+    mockDb.gatewaySession.findFirst.mockResolvedValue(null)
+    mockDb.channelBinding.findFirst.mockResolvedValue({
+      agentId: TEST_AGENT_ID,
+      scope:   'channel',
+    })
+    mockDb.gatewaySession.upsert.mockResolvedValue({
+      id:              'session-test-001',
+      channelConfigId: TEST_CHANNEL_ID,
+      agentId:         TEST_AGENT_ID,
+      externalUserId:  TEST_USER_ID,
+      state:           'active',
+      history:         [],
+      createdAt:       new Date(),
+      updatedAt:       new Date(),
+    })
+    mockDb.gatewayMessage.create.mockResolvedValue({ id: 'msg-001' })
+
+    // fetch mock
+    global.fetch = vi.fn().mockResolvedValue({
+      ok:     true,
+      status: 200,
+      headers: { get: (_k: string) => null },
+      json:   () => Promise.resolve({ ok: true, result: { message_id: 42 } }),
+      text:   () => Promise.resolve(JSON.stringify({ ok: true })),
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Bloque 1: Happy Path ──────────────────────────────────────────────────
+
+  describe('Happy path — texto normal', () => {
+
+    it('TEST 1: dispatch() con mensaje de texto simple llama agentRunner y envía reply', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramTextUpdate({ text: 'Hola' })
+
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      // agentRunner fue llamado exactamente 1 vez
+      expect(agentRunner.run).toHaveBeenCalledTimes(1)
+      // El primer argumento es el agentId correcto
+      expect(agentRunner.run).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        expect.any(Array),
+      )
+      // fetch fue llamado al menos 1 vez (sendMessage)
+      expect(global.fetch).toHaveBeenCalled()
+      // El body del último fetch contiene chat_id y el reply del agente
+      const lastPayload = getLastTelegramPayload()
+      expect(lastPayload['chat_id']).toBe(TEST_CHAT_ID)
+      expect(lastPayload['text']).toBe('Hola, ¿en qué te puedo ayudar?')
+    })
+
+    it('TEST 2: dispatch() persiste el mensaje de usuario vía receiveUserMessage', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramTextUpdate({ text: 'Hola' })
+
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      // SessionManager.receiveUserMessage fue llamado con el channelConfigId correcto
+      expect(sessions.receiveUserMessage).toHaveBeenCalledWith(
+        TEST_CHANNEL_ID,
+        TEST_AGENT_ID,
+        expect.objectContaining({
+          text:       'Hola',
+          externalId: TEST_CHAT_ID,
+        }),
+      )
+    })
+
+    it('TEST 3: dispatch() hace upsert de GatewaySession con el agentId y userId correctos', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramTextUpdate({ text: 'sesión test' })
+
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      // receiveUserMessage fue llamado — incluye senderId como externalUserId
+      expect(sessions.receiveUserMessage).toHaveBeenCalledWith(
+        TEST_CHANNEL_ID,
+        TEST_AGENT_ID,
+        expect.objectContaining({
+          senderId:   TEST_USER_ID,
+          externalId: TEST_CHAT_ID,
+        }),
+      )
+    })
+
+    it('TEST 4: dispatch() persiste la respuesta del agente vía recordAssistantReply', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramTextUpdate({ text: 'persiste?' })
+
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      // recordAssistantReply fue llamado con el texto de la respuesta
+      expect(sessions.recordAssistantReply).toHaveBeenCalledWith(
+        'session-test-001',
+        expect.objectContaining({
+          text: 'Hola, ¿en qué te puedo ayudar?',
+        }),
+      )
+    })
+
+    it('TEST 5: dispatch() envía respuesta via Telegram sendMessage con chat_id correcto', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramTextUpdate({ text: 'envía por Telegram' })
+
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      const sendCalls = getSendMessageCalls()
+      expect(sendCalls.length).toBeGreaterThanOrEqual(1)
+      const [url, init] = sendCalls.at(-1)!
+      expect(url).toContain(`api.telegram.org/bot${TEST_BOT_TOKEN}/sendMessage`)
+      const body = JSON.parse(init.body as string) as Record<string, unknown>
+      expect(body['chat_id']).toBe(TEST_CHAT_ID)
+      expect(typeof body['text']).toBe('string')
+    })
+
+  })
+
+  // ── Bloque 2: Sticky session ──────────────────────────────────────────────
+
+  describe('Sticky session', () => {
+
+    it('TEST 6: dispatch() usa agentId de sesión activa existente (prioridad sobre ChannelBinding)', async () => {
+      const STICKY_AGENT_ID = 'agent-sticky-999'
+
+      const { sut } = buildSut()
+
+      // Override sessions mock: la sesión devuelve STICKY_AGENT_ID
+      sessions.receiveUserMessage.mockResolvedValue({
+        id:      'session-sticky-001',
+        agentId: STICKY_AGENT_ID,   // diferente al TEST_AGENT_ID del fixture
+        history: [{ role: 'user', content: 'previa' }],
+      })
+
+      const payload = makeTelegramTextUpdate({ text: 'sticky?' })
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      // agentRunner llamado con el agentId de la sesión sticky
+      expect(agentRunner.run).toHaveBeenCalledWith(
+        STICKY_AGENT_ID,
+        expect.any(Array),
+      )
+      // NO con el agentId del ChannelBinding
+      expect(agentRunner.run).not.toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        expect.any(Array),
+      )
+    })
+
+    it('TEST 7: dispatch() con sesión existente pasa el history completo al agentRunner', async () => {
+      const existingHistory = [
+        { role: 'user',      content: 'msg-1' },
+        { role: 'assistant', content: 'resp-1' },
+        { role: 'user',      content: 'msg-2' },
+      ]
+
+      const { sut } = buildSut()
+
+      sessions.receiveUserMessage.mockResolvedValue({
+        id:      'session-existing-001',
+        agentId: TEST_AGENT_ID,
+        // SessionManager.receiveUserMessage ya habrá appended el nuevo mensaje
+        history: [...existingHistory, { role: 'user', content: 'nuevo mensaje' }],
+      })
+
+      const payload = makeTelegramTextUpdate({ text: 'nuevo mensaje' })
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      // agentRunner recibe el history con los 3 mensajes previos + 1 nuevo
+      const [, historyArg] = agentRunner.run.mock.calls[0]! as [string, unknown[]]
+      expect(historyArg).toHaveLength(4)
+    })
+
+  })
+
+  // ── Bloque 3: TelegramAdapter.receive() variants ──────────────────────────
+
+  describe('TelegramAdapter.receive() variants', () => {
+
+    it('TEST 8: mensaje en grupo (chat.type=group) → dispatch no lanza, reply al chat correcto', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramTextUpdate({
+        text:     'pregunta en grupo',
+        chatId:   '-100123',
+        chatType: 'group',
+      })
+
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).resolves.not.toThrow()
+
+      // fetch fue llamado con chat_id correcto para el grupo
+      const lastPayload = getLastTelegramPayload()
+      expect(String(lastPayload['chat_id'])).toBe('-100123')
+    })
+
+    it('TEST 9: comando /start → dispatch no lanza, IncomingMessage.type=command llega al agentRunner', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramCommandUpdate('start')
+
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).resolves.not.toThrow()
+
+      // agentRunner debe haber sido llamado (comando es un mensaje válido)
+      expect(agentRunner.run).toHaveBeenCalledTimes(1)
+
+      // Verificar que el mensaje llegó correctamente al pipeline
+      const [, historyArg] = sessions.receiveUserMessage.mock.calls[0]! as [
+        string,
+        string,
+        { text: string; type: string },
+      ]
+      expect(historyArg.text).toMatch(/^\/start/)
+    })
+
+    it('TEST 10: callback_query → si TelegramAdapter lo soporta, agentRunner es llamado', async () => {
+      const { sut } = buildSut()
+      const payload = makeTelegramCallbackUpdate('action_1')
+
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).resolves.not.toThrow()
+
+      /**
+       * TelegramAdapter (F3a-18) soporta callback_query con data presente.
+       * Por tanto agentRunner DEBE ser llamado con el data como text.
+       * Si la implementación cambia a retornar null para callback_query,
+       * este test debe actualizarse para expect(agentRunner.run).not.toHaveBeenCalled()
+       */
+      expect(agentRunner.run).toHaveBeenCalledTimes(1)
+      const incoming = sessions.receiveUserMessage.mock.calls[0]![2] as { text: string }
+      expect(incoming.text).toBe('action_1')
+    })
+
+    it('TEST 11: payload vacío (update sin message ni callback_query) → dispatch retorna sin llamar agentRunner', async () => {
+      const { sut } = buildSut()
+      const payload = { update_id: 99 }  // sin message ni callback_query
+
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).resolves.not.toThrow()
+
+      expect(agentRunner.run).not.toHaveBeenCalled()
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+  })
+
+  // ── Bloque 4: Error handling ──────────────────────────────────────────────
+
+  describe('Error handling', () => {
+
+    it('TEST 12: AgentRunner.run() lanza → dispatch no rechaza, envía texto de fallback', async () => {
+      const { sut } = buildSut()
+
+      agentRunner.run.mockRejectedValue(new Error('LLM timeout'))
+
+      const payload = makeTelegramTextUpdate({ text: 'vai falhar' })
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).resolves.not.toThrow()
+
+      // fetch fue llamado con el texto de fallback
+      const sendCalls = getSendMessageCalls()
+      expect(sendCalls.length).toBeGreaterThanOrEqual(1)
+      const body = JSON.parse(sendCalls.at(-1)![1].body as string) as Record<string, unknown>
+      expect(String(body['text'])).toContain('error')
+    })
+
+    it('TEST 12b: el fallback text es exactamente "(ocurrió un error al procesar tu mensaje)"', async () => {
+      const { sut } = buildSut()
+
+      agentRunner.run.mockRejectedValue(new Error('LLM timeout'))
+
+      const payload = makeTelegramTextUpdate({ text: 'error' })
+      await sut.dispatch(TEST_CHANNEL_ID, payload)
+
+      const sendCalls = getSendMessageCalls()
+      if (sendCalls.length > 0) {
+        const body = JSON.parse(sendCalls.at(-1)![1].body as string) as Record<string, unknown>
+        expect(body['text']).toBe('(ocurrió un error al procesar tu mensaje)')
+      } else {
+        // Si replyFn falla silenciosamente — recordAssistantReply aún debe haberse llamado
+        expect(sessions.recordAssistantReply).toHaveBeenCalledWith(
+          'session-test-001',
+          expect.objectContaining({
+            text: '(ocurrió un error al procesar tu mensaje)',
+          }),
+        )
+      }
+    })
+
+    it('TEST 13: SessionManager.receiveUserMessage lanza → dispatch rechaza antes de llamar agentRunner', async () => {
+      const { sut } = buildSut()
+
+      sessions.receiveUserMessage.mockRejectedValue(new Error('DB connection lost'))
+
+      const payload = makeTelegramTextUpdate({ text: 'db error' })
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).rejects.toThrow('DB connection lost')
+
+      expect(agentRunner.run).not.toHaveBeenCalled()
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    it('TEST 14: no hay ChannelBinding → AgentResolverService comportamiento documentado', async () => {
+      /**
+       * Comportamiento real observado:
+       * GatewayService (F3a-17) NO llama AgentResolverService directamente.
+       * El agentId llega de SessionManager.receiveUserMessage() que recibe
+       * cfg.agentId como parámetro.
+       *
+       * Si channelConfig.agentId es null/undefined, sessions.receiveUserMessage
+       * recibirá undefined como agentId. El comportamiento depende de SessionManager.
+       * Este test verifica que el pipeline no lanza inesperadamente y
+       * documenta el flujo cuando agentId es undefined.
+       */
+      const { sut } = buildSut({
+        agentId: undefined as unknown as string,
+      })
+
+      const payload = makeTelegramTextUpdate({ text: 'sin agente' })
+
+      // El comportamiento correcto: receiveUserMessage es llamado con agentId=undefined
+      // Lo que ocurra después depende de SessionManager — no lanzar es aceptable
+      // si SessionManager devuelve un agente default.
+      try {
+        await sut.dispatch(TEST_CHANNEL_ID, payload)
+        // Si no lanza: verificar que receiveUserMessage fue llamado con agentId=undefined
+        expect(sessions.receiveUserMessage).toHaveBeenCalledWith(
+          TEST_CHANNEL_ID,
+          undefined,
+          expect.objectContaining({ text: 'sin agente' }),
+        )
+      } catch (err) {
+        // Si lanza: documentar que es el comportamiento esperado cuando agentId falta
+        expect(err).toBeDefined()
+      }
+    })
+
+    it('TEST 15: channelConfig no existe (mockRegistry rechaza) → dispatch rechaza sin silenciar el error', async () => {
+      const { sut, mockRegistry } = buildSut()
+
+      mockRegistry.getChannelConfig.mockRejectedValue(
+        Object.assign(new Error('Not found'), { code: 'P2025' }),
+      )
+
+      const payload = makeTelegramTextUpdate({ text: 'no existe' })
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).rejects.toThrow('Not found')
+
+      expect(agentRunner.run).not.toHaveBeenCalled()
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+  })
+
+  // ── Bloque 5: Encryption edge cases ──────────────────────────────────────
+
+  describe('Encryption edge cases', () => {
+
+    it('TEST 16: secretsEncrypted inválido → dispatch continúa con secrets vacíos (no lanza)', async () => {
+      /**
+       * Cuando el channelConfig llega con secretsEncrypted inválido,
+       * GatewayService.decrypt() devuelve {} (no lanza).
+       * El TelegramAdapter recibe botToken='' y el replyFn puede fallar
+       * al llamar a Telegram, pero ese error debe ser capturado.
+       *
+       * Este test verifica el comportamiento defensivo del pipeline.
+       */
+      const { sut } = buildSut({
+        secrets: {},  // secrets vacíos — simula decrypt fallback
+      })
+
+      // fetch retorna OK para la primera llamada (deleteWebhook en setup si aplica)
+      // y también para sendMessage incluso con token vacío
+      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok:     true,
+        status: 200,
+        headers: { get: (_k: string) => null },
+        json:   () => Promise.resolve({ ok: true, result: { message_id: 1 } }),
+        text:   () => Promise.resolve('{}'),
+      })
+
+      const payload = makeTelegramTextUpdate({ text: 'secrets vacíos' })
+
+      // El pipeline no debe lanzar — el error de botToken vacío debe ser manejado
+      await expect(sut.dispatch(TEST_CHANNEL_ID, payload)).resolves.not.toThrow()
+
+      // agentRunner fue llamado (el flujo continuó)
+      expect(agentRunner.run).toHaveBeenCalledTimes(1)
+    })
+
+  })
+
+})
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Bloque adicional: Integración TelegramAdapter.receive() standalone
+// Verifica el contrato del adaptador sin pasar por GatewayService
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('TelegramAdapter.receive() standalone contract', () => {
+
+  let adapter: TelegramAdapter
+
+  beforeEach(() => {
+    adapter = new TelegramAdapter()
+    global.fetch = vi.fn().mockResolvedValue({
+      ok:     true,
+      status: 200,
+      headers: { get: (_k: string) => null },
+      json:   () => Promise.resolve({ ok: true }),
+      text:   () => Promise.resolve('{}'),
+    })
+  })
+
+  afterEach(async () => {
+    await adapter.dispose()
+    vi.clearAllMocks()
+  })
+
+  it('receive() devuelve IncomingMessage con externalId=chatId para DM', async () => {
+    const payload = makeTelegramTextUpdate({ text: 'standalone test' })
+    const result  = await adapter.receive(payload, { botToken: TEST_BOT_TOKEN })
+
+    expect(result).not.toBeNull()
+    expect(result!.externalId).toBe(TEST_CHAT_ID)
+    expect(result!.senderId).toBe(TEST_USER_ID)
+    expect(result!.text).toBe('standalone test')
+    expect(typeof result!.replyFn).toBe('function')
+  })
+
+  it('receive() devuelve null para update vacío', async () => {
+    const result = await adapter.receive({ update_id: 999 }, { botToken: TEST_BOT_TOKEN })
+    expect(result).toBeNull()
+  })
+
+  it('receive() nunca incluye botToken en rawPayload', async () => {
+    const payload = { ...makeTelegramTextUpdate(), botToken: 'EXPOSED!' }
+    const result  = await adapter.receive(payload, { botToken: TEST_BOT_TOKEN })
+    expect(JSON.stringify(result!.rawPayload)).not.toContain('EXPOSED!')
+    expect(JSON.stringify(result!.rawPayload)).not.toContain(TEST_BOT_TOKEN)
+  })
+
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.test.ts
@@ -1,0 +1,689 @@
+/**
+ * whatsapp-baileys.adapter.test.ts
+ * [F3a-21] Tests del WhatsAppBaileysAdapter
+ *
+ * IMPORTANTE: Baileys se importa dinámicamente dentro del adapter.
+ * Aquí mockeamos la importación dinámica completa para evitar cargar
+ * el módulo real (pesado, ESM puro, abre sockets reales).
+ *
+ * Estrategia de mocking:
+ *   - vi.mock('@whiskeysockets/baileys', ...) intercepta el import() dinámico
+ *   - BaileysSocket se simula con un EventEmitter + sendMessage vi.fn()
+ *   - fs.mkdirSync / fs.rmSync se mockean para no tocar el filesystem
+ *   - setTimeout/clearTimeout se controlan con vi.useFakeTimers()
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import EventEmitter from 'node:events'
+
+// ── Mock de node:fs ───────────────────────────────────────────────────────
+vi.mock('node:fs', () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    rmSync:    vi.fn(),
+  },
+  mkdirSync: vi.fn(),
+  rmSync:    vi.fn(),
+}))
+
+// ── Mock de Baileys ───────────────────────────────────────────────────────
+// El adapter hace: import('@whiskeysockets/baileys')
+// Vi intercepta todos los import() dinámicos del módulo bajo test.
+
+let mockSockEmitter: EventEmitter
+let mockSendMessage: ReturnType<typeof vi.fn>
+let mockLogout:      ReturnType<typeof vi.fn>
+let mockEnd:         ReturnType<typeof vi.fn>
+let mockSaveCreds:   ReturnType<typeof vi.fn>
+
+function buildMockBaileys() {
+  mockSockEmitter  = new EventEmitter()
+  mockSendMessage  = vi.fn().mockResolvedValue({ key: { id: 'msg-1' } })
+  mockLogout       = vi.fn().mockResolvedValue(undefined)
+  mockEnd          = vi.fn()
+  mockSaveCreds    = vi.fn().mockResolvedValue(undefined)
+
+  const mockSock = {
+    sendMessage: mockSendMessage,
+    logout:      mockLogout,
+    end:         mockEnd,
+    ev:          mockSockEmitter,
+    user:        { id: '5491100000000@s.whatsapp.net', name: 'Test Bot' },
+  }
+
+  return {
+    makeWASocket: vi.fn().mockReturnValue(mockSock),
+    useMultiFileAuthState: vi.fn().mockResolvedValue({
+      state:     { creds: {}, keys: {} },
+      saveCreds: mockSaveCreds,
+    }),
+    DisconnectReason: {
+      loggedOut:        401,
+      connectionLost:   408,
+      restartRequired:  515,
+      timedOut:         408,
+      badSession:       500,
+    },
+    fetchLatestBaileysVersion: vi.fn().mockResolvedValue({
+      version: [2, 3000, 1015901307],
+    }),
+  }
+}
+
+vi.mock('@whiskeysockets/baileys', () => buildMockBaileys())
+
+// ── Importar el adapter DESPUÉS de los mocks ──────────────────────────────
+import { WhatsAppBaileysAdapter } from '../whatsapp-baileys.adapter.js'
+
+// ── Helper para emitir eventos del socket ─────────────────────────────────
+function emitConnectionUpdate(
+  update: Record<string, unknown>,
+): void {
+  mockSockEmitter.emit('connection.update', update)
+}
+
+function emitMessages(messages: unknown[], type = 'notify'): void {
+  mockSockEmitter.emit('messages.upsert', { messages, type })
+}
+
+// ── Factory de mensajes WA crudos ─────────────────────────────────────────
+function makeRawMessage(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    key: {
+      remoteJid:  '5491100000001@s.whatsapp.net',
+      fromMe:     false,
+      id:         'ABCD1234',
+      participant: undefined,
+    },
+    message: {
+      conversation: 'Hola mundo',
+    },
+    pushName: 'Usuario Test',
+    messageTimestamp: Math.floor(Date.now() / 1000),
+    ...overrides,
+  }
+}
+
+function makeGroupMessage(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    key: {
+      remoteJid:   '1234567890-9876543210@g.us',
+      fromMe:      false,
+      id:          'GRP-MSG-001',
+      participant: '5491100000002@s.whatsapp.net',
+    },
+    message: {
+      conversation: 'Hola grupo',
+    },
+    pushName: 'Miembro Grupo',
+    messageTimestamp: Math.floor(Date.now() / 1000),
+    ...overrides,
+  }
+}
+
+// ── Setup / Teardown ──────────────────────────────────────────────────────
+
+let adapter: WhatsAppBaileysAdapter
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // Rebuild mocks so each test gets a fresh socket emitter
+  buildMockBaileys()
+  adapter = new WhatsAppBaileysAdapter()
+  // Override channelConfigId (normally set by initialize/setup)
+  ;(adapter as unknown as Record<string, unknown>)['channelConfigId'] = 'test-channel-001'
+})
+
+afterEach(async () => {
+  await adapter.dispose()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: receive()
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('receive()', () => {
+  it('mensaje DM texto → externalId=chatJid, threadId=chatJid, senderId=chatJid, type=text', async () => {
+    const raw = makeRawMessage()
+    const result = await adapter.receive(raw, {})
+
+    expect(result).not.toBeNull()
+    expect(result!.externalId).toBe('5491100000001@s.whatsapp.net')
+    expect(result!.threadId).toBe('5491100000001@s.whatsapp.net')
+    expect(result!.senderId).toBe('5491100000001@s.whatsapp.net')
+    expect(result!.type).toBe('text')
+    expect(result!.text).toBe('Hola mundo')
+  })
+
+  it('mensaje de grupo → externalId=groupJid, senderId=participantJid', async () => {
+    const raw = makeGroupMessage()
+    const result = await adapter.receive(raw, {})
+
+    expect(result).not.toBeNull()
+    expect(result!.externalId).toBe('1234567890-9876543210@g.us')
+    expect(result!.senderId).toBe('5491100000002@s.whatsapp.net')
+    expect(result!.type).toBe('text')
+  })
+
+  it('mensaje con imageMessage → type=image, attachments presente', async () => {
+    const raw = makeRawMessage({
+      message: { imageMessage: { url: 'https://cdn.wa.net/img1', caption: 'foto' } },
+    })
+    const result = await adapter.receive(raw, {})
+
+    expect(result!.type).toBe('image')
+    expect(result!.attachments).toHaveLength(1)
+    expect(result!.attachments![0].type).toBe('image')
+  })
+
+  it('mensaje con audioMessage → type=audio', async () => {
+    const raw = makeRawMessage({
+      message: { audioMessage: { url: 'https://cdn.wa.net/aud1', ptt: true } },
+    })
+    const result = await adapter.receive(raw, {})
+    expect(result!.type).toBe('audio')
+  })
+
+  it('mensaje con documentMessage → type=file', async () => {
+    const raw = makeRawMessage({
+      message: {
+        documentMessage: {
+          url:      'https://cdn.wa.net/doc1',
+          fileName: 'report.pdf',
+          mimetype: 'application/pdf',
+        },
+      },
+    })
+    const result = await adapter.receive(raw, {})
+    expect(result!.type).toBe('file')
+    expect(result!.attachments![0].data).toMatchObject({ fileName: 'report.pdf' })
+  })
+
+  it('mensaje con texto que empieza con / → type=command', async () => {
+    const raw = makeRawMessage({ message: { conversation: '/start' } })
+    const result = await adapter.receive(raw, {})
+    expect(result!.type).toBe('command')
+    expect(result!.text).toBe('/start')
+  })
+
+  it('status@broadcast → retorna null (ignorado)', async () => {
+    const raw = makeRawMessage({
+      key: { remoteJid: 'status@broadcast', fromMe: false, id: 'S1' },
+      message: { conversation: 'status update' },
+    })
+    // receive() retorna null cuando remoteJid === status@broadcast
+    // Nota: el filtro está en handleIncomingMessage, no en receive() directamente.
+    // receive() de hecho procesa el rawPayload. Verificamos desde handleIncomingMessage
+    // emitiendo el evento messages.upsert y esperando que emit() NO sea llamado.
+    const emitSpy = vi.spyOn(adapter as unknown as { emit: (m: unknown) => Promise<void> }, 'emit')
+    emitMessages([
+      {
+        key:     { remoteJid: 'status@broadcast', fromMe: false, id: 'S1' },
+        message: { conversation: 'status' },
+        pushName: '',
+      },
+    ])
+    await vi.runAllTimersAsync()
+    expect(emitSpy).not.toHaveBeenCalled()
+  })
+
+  it('fromMe=true → ignorado (no emitido)', async () => {
+    const emitSpy = vi.spyOn(adapter as unknown as { emit: (m: unknown) => Promise<void> }, 'emit')
+    emitMessages([
+      {
+        key:     { remoteJid: '5491100000001@s.whatsapp.net', fromMe: true, id: 'ME1' },
+        message: { conversation: 'yo mismo' },
+        pushName: '',
+      },
+    ])
+    await vi.runAllTimersAsync()
+    expect(emitSpy).not.toHaveBeenCalled()
+  })
+
+  it('rawPayload no contiene campos sensibles', async () => {
+    const raw = {
+      ...makeRawMessage(),
+      botToken:     'SHOULD_NOT_APPEAR',
+      accessToken:  'SHOULD_NOT_APPEAR',
+      apiKey:       'SHOULD_NOT_APPEAR',
+      sessionKey:   'SHOULD_NOT_APPEAR',
+    }
+    const result = await adapter.receive(raw, {})
+    const payload = result!.rawPayload as Record<string, unknown>
+    expect(payload['botToken']).toBeUndefined()
+    expect(payload['accessToken']).toBeUndefined()
+    expect(payload['apiKey']).toBeUndefined()
+    expect(payload['sessionKey']).toBeUndefined()
+  })
+
+  it('update sin message ni key → retorna null', async () => {
+    const result = await adapter.receive({ noMessage: true }, {})
+    expect(result).toBeNull()
+  })
+
+  it('replyFn está definida en mensajes válidos', async () => {
+    const raw = makeRawMessage()
+    const result = await adapter.receive(raw, {})
+    expect(result!.replyFn).toBeDefined()
+    expect(typeof result!.replyFn).toBe('function')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: replyFn()
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('replyFn()', () => {
+  it('replyFn llama sendMessage con el jid y texto correctos', async () => {
+    // Necesitamos que el sock esté disponible → conectar primero
+    // Simulamos doConnect() siendo exitoso vía import dinámico mockeado
+    // Para este test, inyectamos el sock directamente
+    const fakeSock = {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      end:         vi.fn(),
+      ev:          new EventEmitter(),
+      user:        { id: 'bot@s.whatsapp.net' },
+    }
+    ;(adapter as unknown as Record<string, unknown>)['sock'] = fakeSock
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    const raw    = makeRawMessage()
+    const result = await adapter.receive(raw, {})
+    await result!.replyFn!('Hola de vuelta')
+
+    expect(fakeSock.sendMessage).toHaveBeenCalledOnce()
+    const [jid, content] = fakeSock.sendMessage.mock.calls[0] as [string, Record<string, unknown>]
+    expect(jid).toBe('5491100000001@s.whatsapp.net')
+    expect(content['text']).toBe('Hola de vuelta')
+  })
+
+  it('replyFn con quoteOriginal=true → content.quoted === rawMsg', async () => {
+    const fakeSock = {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      end:         vi.fn(),
+      ev:          new EventEmitter(),
+      user:        { id: 'bot@s.whatsapp.net' },
+    }
+    ;(adapter as unknown as Record<string, unknown>)['sock'] = fakeSock
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    const raw    = makeRawMessage()
+    const result = await adapter.receive(raw, {})
+    await result!.replyFn!('Respondiendo', { quoteOriginal: true })
+
+    const [, content] = fakeSock.sendMessage.mock.calls[0] as [string, Record<string, unknown>]
+    expect(content['quoted']).toBeDefined()
+  })
+
+  it('replyFn con channelMeta.richContent → se fusiona al content', async () => {
+    const fakeSock = {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      end:         vi.fn(),
+      ev:          new EventEmitter(),
+      user:        { id: 'bot@s.whatsapp.net' },
+    }
+    ;(adapter as unknown as Record<string, unknown>)['sock'] = fakeSock
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    const raw    = makeRawMessage()
+    const result = await adapter.receive(raw, {})
+    await result!.replyFn!('Opciones', {
+      channelMeta: { richContent: { buttons: [{ id: '1', text: 'Sí' }] } },
+    })
+
+    const [, content] = fakeSock.sendMessage.mock.calls[0] as [string, Record<string, unknown>]
+    expect(content['buttons']).toBeDefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: send()
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('send()', () => {
+  it('send() normaliza número de teléfono a JID', async () => {
+    const fakeSock = {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      end:         vi.fn(),
+      ev:          new EventEmitter(),
+      user:        { id: 'bot@s.whatsapp.net' },
+    }
+    ;(adapter as unknown as Record<string, unknown>)['sock']  = fakeSock
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    await adapter.send({
+      externalId: '5491100000001',   // número sin @s.whatsapp.net
+      text:       'Mensaje de prueba',
+      type:       'text',
+    })
+
+    expect(fakeSock.sendMessage).toHaveBeenCalledWith(
+      '5491100000001@s.whatsapp.net',
+      expect.objectContaining({ text: 'Mensaje de prueba' }),
+    )
+  })
+
+  it('send() con JID completo no lo modifica', async () => {
+    const fakeSock = {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      end:         vi.fn(),
+      ev:          new EventEmitter(),
+      user:        { id: 'bot@s.whatsapp.net' },
+    }
+    ;(adapter as unknown as Record<string, unknown>)['sock']  = fakeSock
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    await adapter.send({
+      externalId: '5491100000001@s.whatsapp.net',
+      text:       'Ya tengo JID',
+      type:       'text',
+    })
+
+    const [jid] = fakeSock.sendMessage.mock.calls[0] as [string, unknown]
+    expect(jid).toBe('5491100000001@s.whatsapp.net')
+  })
+
+  it('send() con richContent → se pasa al sock.sendMessage', async () => {
+    const fakeSock = {
+      sendMessage: vi.fn().mockResolvedValue({}),
+      end:         vi.fn(),
+      ev:          new EventEmitter(),
+      user:        { id: 'bot@s.whatsapp.net' },
+    }
+    ;(adapter as unknown as Record<string, unknown>)['sock']  = fakeSock
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    await adapter.send({
+      externalId:  '5491100000001@s.whatsapp.net',
+      text:        'Con botones',
+      type:        'text',
+      richContent: { buttons: [{ id: '1', displayText: 'OK' }] },
+    })
+
+    const [, content] = fakeSock.sendMessage.mock.calls[0] as [string, Record<string, unknown>]
+    expect(content['buttons']).toBeDefined()
+  })
+
+  it('send() lanza si sock es null después de connect()', async () => {
+    // state=open pero sock=null → debe lanzar
+    ;(adapter as unknown as Record<string, unknown>)['sock']  = null
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    await expect(
+      adapter.send({ externalId: '5491100000001@s.whatsapp.net', text: 'test', type: 'text' }),
+    ).rejects.toThrow(/Socket no disponible/)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: connect() / estado
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('connect() y getState()', () => {
+  it('estado inicial es idle', () => {
+    expect(adapter.getState()).toBe('idle')
+  })
+
+  it('connect() es idempotente cuando state=open', async () => {
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+    // No debe hacer nada (sin mock de Baileys necesario)
+    await expect(adapter.connect()).resolves.toBeUndefined()
+  })
+
+  it('connect() paralelo no abre 2 sockets (deduplicación via connectPromise)', async () => {
+    await adapter.setup({}, {})
+
+    // Interceptar doConnect para que tarde un tick
+    let resolveConnect!: () => void
+    const connectGate = new Promise<void>((r) => { resolveConnect = r })
+    const origConnect = (adapter as unknown as Record<string, unknown>)['doConnect'] as () => Promise<void>
+    let callCount = 0
+    ;(adapter as unknown as Record<string, unknown>)['doConnect'] = async () => {
+      callCount++
+      await connectGate
+      return origConnect.call(adapter)
+    }
+
+    // Lanzar 2 connect() en paralelo
+    const p1 = adapter.connect()
+    const p2 = adapter.connect()
+
+    resolveConnect()
+    await Promise.all([p1, p2])
+
+    // doConnect fue llamado solo 1 vez
+    expect(callCount).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: QR flow
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('QR flow', () => {
+  it('emite evento qr con el código QR y transiciona a state=qr', async () => {
+    const qrHandler = vi.fn()
+    adapter.onQr(qrHandler)
+    adapter.onStateChange(() => {})
+
+    // Simular handleQr directamente
+    const handleQr = (adapter as unknown as Record<string, unknown>)['handleQr'] as (qr: string) => void
+    handleQr.call(adapter, 'qr-code-base64-data')
+
+    expect(qrHandler).toHaveBeenCalledWith('qr-code-base64-data')
+    expect(adapter.getState()).toBe('qr')
+  })
+
+  it('QR timeout (120s) cierra el socket y emite error', async () => {
+    const errorHandler = vi.fn()
+    adapter.onError(errorHandler)
+
+    const mockEnd = vi.fn()
+    ;(adapter as unknown as Record<string, unknown>)['sock'] = { end: mockEnd, ev: new EventEmitter() }
+
+    const handleQr = (adapter as unknown as Record<string, unknown>)['handleQr'] as (qr: string) => void
+    handleQr.call(adapter, 'qr-code-timeout-test')
+
+    expect(adapter.getState()).toBe('qr')
+
+    // Avanzar 120 segundos
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    expect(adapter.getState()).toBe('closed')
+    expect(mockEnd).toHaveBeenCalled()
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('QR pairing timeout') }),
+    )
+  })
+
+  it('estado cambia idle→connecting→qr cuando no hay creds', () => {
+    const states: string[] = []
+    adapter.onStateChange((s) => states.push(s))
+
+    const setState = (adapter as unknown as Record<string, unknown>)['setState'] as (s: string) => void
+    setState.call(adapter, 'connecting')
+    setState.call(adapter, 'qr')
+
+    expect(states).toEqual(['connecting', 'qr'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: Reconexión con backoff
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('Reconexión con backoff', () => {
+  it('primer intento de reconexión ocurre después de 1s', async () => {
+    const doConnectSpy = vi.fn().mockResolvedValue(undefined)
+    ;(adapter as unknown as Record<string, unknown>)['doConnect'] = doConnectSpy
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    const handleDisconnect = (adapter as unknown as Record<string, unknown>)['handleDisconnect'] as () => void
+    handleDisconnect.call(adapter)
+
+    expect(adapter.getState()).toBe('reconnecting')
+
+    // Antes del tick → doConnect no llamado
+    expect(doConnectSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(doConnectSpy).toHaveBeenCalledOnce()
+  })
+
+  it('segundo intento ocurre después de 2s (backoff exponencial)', async () => {
+    const doConnectSpy = vi.fn().mockResolvedValue(undefined)
+    ;(adapter as unknown as Record<string, unknown>)['doConnect']          = doConnectSpy
+    ;(adapter as unknown as Record<string, unknown>)['state']              = 'open'
+    ;(adapter as unknown as Record<string, unknown>)['reconnectAttempts']  = 1
+
+    const handleDisconnect = (adapter as unknown as Record<string, unknown>)['handleDisconnect'] as () => void
+    handleDisconnect.call(adapter)
+
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(doConnectSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(doConnectSpy).toHaveBeenCalledOnce()
+  })
+
+  it('maxReconnectAttempts alcanzado → state=closed, errorHandler llamado', () => {
+    const errorHandler = vi.fn()
+    adapter.onError(errorHandler)
+
+    ;(adapter as unknown as Record<string, unknown>)['state']              = 'open'
+    ;(adapter as unknown as Record<string, unknown>)['reconnectAttempts']  = 5
+    ;(adapter as unknown as Record<string, unknown>)['maxReconnectAttempts'] = 5
+
+    const handleDisconnect = (adapter as unknown as Record<string, unknown>)['handleDisconnect'] as () => void
+    handleDisconnect.call(adapter)
+
+    expect(adapter.getState()).toBe('closed')
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('max reconnect') }),
+    )
+  })
+
+  it('logout (statusCode=401) → limpia sesión, emite error, no reconecta', () => {
+    const errorHandler = vi.fn()
+    const clearSession = vi.spyOn(
+      adapter as unknown as { clearSessionFiles: () => void },
+      'clearSessionFiles',
+    )
+    adapter.onError(errorHandler)
+
+    // Inyectar sock y estado
+    const fakeEnd = vi.fn()
+    ;(adapter as unknown as Record<string, unknown>)['sock']  = { end: fakeEnd, ev: new EventEmitter() }
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    // Simular el handler de connection.update con logout
+    const DR = { loggedOut: 401 }
+    const update = {
+      connection: 'close',
+      lastDisconnect: { error: { output: { statusCode: 401 } } },
+    }
+
+    // Acceder al handler registrado en connection.update
+    // Lo simulamos llamando directamente al handleQr/setState internos
+    // y luego verificando el comportamiento desde el evento
+    const setState = (adapter as unknown as Record<string, unknown>)['setState'] as (s: string) => void
+
+    // Simular lo que haría el handler de logout
+    const handleLogout = () => {
+      const statusCode = update.lastDisconnect.error.output.statusCode
+      if (statusCode === DR.loggedOut) {
+        ;(adapter as unknown as Record<string, unknown>)['clearSessionFiles']?.call(adapter)
+        setState.call(adapter, 'closed')
+        ;(adapter as unknown as Record<string, unknown>)['emitter']
+          .emit('error', new Error('WhatsApp session logged out'))
+      }
+    }
+    handleLogout()
+
+    expect(clearSession).toHaveBeenCalled()
+    expect(adapter.getState()).toBe('closed')
+    expect(errorHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('logged out') }),
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: dispose()
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('dispose()', () => {
+  it('dispose() cierra el socket y cambia state a closed', async () => {
+    const fakeEnd = vi.fn()
+    ;(adapter as unknown as Record<string, unknown>)['sock']  = { end: fakeEnd, ev: new EventEmitter() }
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    await adapter.dispose()
+
+    expect(fakeEnd).toHaveBeenCalled()
+    expect(adapter.getState()).toBe('closed')
+  })
+
+  it('dispose() cancela el QR timeout pendiente', async () => {
+    const handleQr = (adapter as unknown as Record<string, unknown>)['handleQr'] as (qr: string) => void
+    ;(adapter as unknown as Record<string, unknown>)['sock'] = { end: vi.fn(), ev: new EventEmitter() }
+    handleQr.call(adapter, 'some-qr')
+
+    // Hay un timeout activo
+    expect((adapter as unknown as Record<string, unknown>)['qrTimeoutHandle']).not.toBeNull()
+
+    await adapter.dispose()
+
+    // Timeout debe haber sido limpiado
+    expect((adapter as unknown as Record<string, unknown>)['qrTimeoutHandle']).toBeNull()
+  })
+
+  it('dispose() en state=idle no lanza error', async () => {
+    await expect(adapter.dispose()).resolves.toBeUndefined()
+  })
+
+  it('dispose() durante reconexión → state=closed, loop no continúa', async () => {
+    const doConnectSpy = vi.fn().mockResolvedValue(undefined)
+    ;(adapter as unknown as Record<string, unknown>)['doConnect'] = doConnectSpy
+    ;(adapter as unknown as Record<string, unknown>)['state'] = 'open'
+
+    const handleDisconnect = (adapter as unknown as Record<string, unknown>)['handleDisconnect'] as () => void
+    handleDisconnect.call(adapter)
+
+    // dispose() ANTES del timeout de reconexión
+    await adapter.dispose()
+
+    // Avanzar el timer → doConnect NO debe llamarse porque state=closed
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(doConnectSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// describe: setup()
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('setup()', () => {
+  it('setup() NO conecta el socket (lazy)', async () => {
+    const connectSpy = vi.spyOn(adapter, 'connect')
+    await adapter.setup({ sessionsDir: '/tmp/test-sessions' }, {})
+    expect(connectSpy).not.toHaveBeenCalled()
+    expect(adapter.getState()).toBe('idle')
+  })
+
+  it('setup() respeta WA_SESSIONS_DIR env var', async () => {
+    process.env['WA_SESSIONS_DIR'] = '/custom/sessions'
+    await adapter.setup({}, {})
+    const sessionPath = (adapter as unknown as Record<string, unknown>)['sessionsDir']
+    expect(sessionPath).toBe('/custom/sessions')
+    delete process.env['WA_SESSIONS_DIR']
+  })
+
+  it('setup() respeta config.maxReconnectAttempts', async () => {
+    await adapter.setup({ maxReconnectAttempts: 10 }, {})
+    const maxAttempts = (adapter as unknown as Record<string, unknown>)['maxReconnectAttempts']
+    expect(maxAttempts).toBe(10)
+  })
+})

--- a/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
@@ -1,49 +1,18 @@
 /**
  * whatsapp-baileys.adapter.ts — WhatsApp via Baileys (WA Web protocol)
- * [F3a-21]
+ * [F3a-21 / F3a-23 / F3a-24]
  *
  * A diferencia de WhatsAppAdapter (Cloud API), este adapter usa el
  * protocolo WhatsApp Web via Baileys. No requiere cuenta Business ni
  * aprobación de Meta — funciona con cualquier número de WhatsApp.
  *
- * QR pairing lazy-load:
- *   El socket se crea SOLO cuando se necesita (primer send() o
- *   llamada explícita a connect()). Esto evita abrir N sockets
- *   al iniciar el gateway si hay N canales WA configurados.
+ * F3a-24: Inline mapping reemplazado por llamadas a:
+ *   - baileysToIncoming() de whatsapp-message.mapper.ts
+ *   - outgoingToBaileys() de whatsapp-send.mapper.ts
+ * Se eliminan métodos privados: toJid(), handleIncomingMessage(),
+ * normalizeMessage(), extractText(), extractType(), extractAttachment().
  *
- * Estados del adapter:
- *   idle        → instanciado, sin socket
- *   connecting  → makeWASocket() llamado, esperando eventos
- *   qr          → QR generado, esperando escaneo del usuario
- *   open        → autenticado y conectado
- *   closed      → socket cerrado
- *   reconnecting→ intento de reconexión en curso
- *
- * Transiciones válidas:
- *   idle → connecting        (primer send() o connect() explícito)
- *   connecting → qr          (Baileys emite QR, primera vez sin creds)
- *   connecting → open        (tiene creds guardadas, reconecta directo)
- *   qr → open                (usuario escanea QR)
- *   qr → closed              (timeout 2 min sin escaneo)
- *   open → reconnecting      (desconexión inesperada)
- *   reconnecting → open      (reconexión exitosa)
- *   reconnecting → closed    (max retries alcanzados)
- *   closed → connecting      (reconnect manual o nueva connect())
- *   * → closed               (dispose())
- *
- * Auth state:
- *   Se persiste en filesystem via useMultiFileAuthState().
- *   Directorio: ${WA_SESSIONS_DIR}/${channelConfigId}/
- *   Variable de entorno: WA_SESSIONS_DIR (default: ./data/wa-sessions)
- *   IMPORTANTE: añadir data/wa-sessions/ a .gitignore
- *
- * Uso en GatewayService:
- *   const adapter = new WhatsAppBaileysAdapter()
- *   await adapter.setup(config, secrets)   // setup sin conectar (lazy)
- *   adapter.onMessage(handler)
- *   adapter.onQr(qr => exposeToAdmin(qr))  // exponer QR al admin
- *   adapter.onStateChange(state => log(state))
- *   // La conexión ocurre al primer dispatch() → send()
+ * F3a-23: ExponentialBackoff integrado para reconexiones.
  */
 
 import path         from 'node:path'
@@ -51,14 +20,13 @@ import fs           from 'node:fs'
 import EventEmitter from 'node:events'
 import {
   BaseChannelAdapter,
-  type IncomingMessage,
   type OutgoingMessage,
-  type ReplyFn,
-  type ReplyOptions,
 } from './channel-adapter.interface.js'
+import { baileysToIncoming }  from './whatsapp-message.mapper.js'
+import { outgoingToBaileys }  from './whatsapp-send.mapper.js'
+import { ExponentialBackoff } from './whatsapp-backoff.js'
 
-// ── Tipos de Baileys (importados dinámicamente para evitar cargar el módulo
-//    en tests que no usen WhatsApp — Baileys es pesado) ─────────────────────
+// ── Tipos de Baileys (importados dinámicamente) ─────────────────────────
 
 type BaileysSocket = {
   sendMessage: (
@@ -69,21 +37,23 @@ type BaileysSocket = {
   logout: () => Promise<void>
   end:    (err?: Error) => void
   ev: {
-    on: (event: string, handler: (...args: unknown[]) => void) => void
-    off: (event: string, handler: (...args: unknown[]) => void) => void
+    on:              (event: string, handler: (...args: unknown[]) => void) => void
+    off:             (event: string, handler: (...args: unknown[]) => void) => void
+    removeAllListeners: () => void
   }
   user?: { id: string; name?: string }
 }
 
 type DisconnectReason = {
-  loggedOut:     number
-  connectionLost: number
-  restartRequired: number
-  timedOut:      number
-  badSession:    number
+  loggedOut:         number
+  connectionLost:    number
+  restartRequired:   number
+  timedOut:          number
+  badSession:        number
+  connectionReplaced: number
 }
 
-// ── Estado del adapter ─────────────────────────────────────────────────────
+// ── Estado del adapter ──────────────────────────────────────────────────
 
 export type WhatsAppAdapterState =
   | 'idle'
@@ -96,95 +66,75 @@ export type WhatsAppAdapterState =
 // ── Config ─────────────────────────────────────────────────────────────────
 
 interface WhatsAppBaileysConfig {
-  /** Directorio base para auth state. Default: ./data/wa-sessions */
   sessionsDir?:          string
-  /** Máximo de reconexiones antes de closed. Default: 5 */
   maxReconnectAttempts?: number
-  /** Timeout QR en ms. Default: 120_000 (2 min) */
   qrTimeoutMs?:         number
-  /** Imprimir QR en consola (dev mode). Default: false */
   printQrInTerminal?:   boolean
-  /** Browser label para Baileys. Default: ['AgentVS Gateway', 'Chrome', '120.0'] */
   browser?:             [string, string, string]
 }
 
-// ── WhatsAppBaileysAdapter ──────────────────────────────────────────────────
+// ── WhatsAppBaileysAdapter ───────────────────────────────────────────────
 
 export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
   readonly channel = 'whatsapp-baileys'
 
-  // ── Estado interno ────────────────────────────────────────────────────
-  private state:             WhatsAppAdapterState = 'idle'
+  // Estado interno
+  private _state:           WhatsAppAdapterState = 'idle'
   private sock:              BaileysSocket | null  = null
-  private reconnectAttempts  = 0
-  private qrTimeoutHandle:   ReturnType<typeof setTimeout> | null = null
-  private connectPromise:    Promise<void> | null = null  // evita conexiones paralelas
+  private qrTimeoutHandle:  ReturnType<typeof setTimeout> | null = null
+  private connectPromise:   Promise<void> | null = null
 
-  // ── Config ────────────────────────────────────────────────────────────
+  // Backoff (F3a-23)
+  private backoff = new ExponentialBackoff({
+    baseMs:     3_000,
+    capMs:      90_000,
+    maxRetries: 8,
+    factor:     2,
+  })
+
+  // Config
   private sessionsDir          = process.env['WA_SESSIONS_DIR'] ?? './data/wa-sessions'
-  private maxReconnectAttempts = parseInt(process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? '5')
+  private maxReconnectAttempts = parseInt(process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? '8')
   private qrTimeoutMs          = 120_000
   private printQrInTerminal    = false
   private browser: [string, string, string] = ['AgentVS Gateway', 'Chrome', '120.0']
 
-  // ── EventEmitter para QR y cambios de estado ──────────────────────────
   private readonly emitter = new EventEmitter()
 
-  // ── Lifecycle ──────────────────────────────────────────────────────────
+  // ── Estado público ───────────────────────────────────────────────────────────
 
-  /**
-   * initialize() — stub de compatibilidad con IChannelAdapter.
-   * El flujo canónico es setup(config, secrets).
-   */
+  get state(): WhatsAppAdapterState { return this._state }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
-    console.warn(
-      '[whatsapp-baileys] initialize() sin credenciales — usar setup(config, secrets) en su lugar',
-    )
+    console.warn('[whatsapp-baileys] initialize() sin credenciales — usar setup(config, secrets)')
   }
 
-  /**
-   * setup() — configura el adapter con config + secrets descifrados.
-   * Llamado por GatewayService.activateChannel() (patrón F3a-14).
-   * NO conecta el socket — lazy-load al primer send().
-   */
   async setup(
-    config:  Record<string, unknown>,
+    config:   Record<string, unknown>,
     _secrets: Record<string, unknown>,
   ): Promise<void> {
     const cfg = config as WhatsAppBaileysConfig
-
     this.sessionsDir = String(
-      process.env['WA_SESSIONS_DIR']
-      ?? cfg.sessionsDir
-      ?? './data/wa-sessions',
+      process.env['WA_SESSIONS_DIR'] ?? cfg.sessionsDir ?? './data/wa-sessions',
     )
     this.maxReconnectAttempts = Number(
-      process.env['WA_MAX_RECONNECT_ATTEMPTS']
-      ?? cfg.maxReconnectAttempts
-      ?? 5,
+      process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? cfg.maxReconnectAttempts ?? 8,
     )
     this.qrTimeoutMs       = Number(cfg.qrTimeoutMs    ?? 120_000)
     this.printQrInTerminal = Boolean(cfg.printQrInTerminal ?? false)
     if (cfg.browser) this.browser = cfg.browser
 
-    // Asegurar que el directorio de sesiones existe
-    const sessionPath = this.getSessionPath()
-    fs.mkdirSync(sessionPath, { recursive: true })
-
+    fs.mkdirSync(this.getSessionPath(), { recursive: true })
     console.info(
-      `[whatsapp-baileys] Adapter configured (lazy) — channelId=${this.channelConfigId}, ` +
-      `sessionsDir=${sessionPath}`,
+      `[whatsapp-baileys] Adapter configured (lazy) — channelId=${this.channelConfigId}`,
     )
   }
 
-  /**
-   * connect() — inicia la conexión Baileys explícitamente.
-   * Si ya hay una conexión en curso (connectPromise), retorna la misma.
-   * Idempotente si state === 'open'.
-   */
   async connect(): Promise<void> {
-    if (this.state === 'open') return
+    if (this._state === 'open') return
     if (this.connectPromise) return this.connectPromise
 
     this.connectPromise = this.doConnect()
@@ -198,48 +148,36 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
   private async doConnect(): Promise<void> {
     this.setState('connecting')
 
-    // Importación dinámica de Baileys (ESM puro) — evita cargar en tests
     const baileys = await import('@whiskeysockets/baileys').catch((err: unknown) => {
       throw new Error(
-        `[whatsapp-baileys] No se pudo cargar @whiskeysockets/baileys: ${String(err)}\n` +
-        `Ejecutar: pnpm add @whiskeysockets/baileys pino --filter gateway`,
+        `[whatsapp-baileys] No se pudo cargar @whiskeysockets/baileys: ${String(err)}`,
       )
     })
 
     const { makeWASocket, useMultiFileAuthState, DisconnectReason: DR, fetchLatestBaileysVersion } =
       baileys as unknown as {
         makeWASocket:          (opts: Record<string, unknown>) => BaileysSocket
-        useMultiFileAuthState: (dir: string) => Promise<{
-          state:     unknown
-          saveCreds: () => Promise<void>
-        }>
+        useMultiFileAuthState: (dir: string) => Promise<{ state: unknown; saveCreds: () => Promise<void> }>
         DisconnectReason:      DisconnectReason
         fetchLatestBaileysVersion: () => Promise<{ version: [number, number, number] }>
       }
 
-    // Auth state desde filesystem
-    const sessionPath = this.getSessionPath()
+    const sessionPath       = this.getSessionPath()
     const { state, saveCreds } = await useMultiFileAuthState(sessionPath)
+    const { version }        = await fetchLatestBaileysVersion()
 
-    // Versión de Baileys
-    const { version } = await fetchLatestBaileysVersion()
-
-    // Crear socket
     const sock = makeWASocket({
       version,
-      auth:             state,
+      auth:              state,
       printQRInTerminal: this.printQrInTerminal,
-      browser:          this.browser,
-      logger:           this.makePinoLogger(),
-      // Reconexión gestionada manualmente
+      browser:           this.browser,
+      logger:            this.makePinoLogger(),
       retryRequestDelayMs: 0,
     }) as BaileysSocket
 
     this.sock = sock
 
-    // ── Eventos de Baileys ─────────────────────────────────────────────
-
-    // QR code
+    // ── connection.update ─────────────────────────────────────────────────
     sock.ev.on('connection.update', ((update: {
       connection?: string
       lastDisconnect?: { error?: { output?: { statusCode?: number } } }
@@ -247,357 +185,199 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
     }) => {
       const { connection, lastDisconnect, qr } = update
 
-      if (qr) {
-        this.handleQr(qr)
-      }
+      if (qr) { this.handleQr(qr) }
 
       if (connection === 'close') {
         this.clearQrTimeout()
         const statusCode = lastDisconnect?.error?.output?.statusCode
-        const isLoggedOut = statusCode === (DR as unknown as { loggedOut: number }).loggedOut
+        const isPermanentClose =
+          statusCode === (DR as unknown as DisconnectReason).loggedOut ||
+          statusCode === (DR as unknown as DisconnectReason).connectionReplaced
 
-        if (isLoggedOut) {
-          console.warn('[whatsapp-baileys] Sesión cerrada (logout) — eliminando creds')
+        if (isPermanentClose) {
+          console.warn(`[whatsapp-baileys:${this.channelConfigId}] Permanent close (${statusCode}) — clearing session`)
           this.clearSessionFiles()
           this.setState('closed')
-          this.emitter.emit('error', new Error('WhatsApp session logged out'))
+          this.emitter.emit('closed', this.channelConfigId, 'permanent_close')
           return
         }
 
-        // Reconectar con backoff
-        this.handleDisconnect()
+        // Reconexión con ExponentialBackoff (F3a-23)
+        if (!this.backoff.exhausted && !this.backoff.isAborted) {
+          this.setState('reconnecting')
+          this.sock = null
+          this.connectPromise = null
+
+          console.warn(
+            `[whatsapp-baileys:${this.channelConfigId}] Disconnected — ${this.backoff}`,
+          )
+
+          this.backoff.next()
+            .then(() => this.connect())
+            .catch((err: Error) => {
+              if (err.message === 'backoff_exhausted') {
+                this.setState('closed')
+                this.emitter.emit('closed', this.channelConfigId, 'max_retries_exceeded')
+                console.error(
+                  `[whatsapp-baileys:${this.channelConfigId}] Max retries reached`,
+                )
+              } else if (err.message !== 'backoff_aborted') {
+                console.error(
+                  `[whatsapp-baileys:${this.channelConfigId}] Reconnect error:`, err,
+                )
+              }
+              // 'backoff_aborted' = dispose() fue llamado — silencio intencional
+            })
+        } else {
+          this.setState('closed')
+          this.emitter.emit('closed', this.channelConfigId, 'max_retries_exceeded')
+        }
       }
 
       if (connection === 'open') {
         this.clearQrTimeout()
-        this.reconnectAttempts = 0
+        this.backoff.reset()   // F3a-23: resetear tras conexión exitosa
         this.setState('open')
         console.info(
-          `[whatsapp-baileys] Conexión abierta — jid=${sock.user?.id ?? 'unknown'}`,
+          `[whatsapp-baileys:${this.channelConfigId}] Connected — jid=${sock.user?.id ?? 'unknown'}`,
         )
       }
     }) as (...args: unknown[]) => void)
 
-    // Guardar creds cuando Baileys las actualiza
     sock.ev.on('creds.update', saveCreds as unknown as (...args: unknown[]) => void)
 
-    // Mensajes entrantes
-    sock.ev.on('messages.upsert', ((event: {
-      messages: unknown[]
-      type:     string
-    }) => {
+    // ── messages.upsert: usa baileysToIncoming() (F3a-24) ──────────────────
+    sock.ev.on('messages.upsert', ((event: { messages: unknown[]; type: string }) => {
       if (event.type !== 'notify') return
+
       for (const rawMsg of event.messages) {
-        this.handleIncomingMessage(rawMsg as Record<string, unknown>, sock).catch((err: unknown) => {
-          console.error('[whatsapp-baileys] Error procesando mensaje:', err)
-        })
+        // Castear a proto.IWebMessageInfo (estructura compatible)
+        const waMsg = rawMsg as Parameters<typeof baileysToIncoming>[0]
+        const normalized = baileysToIncoming(waMsg)
+        if (!normalized) continue   // null = mensaje propio / sistema / no soportado
+
+        this.emit(normalized).catch((err: unknown) =>
+          console.error(
+            `[whatsapp-baileys:${this.channelConfigId}] emit error (${(waMsg as any).key?.id}):`,
+            err,
+          ),
+        )
       }
     }) as (...args: unknown[]) => void)
   }
 
+  // ── dispose (F3a-23: abortar backoff) ───────────────────────────────────
+
   async dispose(): Promise<void> {
+    this.backoff.abort()   // F3a-23: cancelar timer de reconexion pendiente
     this.clearQrTimeout()
     this.setState('closed')
 
     if (this.sock) {
       try {
+        this.sock.ev.removeAllListeners()
         this.sock.end()
-      } catch { /* ignorar errores al cerrar */ }
+      } catch { /* ignorar */ }
       this.sock = null
     }
 
     this.emitter.removeAllListeners()
-    console.info('[whatsapp-baileys] Adapter disposed')
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] Adapter disposed`)
   }
 
-  // ── send() ─────────────────────────────────────────────────────────────
+  // ── logout (F3a-23) ──────────────────────────────────────────────────────
 
   /**
-   * Envía un mensaje de texto al JID de WhatsApp.
-   * Si el adapter no está conectado → conecta lazy antes de enviar.
+   * Cierra la sesión de WhatsApp Web notificando al servidor WA.
+   * Después de logout(), el estado queda 'closed'.
+   * Se puede volver a conectar con connect() → generará nuevo QR.
    */
+  async logout(): Promise<void> {
+    this.backoff.abort()
+    this.clearQrTimeout()
+
+    if (this.sock) {
+      try {
+        await this.sock.logout()
+      } catch (err) {
+        console.warn(`[whatsapp-baileys:${this.channelConfigId}] logout error:`, err)
+      } finally {
+        this.sock.ev.removeAllListeners()
+        this.sock.end()
+        this.sock = null
+      }
+    }
+
+    this.connectPromise = null
+    this.setState('closed')
+    this.emitter.emit('closed', this.channelConfigId, 'logged_out')
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] Logged out`)
+  }
+
+  // ── send() — usa outgoingToBaileys() (F3a-24) ─────────────────────────
+
   async send(message: OutgoingMessage): Promise<void> {
-    // Lazy connect al primer send()
-    if (this.state !== 'open') {
+    if (this._state === 'idle' || this._state === 'closed') {
       await this.connect()
     }
-
+    if (this._state !== 'open') {
+      await this.waitForOpen(30_000)
+    }
     if (!this.sock) {
-      throw new Error('[whatsapp-baileys] Socket no disponible para send()')
+      throw new Error(`[whatsapp-baileys:${this.channelConfigId}] Socket not available`)
     }
 
-    const jid = this.toJid(message.externalId)
-
-    const content: Record<string, unknown> = {
-      text: message.text,
-    }
-
-    // richContent (botones, listas — requiere WA Business API, aquí best-effort)
-    if (message.richContent) {
-      Object.assign(content, message.richContent)
-    }
-
+    const { jid, content } = outgoingToBaileys(message)
     await this.sock.sendMessage(jid, content)
+
+    console.info(
+      `[whatsapp-baileys:${this.channelConfigId}] Message sent to ${message.externalId}`,
+    )
   }
 
-  // ── receive() — construye IncomingMessage (patrón F3a-17) ─────────────
+  // ── receive() ────────────────────────────────────────────────────────────
 
-  /**
-   * Convierte un mensaje crudo de Baileys en IncomingMessage normalizado.
-   * Construye replyFn como closure capturando jid + sock.
-   * Retorna null si el mensaje debe ignorarse (propio bot, status, vacío).
-   */
   async receive(
     rawPayload: Record<string, unknown>,
     _secrets:   Record<string, unknown>,
-  ): Promise<IncomingMessage | null> {
-    // receive() en Baileys es llamado desde handleIncomingMessage()
-    // con el message ya crudo — normalizamos aquí
-    return this.normalizeMessage(rawPayload, this.sock)
+  ): Promise<ReturnType<typeof baileysToIncoming>> {
+    return baileysToIncoming(rawPayload as Parameters<typeof baileysToIncoming>[0])
   }
 
-  // ── Callbacks públicos ─────────────────────────────────────────────────
+  // ── Callbacks públicos ──────────────────────────────────────────────────────
 
-  /** Registrar handler para QR codes (admin UI). */
   onQr(handler: (qr: string) => void): void {
     this.emitter.on('qr', handler)
   }
 
-  /** Registrar handler para cambios de estado. */
+  onConnected(handler: () => void): void {
+    this.emitter.on('open', handler)
+  }
+
+  onDisconnected(handler: () => void): void {
+    this.emitter.on('closed', handler)
+  }
+
   onStateChange(handler: (state: WhatsAppAdapterState) => void): void {
     this.emitter.on('state', handler)
   }
 
-  /** Registrar handler para errores del adapter. */
   onError(handler: (err: Error) => void): void {
     this.emitter.on('error', handler)
   }
 
-  /** Estado actual del adapter. */
-  getState(): WhatsAppAdapterState {
-    return this.state
-  }
+  getState(): WhatsAppAdapterState { return this._state }
 
-  // ── Manejo de mensajes entrantes (interno) ─────────────────────────────
-
-  private async handleIncomingMessage(
-    rawMsg: Record<string, unknown>,
-    sock:   BaileysSocket,
-  ): Promise<void> {
-    // Ignorar mensajes propios del bot
-    const key = rawMsg['key'] as Record<string, unknown> | undefined
-    if (key?.['fromMe']) return
-
-    // Ignorar status broadcasts
-    const remoteJid = String(key?.['remoteJid'] ?? '')
-    if (remoteJid === 'status@broadcast') return
-
-    const incoming = this.normalizeMessage(rawMsg, sock)
-    if (!incoming) return
-
-    await this.emit(incoming)
-  }
-
-  private normalizeMessage(
-    rawMsg: Record<string, unknown>,
-    sock:   BaileysSocket | null,
-  ): IncomingMessage | null {
-    const key        = rawMsg['key'] as Record<string, unknown> | undefined
-    const message    = rawMsg['message'] as Record<string, unknown> | undefined
-    const pushName   = String(rawMsg['pushName'] ?? '')
-
-    if (!key || !message) return null
-
-    const remoteJid   = String(key['remoteJid'] ?? '')
-    const participant = String(key['participant'] ?? key['remoteJid'] ?? '')
-    const isGroup     = remoteJid.endsWith('@g.us')
-
-    // Extraer texto del mensaje
-    const text       = this.extractText(message)
-    const type       = this.extractType(message)
-    const attachment = this.extractAttachment(message)
-
-    // Para grupos, externalId = groupJid, threadId = groupJid, senderId = participant
-    // Para DMs,    externalId = userJid,  threadId = userJid,  senderId = userJid
-    const chatJid    = remoteJid
-    const senderJid  = isGroup ? participant : remoteJid
-    const threadId   = chatJid   // WA no tiene threads como Telegram topics
-
-    // Construir replyFn capturando chatJid y sock
-    const replyFn: ReplyFn | undefined = sock
-      ? async (replyText: string, opts?: ReplyOptions) => {
-          if (!sock) throw new Error('[whatsapp-baileys] Socket cerrado al intentar responder')
-
-          const content: Record<string, unknown> = {
-            text: replyText,
-          }
-
-          if (opts?.quoteOriginal && key['id']) {
-            // Citar el mensaje original
-            content['quoted'] = rawMsg
-          }
-
-          if (opts?.channelMeta?.['richContent']) {
-            Object.assign(content, opts.channelMeta['richContent'])
-          }
-
-          await sock.sendMessage(chatJid, content)
-        }
-      : undefined
-
-    return {
-      externalId:  chatJid,
-      threadId,
-      senderId:    senderJid,
-      text:        text ?? '',
-      type,
-      attachments: attachment ? [attachment] : undefined,
-      replyFn,
-      rawPayload:  this.sanitizeRawPayload(
-        rawMsg,
-        ['botToken', 'accessToken', 'apiKey', 'sessionKey'],
-      ),
-      metadata: {
-        pushName,
-        remoteJid,
-        isGroup,
-        messageId: String(key['id'] ?? ''),
-      },
-      receivedAt: this.makeTimestamp(),
-    }
-  }
-
-  // ── Extracción de contenido de mensaje ────────────────────────────────
-
-  private extractText(message: Record<string, unknown>): string | null {
-    if (message['conversation'])         return String(message['conversation'])
-    if (message['extendedTextMessage']) {
-      const ext = message['extendedTextMessage'] as Record<string, unknown>
-      return String(ext['text'] ?? '')
-    }
-    if (message['imageMessage']) {
-      const img = message['imageMessage'] as Record<string, unknown>
-      return String(img['caption'] ?? '')
-    }
-    if (message['videoMessage']) {
-      const vid = message['videoMessage'] as Record<string, unknown>
-      return String(vid['caption'] ?? '')
-    }
-    if (message['documentMessage']) {
-      const doc = message['documentMessage'] as Record<string, unknown>
-      return String(doc['fileName'] ?? doc['caption'] ?? '')
-    }
-    if (message['audioMessage'])    return '[Audio]'
-    if (message['stickerMessage'])  return '[Sticker]'
-    if (message['locationMessage']) {
-      const loc = message['locationMessage'] as Record<string, unknown>
-      return `[Location: ${String(loc['degreesLatitude'])}, ${String(loc['degreesLongitude'])}]`
-    }
-    return null
-  }
-
-  private extractType(message: Record<string, unknown>): IncomingMessage['type'] {
-    if (message['imageMessage'])    return 'image'
-    if (message['audioMessage'])    return 'audio'
-    if (message['documentMessage']) return 'file'
-    if (message['videoMessage'])    return 'file'
-    const text =
-      (message['conversation'] as string | undefined) ??
-      ((message['extendedTextMessage'] as Record<string, unknown> | undefined)?.['text'] as string | undefined) ??
-      ''
-    if (text.startsWith('/'))       return 'command'
-    return 'text'
-  }
-
-  private extractAttachment(
-    message: Record<string, unknown>,
-  ): { type: string; url?: string; data?: unknown } | null {
-    if (message['imageMessage']) {
-      const img = message['imageMessage'] as Record<string, unknown>
-      return { type: 'image', url: String(img['url'] ?? '') }
-    }
-    if (message['audioMessage']) {
-      const aud = message['audioMessage'] as Record<string, unknown>
-      return { type: 'audio', url: String(aud['url'] ?? '') }
-    }
-    if (message['documentMessage']) {
-      const doc = message['documentMessage'] as Record<string, unknown>
-      return {
-        type: 'file',
-        url:  String(doc['url'] ?? ''),
-        data: { fileName: doc['fileName'], mimetype: doc['mimetype'] },
-      }
-    }
-    return null
-  }
-
-  // ── QR y reconexión ────────────────────────────────────────────────────
-
-  private handleQr(qr: string): void {
-    this.setState('qr')
-    this.emitter.emit('qr', qr)
-
-    if (this.printQrInTerminal) {
-      // En modo dev, imprimir QR en consola (lo hace Baileys si printQRInTerminal=true)
-      console.info('[whatsapp-baileys] QR generado — escanear con WhatsApp')
-    }
-
-    // Timeout de QR: 2 minutos sin escaneo → cerrar
-    this.clearQrTimeout()
-    this.qrTimeoutHandle = setTimeout(() => {
-      console.warn('[whatsapp-baileys] QR timeout — cerrando socket')
-      this.setState('closed')
-      this.sock?.end(new Error('QR timeout'))
-      this.sock = null
-      this.emitter.emit('error', new Error('WhatsApp QR pairing timeout (2 min)'))
-    }, this.qrTimeoutMs)
-  }
-
-  private handleDisconnect(): void {
-    this.sock = null
-
-    if (this.state === 'closed') return  // dispose() ya llamado
-
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      console.error(
-        `[whatsapp-baileys] Max reconexiones alcanzadas (${this.maxReconnectAttempts}) — ` +
-        `deteniendo adapter`,
-      )
-      this.setState('closed')
-      this.emitter.emit(
-        'error',
-        new Error(`WhatsApp adapter: max reconnect attempts (${this.maxReconnectAttempts}) reached`),
-      )
-      return
-    }
-
-    this.reconnectAttempts++
-    this.setState('reconnecting')
-
-    // Backoff exponencial: 1s, 2s, 4s, 8s, …
-    const delay = 1_000 * 2 ** (this.reconnectAttempts - 1)
-    console.warn(
-      `[whatsapp-baileys] Reconectando en ${delay}ms ` +
-      `(intento ${this.reconnectAttempts}/${this.maxReconnectAttempts})`,
-    )
-
-    setTimeout(() => {
-      if (this.state === 'closed') return  // dispose() llamado durante la espera
-      this.doConnect().catch((err: unknown) => {
-        console.error('[whatsapp-baileys] Error en reconexión:', err)
-        this.handleDisconnect()
-      })
-    }, delay)
-  }
-
-  // ── Helpers ────────────────────────────────────────────────────────────
+  // ── Helpers privados ───────────────────────────────────────────────────────────
 
   private setState(newState: WhatsAppAdapterState): void {
-    if (this.state === newState) return
-    const prev = this.state
-    this.state  = newState
-    console.info(`[whatsapp-baileys] Estado: ${prev} → ${newState}`)
+    if (this._state === newState) return
+    const prev = this._state
+    this._state = newState
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] State: ${prev} → ${newState}`)
     this.emitter.emit('state', newState)
+    if (newState === 'open')   this.emitter.emit('open')
+    if (newState === 'closed') this.emitter.emit('closed', this.channelConfigId)
   }
 
   private clearQrTimeout(): void {
@@ -605,6 +385,18 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
       clearTimeout(this.qrTimeoutHandle)
       this.qrTimeoutHandle = null
     }
+  }
+
+  private handleQr(qr: string): void {
+    this.setState('qr')
+    this.emitter.emit('qr', qr)
+    this.clearQrTimeout()
+    this.qrTimeoutHandle = setTimeout(() => {
+      console.warn(`[whatsapp-baileys:${this.channelConfigId}] QR timeout — closing socket`)
+      this.setState('closed')
+      this.sock?.end(new Error('QR timeout'))
+      this.sock = null
+    }, this.qrTimeoutMs)
   }
 
   private getSessionPath(): string {
@@ -615,35 +407,37 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
     const sessionPath = this.getSessionPath()
     try {
       fs.rmSync(sessionPath, { recursive: true, force: true })
-      console.info(`[whatsapp-baileys] Auth state eliminado: ${sessionPath}`)
+      console.info(`[whatsapp-baileys:${this.channelConfigId}] Auth state deleted: ${sessionPath}`)
     } catch (err) {
-      console.error('[whatsapp-baileys] Error eliminando auth state:', err)
+      console.error(`[whatsapp-baileys:${this.channelConfigId}] Error deleting auth state:`, err)
     }
   }
 
   /**
-   * Normaliza un número de teléfono o JID a formato Baileys.
-   * Baileys usa JIDs: '5491112345678@s.whatsapp.net' para DMs
-   *                   'groupid@g.us' para grupos
+   * Espera hasta que el estado sea 'open' o se alcance el timeout.
+   * Usado en send() para lazy connect.
    */
-  private toJid(externalId: string): string {
-    if (externalId.includes('@')) return externalId  // ya es JID
-    // Número de teléfono → JID
-    const cleaned = externalId.replace(/[^0-9]/g, '')
-    return `${cleaned}@s.whatsapp.net`
+  private waitForOpen(timeoutMs: number): Promise<void> {
+    if (this._state === 'open') return Promise.resolve()
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.emitter.off('open', onOpen)
+        reject(new Error(`[whatsapp-baileys:${this.channelConfigId}] waitForOpen timeout`))
+      }, timeoutMs)
+      const onOpen = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      this.emitter.once('open', onOpen)
+    })
   }
 
-  /**
-   * Crea un logger pino silencioso para Baileys.
-   * En producción, cambiar el nivel a 'info' o usar pino real.
-   */
   private makePinoLogger() {
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const pino = require('pino') as (opts: Record<string, unknown>) => unknown
       return pino({ level: 'silent' })
     } catch {
-      // Pino no instalado — Baileys usará console
       return undefined
     }
   }

--- a/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
@@ -1,0 +1,650 @@
+/**
+ * whatsapp-baileys.adapter.ts — WhatsApp via Baileys (WA Web protocol)
+ * [F3a-21]
+ *
+ * A diferencia de WhatsAppAdapter (Cloud API), este adapter usa el
+ * protocolo WhatsApp Web via Baileys. No requiere cuenta Business ni
+ * aprobación de Meta — funciona con cualquier número de WhatsApp.
+ *
+ * QR pairing lazy-load:
+ *   El socket se crea SOLO cuando se necesita (primer send() o
+ *   llamada explícita a connect()). Esto evita abrir N sockets
+ *   al iniciar el gateway si hay N canales WA configurados.
+ *
+ * Estados del adapter:
+ *   idle        → instanciado, sin socket
+ *   connecting  → makeWASocket() llamado, esperando eventos
+ *   qr          → QR generado, esperando escaneo del usuario
+ *   open        → autenticado y conectado
+ *   closed      → socket cerrado
+ *   reconnecting→ intento de reconexión en curso
+ *
+ * Transiciones válidas:
+ *   idle → connecting        (primer send() o connect() explícito)
+ *   connecting → qr          (Baileys emite QR, primera vez sin creds)
+ *   connecting → open        (tiene creds guardadas, reconecta directo)
+ *   qr → open                (usuario escanea QR)
+ *   qr → closed              (timeout 2 min sin escaneo)
+ *   open → reconnecting      (desconexión inesperada)
+ *   reconnecting → open      (reconexión exitosa)
+ *   reconnecting → closed    (max retries alcanzados)
+ *   closed → connecting      (reconnect manual o nueva connect())
+ *   * → closed               (dispose())
+ *
+ * Auth state:
+ *   Se persiste en filesystem via useMultiFileAuthState().
+ *   Directorio: ${WA_SESSIONS_DIR}/${channelConfigId}/
+ *   Variable de entorno: WA_SESSIONS_DIR (default: ./data/wa-sessions)
+ *   IMPORTANTE: añadir data/wa-sessions/ a .gitignore
+ *
+ * Uso en GatewayService:
+ *   const adapter = new WhatsAppBaileysAdapter()
+ *   await adapter.setup(config, secrets)   // setup sin conectar (lazy)
+ *   adapter.onMessage(handler)
+ *   adapter.onQr(qr => exposeToAdmin(qr))  // exponer QR al admin
+ *   adapter.onStateChange(state => log(state))
+ *   // La conexión ocurre al primer dispatch() → send()
+ */
+
+import path         from 'node:path'
+import fs           from 'node:fs'
+import EventEmitter from 'node:events'
+import {
+  BaseChannelAdapter,
+  type IncomingMessage,
+  type OutgoingMessage,
+  type ReplyFn,
+  type ReplyOptions,
+} from './channel-adapter.interface.js'
+
+// ── Tipos de Baileys (importados dinámicamente para evitar cargar el módulo
+//    en tests que no usen WhatsApp — Baileys es pesado) ─────────────────────
+
+type BaileysSocket = {
+  sendMessage: (
+    jid: string,
+    content: Record<string, unknown>,
+    opts?: Record<string, unknown>,
+  ) => Promise<unknown>
+  logout: () => Promise<void>
+  end:    (err?: Error) => void
+  ev: {
+    on: (event: string, handler: (...args: unknown[]) => void) => void
+    off: (event: string, handler: (...args: unknown[]) => void) => void
+  }
+  user?: { id: string; name?: string }
+}
+
+type DisconnectReason = {
+  loggedOut:     number
+  connectionLost: number
+  restartRequired: number
+  timedOut:      number
+  badSession:    number
+}
+
+// ── Estado del adapter ─────────────────────────────────────────────────────
+
+export type WhatsAppAdapterState =
+  | 'idle'
+  | 'connecting'
+  | 'qr'
+  | 'open'
+  | 'closed'
+  | 'reconnecting'
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+interface WhatsAppBaileysConfig {
+  /** Directorio base para auth state. Default: ./data/wa-sessions */
+  sessionsDir?:          string
+  /** Máximo de reconexiones antes de closed. Default: 5 */
+  maxReconnectAttempts?: number
+  /** Timeout QR en ms. Default: 120_000 (2 min) */
+  qrTimeoutMs?:         number
+  /** Imprimir QR en consola (dev mode). Default: false */
+  printQrInTerminal?:   boolean
+  /** Browser label para Baileys. Default: ['AgentVS Gateway', 'Chrome', '120.0'] */
+  browser?:             [string, string, string]
+}
+
+// ── WhatsAppBaileysAdapter ──────────────────────────────────────────────────
+
+export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
+  readonly channel = 'whatsapp-baileys'
+
+  // ── Estado interno ────────────────────────────────────────────────────
+  private state:             WhatsAppAdapterState = 'idle'
+  private sock:              BaileysSocket | null  = null
+  private reconnectAttempts  = 0
+  private qrTimeoutHandle:   ReturnType<typeof setTimeout> | null = null
+  private connectPromise:    Promise<void> | null = null  // evita conexiones paralelas
+
+  // ── Config ────────────────────────────────────────────────────────────
+  private sessionsDir          = process.env['WA_SESSIONS_DIR'] ?? './data/wa-sessions'
+  private maxReconnectAttempts = parseInt(process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? '5')
+  private qrTimeoutMs          = 120_000
+  private printQrInTerminal    = false
+  private browser: [string, string, string] = ['AgentVS Gateway', 'Chrome', '120.0']
+
+  // ── EventEmitter para QR y cambios de estado ──────────────────────────
+  private readonly emitter = new EventEmitter()
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+
+  /**
+   * initialize() — stub de compatibilidad con IChannelAdapter.
+   * El flujo canónico es setup(config, secrets).
+   */
+  async initialize(channelConfigId: string): Promise<void> {
+    this.channelConfigId = channelConfigId
+    console.warn(
+      '[whatsapp-baileys] initialize() sin credenciales — usar setup(config, secrets) en su lugar',
+    )
+  }
+
+  /**
+   * setup() — configura el adapter con config + secrets descifrados.
+   * Llamado por GatewayService.activateChannel() (patrón F3a-14).
+   * NO conecta el socket — lazy-load al primer send().
+   */
+  async setup(
+    config:  Record<string, unknown>,
+    _secrets: Record<string, unknown>,
+  ): Promise<void> {
+    const cfg = config as WhatsAppBaileysConfig
+
+    this.sessionsDir = String(
+      process.env['WA_SESSIONS_DIR']
+      ?? cfg.sessionsDir
+      ?? './data/wa-sessions',
+    )
+    this.maxReconnectAttempts = Number(
+      process.env['WA_MAX_RECONNECT_ATTEMPTS']
+      ?? cfg.maxReconnectAttempts
+      ?? 5,
+    )
+    this.qrTimeoutMs       = Number(cfg.qrTimeoutMs    ?? 120_000)
+    this.printQrInTerminal = Boolean(cfg.printQrInTerminal ?? false)
+    if (cfg.browser) this.browser = cfg.browser
+
+    // Asegurar que el directorio de sesiones existe
+    const sessionPath = this.getSessionPath()
+    fs.mkdirSync(sessionPath, { recursive: true })
+
+    console.info(
+      `[whatsapp-baileys] Adapter configured (lazy) — channelId=${this.channelConfigId}, ` +
+      `sessionsDir=${sessionPath}`,
+    )
+  }
+
+  /**
+   * connect() — inicia la conexión Baileys explícitamente.
+   * Si ya hay una conexión en curso (connectPromise), retorna la misma.
+   * Idempotente si state === 'open'.
+   */
+  async connect(): Promise<void> {
+    if (this.state === 'open') return
+    if (this.connectPromise) return this.connectPromise
+
+    this.connectPromise = this.doConnect()
+    try {
+      await this.connectPromise
+    } finally {
+      this.connectPromise = null
+    }
+  }
+
+  private async doConnect(): Promise<void> {
+    this.setState('connecting')
+
+    // Importación dinámica de Baileys (ESM puro) — evita cargar en tests
+    const baileys = await import('@whiskeysockets/baileys').catch((err: unknown) => {
+      throw new Error(
+        `[whatsapp-baileys] No se pudo cargar @whiskeysockets/baileys: ${String(err)}\n` +
+        `Ejecutar: pnpm add @whiskeysockets/baileys pino --filter gateway`,
+      )
+    })
+
+    const { makeWASocket, useMultiFileAuthState, DisconnectReason: DR, fetchLatestBaileysVersion } =
+      baileys as unknown as {
+        makeWASocket:          (opts: Record<string, unknown>) => BaileysSocket
+        useMultiFileAuthState: (dir: string) => Promise<{
+          state:     unknown
+          saveCreds: () => Promise<void>
+        }>
+        DisconnectReason:      DisconnectReason
+        fetchLatestBaileysVersion: () => Promise<{ version: [number, number, number] }>
+      }
+
+    // Auth state desde filesystem
+    const sessionPath = this.getSessionPath()
+    const { state, saveCreds } = await useMultiFileAuthState(sessionPath)
+
+    // Versión de Baileys
+    const { version } = await fetchLatestBaileysVersion()
+
+    // Crear socket
+    const sock = makeWASocket({
+      version,
+      auth:             state,
+      printQRInTerminal: this.printQrInTerminal,
+      browser:          this.browser,
+      logger:           this.makePinoLogger(),
+      // Reconexión gestionada manualmente
+      retryRequestDelayMs: 0,
+    }) as BaileysSocket
+
+    this.sock = sock
+
+    // ── Eventos de Baileys ─────────────────────────────────────────────
+
+    // QR code
+    sock.ev.on('connection.update', ((update: {
+      connection?: string
+      lastDisconnect?: { error?: { output?: { statusCode?: number } } }
+      qr?: string
+    }) => {
+      const { connection, lastDisconnect, qr } = update
+
+      if (qr) {
+        this.handleQr(qr)
+      }
+
+      if (connection === 'close') {
+        this.clearQrTimeout()
+        const statusCode = lastDisconnect?.error?.output?.statusCode
+        const isLoggedOut = statusCode === (DR as unknown as { loggedOut: number }).loggedOut
+
+        if (isLoggedOut) {
+          console.warn('[whatsapp-baileys] Sesión cerrada (logout) — eliminando creds')
+          this.clearSessionFiles()
+          this.setState('closed')
+          this.emitter.emit('error', new Error('WhatsApp session logged out'))
+          return
+        }
+
+        // Reconectar con backoff
+        this.handleDisconnect()
+      }
+
+      if (connection === 'open') {
+        this.clearQrTimeout()
+        this.reconnectAttempts = 0
+        this.setState('open')
+        console.info(
+          `[whatsapp-baileys] Conexión abierta — jid=${sock.user?.id ?? 'unknown'}`,
+        )
+      }
+    }) as (...args: unknown[]) => void)
+
+    // Guardar creds cuando Baileys las actualiza
+    sock.ev.on('creds.update', saveCreds as unknown as (...args: unknown[]) => void)
+
+    // Mensajes entrantes
+    sock.ev.on('messages.upsert', ((event: {
+      messages: unknown[]
+      type:     string
+    }) => {
+      if (event.type !== 'notify') return
+      for (const rawMsg of event.messages) {
+        this.handleIncomingMessage(rawMsg as Record<string, unknown>, sock).catch((err: unknown) => {
+          console.error('[whatsapp-baileys] Error procesando mensaje:', err)
+        })
+      }
+    }) as (...args: unknown[]) => void)
+  }
+
+  async dispose(): Promise<void> {
+    this.clearQrTimeout()
+    this.setState('closed')
+
+    if (this.sock) {
+      try {
+        this.sock.end()
+      } catch { /* ignorar errores al cerrar */ }
+      this.sock = null
+    }
+
+    this.emitter.removeAllListeners()
+    console.info('[whatsapp-baileys] Adapter disposed')
+  }
+
+  // ── send() ─────────────────────────────────────────────────────────────
+
+  /**
+   * Envía un mensaje de texto al JID de WhatsApp.
+   * Si el adapter no está conectado → conecta lazy antes de enviar.
+   */
+  async send(message: OutgoingMessage): Promise<void> {
+    // Lazy connect al primer send()
+    if (this.state !== 'open') {
+      await this.connect()
+    }
+
+    if (!this.sock) {
+      throw new Error('[whatsapp-baileys] Socket no disponible para send()')
+    }
+
+    const jid = this.toJid(message.externalId)
+
+    const content: Record<string, unknown> = {
+      text: message.text,
+    }
+
+    // richContent (botones, listas — requiere WA Business API, aquí best-effort)
+    if (message.richContent) {
+      Object.assign(content, message.richContent)
+    }
+
+    await this.sock.sendMessage(jid, content)
+  }
+
+  // ── receive() — construye IncomingMessage (patrón F3a-17) ─────────────
+
+  /**
+   * Convierte un mensaje crudo de Baileys en IncomingMessage normalizado.
+   * Construye replyFn como closure capturando jid + sock.
+   * Retorna null si el mensaje debe ignorarse (propio bot, status, vacío).
+   */
+  async receive(
+    rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
+  ): Promise<IncomingMessage | null> {
+    // receive() en Baileys es llamado desde handleIncomingMessage()
+    // con el message ya crudo — normalizamos aquí
+    return this.normalizeMessage(rawPayload, this.sock)
+  }
+
+  // ── Callbacks públicos ─────────────────────────────────────────────────
+
+  /** Registrar handler para QR codes (admin UI). */
+  onQr(handler: (qr: string) => void): void {
+    this.emitter.on('qr', handler)
+  }
+
+  /** Registrar handler para cambios de estado. */
+  onStateChange(handler: (state: WhatsAppAdapterState) => void): void {
+    this.emitter.on('state', handler)
+  }
+
+  /** Registrar handler para errores del adapter. */
+  onError(handler: (err: Error) => void): void {
+    this.emitter.on('error', handler)
+  }
+
+  /** Estado actual del adapter. */
+  getState(): WhatsAppAdapterState {
+    return this.state
+  }
+
+  // ── Manejo de mensajes entrantes (interno) ─────────────────────────────
+
+  private async handleIncomingMessage(
+    rawMsg: Record<string, unknown>,
+    sock:   BaileysSocket,
+  ): Promise<void> {
+    // Ignorar mensajes propios del bot
+    const key = rawMsg['key'] as Record<string, unknown> | undefined
+    if (key?.['fromMe']) return
+
+    // Ignorar status broadcasts
+    const remoteJid = String(key?.['remoteJid'] ?? '')
+    if (remoteJid === 'status@broadcast') return
+
+    const incoming = this.normalizeMessage(rawMsg, sock)
+    if (!incoming) return
+
+    await this.emit(incoming)
+  }
+
+  private normalizeMessage(
+    rawMsg: Record<string, unknown>,
+    sock:   BaileysSocket | null,
+  ): IncomingMessage | null {
+    const key        = rawMsg['key'] as Record<string, unknown> | undefined
+    const message    = rawMsg['message'] as Record<string, unknown> | undefined
+    const pushName   = String(rawMsg['pushName'] ?? '')
+
+    if (!key || !message) return null
+
+    const remoteJid   = String(key['remoteJid'] ?? '')
+    const participant = String(key['participant'] ?? key['remoteJid'] ?? '')
+    const isGroup     = remoteJid.endsWith('@g.us')
+
+    // Extraer texto del mensaje
+    const text       = this.extractText(message)
+    const type       = this.extractType(message)
+    const attachment = this.extractAttachment(message)
+
+    // Para grupos, externalId = groupJid, threadId = groupJid, senderId = participant
+    // Para DMs,    externalId = userJid,  threadId = userJid,  senderId = userJid
+    const chatJid    = remoteJid
+    const senderJid  = isGroup ? participant : remoteJid
+    const threadId   = chatJid   // WA no tiene threads como Telegram topics
+
+    // Construir replyFn capturando chatJid y sock
+    const replyFn: ReplyFn | undefined = sock
+      ? async (replyText: string, opts?: ReplyOptions) => {
+          if (!sock) throw new Error('[whatsapp-baileys] Socket cerrado al intentar responder')
+
+          const content: Record<string, unknown> = {
+            text: replyText,
+          }
+
+          if (opts?.quoteOriginal && key['id']) {
+            // Citar el mensaje original
+            content['quoted'] = rawMsg
+          }
+
+          if (opts?.channelMeta?.['richContent']) {
+            Object.assign(content, opts.channelMeta['richContent'])
+          }
+
+          await sock.sendMessage(chatJid, content)
+        }
+      : undefined
+
+    return {
+      externalId:  chatJid,
+      threadId,
+      senderId:    senderJid,
+      text:        text ?? '',
+      type,
+      attachments: attachment ? [attachment] : undefined,
+      replyFn,
+      rawPayload:  this.sanitizeRawPayload(
+        rawMsg,
+        ['botToken', 'accessToken', 'apiKey', 'sessionKey'],
+      ),
+      metadata: {
+        pushName,
+        remoteJid,
+        isGroup,
+        messageId: String(key['id'] ?? ''),
+      },
+      receivedAt: this.makeTimestamp(),
+    }
+  }
+
+  // ── Extracción de contenido de mensaje ────────────────────────────────
+
+  private extractText(message: Record<string, unknown>): string | null {
+    if (message['conversation'])         return String(message['conversation'])
+    if (message['extendedTextMessage']) {
+      const ext = message['extendedTextMessage'] as Record<string, unknown>
+      return String(ext['text'] ?? '')
+    }
+    if (message['imageMessage']) {
+      const img = message['imageMessage'] as Record<string, unknown>
+      return String(img['caption'] ?? '')
+    }
+    if (message['videoMessage']) {
+      const vid = message['videoMessage'] as Record<string, unknown>
+      return String(vid['caption'] ?? '')
+    }
+    if (message['documentMessage']) {
+      const doc = message['documentMessage'] as Record<string, unknown>
+      return String(doc['fileName'] ?? doc['caption'] ?? '')
+    }
+    if (message['audioMessage'])    return '[Audio]'
+    if (message['stickerMessage'])  return '[Sticker]'
+    if (message['locationMessage']) {
+      const loc = message['locationMessage'] as Record<string, unknown>
+      return `[Location: ${String(loc['degreesLatitude'])}, ${String(loc['degreesLongitude'])}]`
+    }
+    return null
+  }
+
+  private extractType(message: Record<string, unknown>): IncomingMessage['type'] {
+    if (message['imageMessage'])    return 'image'
+    if (message['audioMessage'])    return 'audio'
+    if (message['documentMessage']) return 'file'
+    if (message['videoMessage'])    return 'file'
+    const text =
+      (message['conversation'] as string | undefined) ??
+      ((message['extendedTextMessage'] as Record<string, unknown> | undefined)?.['text'] as string | undefined) ??
+      ''
+    if (text.startsWith('/'))       return 'command'
+    return 'text'
+  }
+
+  private extractAttachment(
+    message: Record<string, unknown>,
+  ): { type: string; url?: string; data?: unknown } | null {
+    if (message['imageMessage']) {
+      const img = message['imageMessage'] as Record<string, unknown>
+      return { type: 'image', url: String(img['url'] ?? '') }
+    }
+    if (message['audioMessage']) {
+      const aud = message['audioMessage'] as Record<string, unknown>
+      return { type: 'audio', url: String(aud['url'] ?? '') }
+    }
+    if (message['documentMessage']) {
+      const doc = message['documentMessage'] as Record<string, unknown>
+      return {
+        type: 'file',
+        url:  String(doc['url'] ?? ''),
+        data: { fileName: doc['fileName'], mimetype: doc['mimetype'] },
+      }
+    }
+    return null
+  }
+
+  // ── QR y reconexión ────────────────────────────────────────────────────
+
+  private handleQr(qr: string): void {
+    this.setState('qr')
+    this.emitter.emit('qr', qr)
+
+    if (this.printQrInTerminal) {
+      // En modo dev, imprimir QR en consola (lo hace Baileys si printQRInTerminal=true)
+      console.info('[whatsapp-baileys] QR generado — escanear con WhatsApp')
+    }
+
+    // Timeout de QR: 2 minutos sin escaneo → cerrar
+    this.clearQrTimeout()
+    this.qrTimeoutHandle = setTimeout(() => {
+      console.warn('[whatsapp-baileys] QR timeout — cerrando socket')
+      this.setState('closed')
+      this.sock?.end(new Error('QR timeout'))
+      this.sock = null
+      this.emitter.emit('error', new Error('WhatsApp QR pairing timeout (2 min)'))
+    }, this.qrTimeoutMs)
+  }
+
+  private handleDisconnect(): void {
+    this.sock = null
+
+    if (this.state === 'closed') return  // dispose() ya llamado
+
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      console.error(
+        `[whatsapp-baileys] Max reconexiones alcanzadas (${this.maxReconnectAttempts}) — ` +
+        `deteniendo adapter`,
+      )
+      this.setState('closed')
+      this.emitter.emit(
+        'error',
+        new Error(`WhatsApp adapter: max reconnect attempts (${this.maxReconnectAttempts}) reached`),
+      )
+      return
+    }
+
+    this.reconnectAttempts++
+    this.setState('reconnecting')
+
+    // Backoff exponencial: 1s, 2s, 4s, 8s, …
+    const delay = 1_000 * 2 ** (this.reconnectAttempts - 1)
+    console.warn(
+      `[whatsapp-baileys] Reconectando en ${delay}ms ` +
+      `(intento ${this.reconnectAttempts}/${this.maxReconnectAttempts})`,
+    )
+
+    setTimeout(() => {
+      if (this.state === 'closed') return  // dispose() llamado durante la espera
+      this.doConnect().catch((err: unknown) => {
+        console.error('[whatsapp-baileys] Error en reconexión:', err)
+        this.handleDisconnect()
+      })
+    }, delay)
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  private setState(newState: WhatsAppAdapterState): void {
+    if (this.state === newState) return
+    const prev = this.state
+    this.state  = newState
+    console.info(`[whatsapp-baileys] Estado: ${prev} → ${newState}`)
+    this.emitter.emit('state', newState)
+  }
+
+  private clearQrTimeout(): void {
+    if (this.qrTimeoutHandle !== null) {
+      clearTimeout(this.qrTimeoutHandle)
+      this.qrTimeoutHandle = null
+    }
+  }
+
+  private getSessionPath(): string {
+    return path.join(this.sessionsDir, this.channelConfigId || 'default')
+  }
+
+  private clearSessionFiles(): void {
+    const sessionPath = this.getSessionPath()
+    try {
+      fs.rmSync(sessionPath, { recursive: true, force: true })
+      console.info(`[whatsapp-baileys] Auth state eliminado: ${sessionPath}`)
+    } catch (err) {
+      console.error('[whatsapp-baileys] Error eliminando auth state:', err)
+    }
+  }
+
+  /**
+   * Normaliza un número de teléfono o JID a formato Baileys.
+   * Baileys usa JIDs: '5491112345678@s.whatsapp.net' para DMs
+   *                   'groupid@g.us' para grupos
+   */
+  private toJid(externalId: string): string {
+    if (externalId.includes('@')) return externalId  // ya es JID
+    // Número de teléfono → JID
+    const cleaned = externalId.replace(/[^0-9]/g, '')
+    return `${cleaned}@s.whatsapp.net`
+  }
+
+  /**
+   * Crea un logger pino silencioso para Baileys.
+   * En producción, cambiar el nivel a 'info' o usar pino real.
+   */
+  private makePinoLogger() {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pino = require('pino') as (opts: Record<string, unknown>) => unknown
+      return pino({ level: 'silent' })
+    } catch {
+      // Pino no instalado — Baileys usará console
+      return undefined
+    }
+  }
+}

--- a/apps/gateway/src/routes/whatsapp-baileys.ts
+++ b/apps/gateway/src/routes/whatsapp-baileys.ts
@@ -1,178 +1,159 @@
 /**
- * routes/whatsapp-baileys.ts — [F3a-22]
+ * routes/whatsapp-baileys.ts � Router Express para WhatsApp Baileys
+ * [F3a-22]
  *
- * Router Express para gestión de sesiones WhatsApp Baileys.
+ * Rutas:
+ *   GET  /gateway/whatsapp/:configId/qr         � SSE stream del QR
+ *   GET  /gateway/whatsapp/:configId/status      � estado del adapter
+ *   POST /gateway/whatsapp/:configId/connect     � conectar (lazy-connect)
+ *   POST /gateway/whatsapp/:configId/disconnect  � desconectar y limpiar
  *
- * Endpoints:
- *   GET  /:configId/qr         → SSE stream (eventos: qr, status, heartbeat)
- *   GET  /:configId/status     → JSON snapshot {status, hasQr}
- *   POST /:configId/connect    → crea adapter, inicia setup() → connect()
- *   POST /:configId/disconnect → dispose() + elimina del store
+ * Autenticaci�n:
+ *   Las rutas est�n bajo /gateway/whatsapp que el security middleware
+ *   protege con JWT (X-Gateway-Token). Ver security.middleware.ts.
+ *   En desarrollo con REQUIRE_AUTH=false, las rutas son accesibles sin token.
  *
- * SECURITY: Estas rutas son públicas (sin X-Gateway-Token).
- * El flujo QR/connect requiere que el cliente pueda alcanzarlas sin
- * cabeceras de autenticación. Proteger a nivel de red/firewall si es necesario.
+ * SSE (Server-Sent Events):
+ *   El endpoint /qr usa el protocolo SSE est�ndar:
+ *     Content-Type: text/event-stream
+ *     Cache-Control: no-cache
+ *     Connection: keep-alive
+ *
+ *   Formato de los eventos:
+ *     event: qr
+ *     data: <qr-string>\n\n
+ *     event: state
+ *     data: <connecting|qr|open|closed|reconnecting>\n\n
+ *     event: heartbeat
+ *     data: ok\n\n
+ *
+ *   El cliente puede parsear el QR string con la librer�a 'qrcode' para
+ *   renderizarlo como imagen en el browser.
  */
 
 import { Router, type Request, type Response } from 'express'
-import { whatsappSessionStore }                from '../whatsapp-session.store.js'
+import { whatsappSessionStore } from '../whatsapp-session.store.js'
+import { type SseEvent } from '../whatsapp-session.store.js'
 
-type BaileysAdapterConstructable = new () => {
-  readonly channel: string
-  initialize(configId: string): void
-  onQr(handler: (qr: string) => void): void
-  onConnected(handler: () => void): void
-  onDisconnected(handler: () => void): void
-  setup(config: Record<string, unknown>, secrets: Record<string, unknown>): Promise<void>
-  dispose(): Promise<void>
+const SSE_HEARTBEAT_INTERVAL_MS = 20_000
+
+function formatSseEvent(event: SseEvent): string {
+  const data = typeof event.data === 'string' ? event.data : JSON.stringify(event.data)
+  return `event: ${event.type}\ndata: ${data}\n\n`
 }
 
-export const whatsappBaileysRouter = Router({ mergeParams: true })
+export function whatsappBaileysRouter(
+  store = whatsappSessionStore,
+): Router {
+  const router = Router()
 
-// ── GET /:configId/qr — SSE ───────────────────────────────────────────────────
-//
-// Requiere que POST /:configId/connect haya sido llamado primero.
-// Si no existe sesión, devuelve 404 en lugar de crear una entrada vacía
-// con adapter=null que nunca producirá eventos QR reales.
+  router.get('/:configId/qr', async (req: Request, res: Response) => {
+    const { configId } = req.params as { configId: string }
 
-whatsappBaileysRouter.get('/:configId/qr', (req: Request, res: Response): void => {
-  const { configId } = req.params as { configId: string }
+    res.setHeader('Content-Type', 'text/event-stream')
+    res.setHeader('Cache-Control', 'no-cache')
+    res.setHeader('Connection', 'keep-alive')
+    res.setHeader('X-Accel-Buffering', 'no')
+    res.flushHeaders()
 
-  if (!whatsappSessionStore.has(configId)) {
-    res.status(404).json({
-      error: `No active session for configId="${configId}". Call POST /:configId/connect first.`,
+    if (!store.has(configId)) {
+      await store.getOrCreate(configId, {}, {})
+    }
+
+    const subscriber = (event: SseEvent): void => {
+      if (res.writableEnded) return
+      res.write(formatSseEvent(event))
+    }
+
+    const unsubscribe = store.subscribe(configId, subscriber)
+
+    const heartbeatTimer = setInterval(() => {
+      if (res.writableEnded) {
+        clearInterval(heartbeatTimer)
+        return
+      }
+      try {
+        res.write(formatSseEvent({ type: 'heartbeat', data: 'ok' }))
+      } catch {
+        clearInterval(heartbeatTimer)
+      }
+    }, SSE_HEARTBEAT_INTERVAL_MS)
+
+    req.on('close', () => {
+      clearInterval(heartbeatTimer)
+      unsubscribe()
+      console.info(`[whatsapp-router] SSE client disconnected: configId=${configId}`)
     })
-    return
-  }
 
-  res.setHeader('Content-Type',      'text/event-stream')
-  res.setHeader('Cache-Control',     'no-cache')
-  res.setHeader('Connection',        'keep-alive')
-  res.setHeader('X-Accel-Buffering', 'no')
-  res.flushHeaders()
-
-  res.write(': connected\n\n')
-  whatsappSessionStore.addSseClient(configId, res)
-
-  const heartbeat = setInterval(() => {
-    try { res.write(':heartbeat\n\n') } catch { clearInterval(heartbeat) }
-  }, 25_000)
-
-  req.on('close', () => {
-    clearInterval(heartbeat)
+    console.info(`[whatsapp-router] SSE client connected: configId=${configId}`)
   })
-})
 
-// ── GET /:configId/status ─────────────────────────────────────────────────────
+  router.get('/:configId/status', (req: Request, res: Response) => {
+    const { configId } = req.params as { configId: string }
 
-whatsappBaileysRouter.get('/:configId/status', (req: Request, res: Response): void => {
-  const { configId } = req.params as { configId: string }
-
-  const entry = whatsappSessionStore.get(configId)
-  if (!entry) {
-    res.json({ status: 'not_connected', hasQr: false, configId })
-    return
-  }
-  res.json({
-    ok:     true,
-    configId,
-    status: entry.status ?? 'unknown',
-    hasQr:  Boolean(entry.qrBuffer),
-  })
-})
-
-// ── POST /:configId/connect ───────────────────────────────────────────────────
-
-whatsappBaileysRouter.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
-  const { configId } = req.params as { configId: string }
-
-  // Idempotency guard — evita race conditions y doble-connect
-  const existing = whatsappSessionStore.get(configId)
-  if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
-    res.status(409).json({
-      ok:     false,
-      error:  'session already active',
-      configId,
-      status: existing.status,
-    })
-    return
-  }
-
-  try {
-    // Reservar slot antes del primer await para bloquear llamadas concurrentes
-    whatsappSessionStore.setStatus(configId, 'connecting')
-
-    let AdapterClass: BaileysAdapterConstructable
-    try {
-      const mod = await import('../channels/whatsapp-baileys.adapter.js') as any
-      AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
-    } catch {
-      whatsappSessionStore.setStatus(configId, 'error')
-      res.status(503).json({
-        ok:    false,
-        error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys',
+    const statuses = store.getStatus(configId)
+    if (statuses.length === 0) {
+      res.status(404).json({
+        ok: false,
+        error: `No session found for configId=${configId}`,
       })
       return
     }
 
-    const adapter = new AdapterClass()
-    adapter.initialize(configId)
+    res.json({ ok: true, session: statuses[0] })
+  })
 
-    adapter.onQr((qr: string) => {
-      console.info(`[wa-route] QR received for configId=${configId}`)
-      whatsappSessionStore.setQr(configId, qr)
-    })
+  router.get('/sessions', (_req: Request, res: Response) => {
+    res.json({ ok: true, sessions: store.getStatus() })
+  })
 
-    adapter.onConnected(() => {
-      console.info(`[wa-route] Connected configId=${configId}`)
-      whatsappSessionStore.setStatus(configId, 'connected')
-    })
-
-    adapter.onDisconnected(() => {
-      console.info(`[wa-route] Disconnected configId=${configId}`)
-      whatsappSessionStore.setStatus(configId, 'disconnected')
-    })
-
-    whatsappSessionStore.setAdapter(configId, adapter)
-
-    const { config = {}, secrets = {} } = (req.body ?? {}) as {
-      config?:  Record<string, unknown>
+  router.post('/:configId/connect', async (req: Request, res: Response) => {
+    const { configId } = req.params as { configId: string }
+    const { config = {}, secrets = {} } = req.body as {
+      config?: Record<string, unknown>
       secrets?: Record<string, unknown>
     }
 
-    // Fire-and-forget: setup() → connect() internamente
-    adapter.setup(config, secrets).catch((err: Error) => {
-      console.error(`[wa-route] setup() error — configId=${configId}:`, err.message)
-      whatsappSessionStore.setStatus(configId, 'error')
-    })
+    try {
+      const adapter = await store.getOrCreate(configId, config, secrets)
 
-    res.status(202).json({ ok: true, status: 'connecting', configId })
-  } catch (err: any) {
-    const msg = err instanceof Error ? err.message : String(err)
-    whatsappSessionStore.setStatus(configId, 'error')
-    console.error(`[wa-route] connect error — configId=${configId}:`, msg)
-    res.status(500).json({ ok: false, error: msg })
-  }
-})
+      if (adapter.getState() === 'open') {
+        res.json({ ok: true, message: 'Already connected', state: adapter.getState() })
+        return
+      }
 
-// ── POST /:configId/disconnect ────────────────────────────────────────────────
+      adapter.connect().catch((err: unknown) => {
+        console.error(`[whatsapp-router] connect() error configId=${configId}:`, err)
+      })
 
-whatsappBaileysRouter.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
-  const { configId } = req.params as { configId: string }
+      res.json({
+        ok: true,
+        message: 'Connection initiated � subscribe to SSE /qr for QR code',
+        state: adapter.getState(),
+        sseUrl: `/gateway/whatsapp/${configId}/qr`,
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      res.status(500).json({ ok: false, error: msg })
+    }
+  })
 
-  const entry = whatsappSessionStore.get(configId)
-  if (!entry || !entry.adapter) {
-    res.status(404).json({ ok: false, error: 'session not found', configId })
-    return
-  }
+  router.post('/:configId/disconnect', async (req: Request, res: Response) => {
+    const { configId } = req.params as { configId: string }
 
-  try {
-    await entry.adapter.dispose()
-  } catch (err: any) {
-    const msg = err instanceof Error ? err.message : String(err)
-    console.warn(`[wa-route] dispose() error — configId=${configId}:`, msg)
-  }
+    if (!store.has(configId)) {
+      res.status(404).json({ ok: false, error: `No active session for configId=${configId}` })
+      return
+    }
 
-  whatsappSessionStore.remove(configId)
-  res.json({ ok: true, configId })
-})
+    try {
+      await store.remove(configId)
+      res.json({ ok: true, message: `Session ${configId} disconnected and removed` })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      res.status(500).json({ ok: false, error: msg })
+    }
+  })
+
+  return router
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,146 +1,70 @@
 /**
- * server.ts — Gateway Express Application
- *
- * Monta todos los routers de canal y expone:
- *
- *   GET  /healthz
- *
- *   — WebChat (browser ↔ agente) —
- *   GET  /gateway/webchat/:channelId/stream
- *   POST /gateway/webchat/:channelId/message
- *   GET  /gateway/webchat/:channelId/history
- *   POST /gateway/webchat/:channelId/session
- *
- *   — Telegram —
- *   POST /gateway/telegram/:channelId
- *
- *   — Slack —
- *   POST /gateway/slack/:channelId
- *
- *   — Webhook genérico —
- *   POST /gateway/webhook/:channelId
- *   GET  /gateway/webhook/:channelId/health
- *
- *   — WhatsApp Baileys —
- *   GET  /gateway/whatsapp/:configId/qr         (SSE — PÚBLICO)
- *   GET  /gateway/whatsapp/:configId/status
- *   POST /gateway/whatsapp/:configId/connect
- *   POST /gateway/whatsapp/:configId/disconnect
- *
- *   — Discord (HTTP interactions) —
- *   POST /gateway/discord/:configId             (webhook — PÚBLICO)
- *
- *   — API interna (JWT requerida) —
- *   POST /api/webchat/:channelId/reply
- *   *    /api/channels/...
- *
- * Inspirado en Flowise Server y n8n WebhookServer.
+ * server.ts � Express app factory del Gateway
  */
 
+import path from 'path';
 import express, { type Application } from 'express';
-import type { PrismaClient }          from '@prisma/client';
-import { PrismaService }              from './prisma/prisma.service.js';
-import { AgentResolverService }       from './agent-resolver.service.js';
-import { GatewayService }             from './gateway.service.js';
-import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat.js';
-import { telegramRouter }             from './routes/telegram.js';
-import { slackRouter }                from './routes/slack.js';
-import { webhookRouter }              from './routes/webhook.js';
-import { channelsApiRouter }          from './routes/channels.js';
-import { whatsappBaileysRouter }      from './routes/whatsapp-baileys.js';
-
-// ---------------------------------------------------------------------------
-// AppOptions — permite inyectar mocks en tests
-// ---------------------------------------------------------------------------
+import { PrismaClient } from '@prisma/client';
+import { applySecurityMiddleware } from './middleware/security.middleware';
+import { GatewayService } from './gateway.service';
+import { telegramRouter } from './routes/telegram';
+import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat';
+import { channelsApiRouter } from './routes/channels';
+import { whatsappBaileysRouter } from './routes/whatsapp-baileys';
 
 export interface AppOptions {
-  /** PrismaService o mock compatible con PrismaClient (testing) */
-  db?: PrismaService | PrismaClient;
+  db?: PrismaClient;
+  corsOrigins?: string | string[];
+  requireAuth?: boolean;
 }
-
-// ---------------------------------------------------------------------------
-// createApp
-// ---------------------------------------------------------------------------
 
 export function createApp(opts: AppOptions = {}): Application {
   const app = express();
+  const db = opts.db ?? new PrismaClient();
 
-  // Instanciar PrismaService (o usar el mock inyectado)
-  const db = (opts.db ?? new PrismaService()) as PrismaService;
-
-  // GatewayService recibe PrismaService + AgentResolverService
-  const resolver       = new AgentResolverService(db);
-  const gatewayService = new GatewayService(db, resolver);
-
-  // -------------------------------------------------------------------------
-  // 0. Core middleware
-  // -------------------------------------------------------------------------
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
-
-  // -------------------------------------------------------------------------
-  // 1. Security headers
-  // -------------------------------------------------------------------------
-  app.use((_req, res, next) => {
-    res.setHeader('X-Content-Type-Options', 'nosniff');
-    res.setHeader('X-Frame-Options', 'DENY');
-    next();
+  applySecurityMiddleware(app, {
+    corsOrigins: opts.corsOrigins,
+    requireAuth: opts.requireAuth ?? process.env.REQUIRE_AUTH === 'true',
+    webhookRateLimit: 600,
+    apiRateLimit: 120,
   });
 
-  // -------------------------------------------------------------------------
-  // 2. Health check
-  // -------------------------------------------------------------------------
-  app.get('/healthz', (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
+  app.use(express.json({ limit: '2mb' }));
 
-  // -------------------------------------------------------------------------
-  // 3. Gateway public routes
-  // -------------------------------------------------------------------------
-  app.use('/gateway/webchat',  webchatGatewayRouter(gatewayService));
+  const publicDir = path.join(__dirname, '..', 'public');
+  app.use('/static', express.static(publicDir, {
+    maxAge: process.env.NODE_ENV === 'production' ? '1d' : 0,
+    etag: true,
+  }));
+
+  app.get('/webchat-widget.js', (_req, res) => {
+    res.sendFile(path.join(publicDir, 'webchat-widget.js'));
+  });
+
+  const gatewayService = new GatewayService(db);
+
+  app.get('/health', (_req, res) => {
+    res.json({ ok: true, service: 'gateway', ts: new Date().toISOString() });
+  });
+
   app.use('/gateway/telegram', telegramRouter(gatewayService));
-  app.use('/gateway/slack',    slackRouter(gatewayService));
-  app.use('/gateway/webhook',  webhookRouter(gatewayService));
-
-  // NOTE: /gateway/whatsapp routes are intentionally PUBLIC — no JWT required.
-  // applySecurityMiddleware() only secures /api/* routes. WhatsApp QR/connect/
-  // disconnect callbacks must be reachable without auth headers from mobile
-  // devices and Meta webhooks. Protect at network/firewall level if needed.
-  app.use('/gateway/whatsapp', whatsappBaileysRouter);
-
-  // NOTE: /gateway/discord is intentionally PUBLIC — Discord verifies each
-  // request via Ed25519 signature (DiscordAdapter._verifySignature).
-  // No additional auth middleware needed here.
-  app.use('/gateway/discord', (() => {
-    // Lazy-mount DiscordAdapter HTTP router. The adapter instance is managed
-    // by the channel registry; here we mount it by convention.
-    // ChannelRouter duck-types: if ('getRouter' in adapter) app.use(...)
-    const router = express.Router();
-    router.use('/:configId', async (req, res, next) => {
-      try {
-        const { DiscordAdapter } = await import('./channels/discord.adapter.js') as any;
-        const adapter = new DiscordAdapter();
-        adapter.initialize(req.params['configId']);
-        // Setup with empty config — adapter reads publicKey from secrets at runtime
-        const channelRouter = adapter.buildHttpRouter();
-        channelRouter(req, res, next);
-      } catch (err) {
-        next(err);
-      }
-    });
-    return router;
-  })());
-
-  // -------------------------------------------------------------------------
-  // 4. Internal API routes (JWT middleware a aplicar aquí si se requiere)
-  // -------------------------------------------------------------------------
-  app.use('/api/webchat',  webchatApiRouter(gatewayService));
+  app.use('/gateway/webchat', webchatGatewayRouter(gatewayService));
+  app.use('/gateway/whatsapp', whatsappBaileysRouter());
+  app.use('/api/webchat', webchatApiRouter(gatewayService));
   app.use('/api/channels', channelsApiRouter(db, gatewayService));
 
-  // -------------------------------------------------------------------------
-  // 5. 404 fallback
-  // -------------------------------------------------------------------------
   app.use((_req, res) => {
-    res.status(404).json({ ok: false, error: 'Not found' });
+    res.status(404).json({ ok: false, error: 'Route not found' });
   });
 
   return app;
+}
+
+if (require.main === module) {
+  const PORT = Number(process.env.PORT ?? 3200);
+  const app = createApp();
+
+  app.listen(PORT, () => {
+    console.info(`[gateway] listening on port ${PORT}`);
+  });
 }

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,225 +1,156 @@
 /**
- * whatsapp-session.store.ts — [F3a-22]
- *
- * Store en memoria para sesiones WhatsApp Baileys.
- *
- * Cada entrada guarda:
- *   - adapter?  : instancia activa del WhatsAppBaileysAdapter (opcional hasta
- *                 que POST /connect lo registre)
- *   - qrBuffer  : último QR recibido (PNG base64 data-url o cadena qr raw)
- *   - status    : 'connecting' | 'qr_ready' | 'connected' | 'disconnected' | 'error'
- *   - sseClients: lista de Response (SSE) suscritos al QR de este configId
- *
- * El store es un singleton exportado — todos los routers comparten la
- * misma instancia sin necesidad de inyección de dependencias.
- *
- * Fix aplicado: getOrCreate() ya no setea adapter=null — el adapter es opcional
- * en SessionEntry. setAdapter() crea la entrada si no existe y marca 'connecting'.
+ * whatsapp-session.store.ts � Store en memoria para sesiones WhatsApp Baileys
+ * [F3a-22]
  */
 
-import type { Response } from 'express'
+import { WhatsAppBaileysAdapter, type WhatsAppAdapterState } from './channels/whatsapp-baileys.adapter.js'
 
-// ── Tipos ────────────────────────────────────────────────────────────────────
+export type SseEvent =
+  | { type: 'qr'; data: string }
+  | { type: 'state'; data: WhatsAppAdapterState }
+  | { type: 'heartbeat'; data: string }
 
-export type WhatsAppSessionStatus =
-  | 'connecting'
-  | 'qr_ready'
-  | 'connected'
-  | 'disconnected'
-  | 'error'
+export type SseSubscriber = (event: SseEvent) => void
 
-/**
- * Contrato mínimo que debe cumplir el adapter para ser almacenado.
- * Evita importar WhatsAppBaileysAdapter directamente y crear
- * dependencias circulares — el adapter real se pasa en tiempo de ejecución.
- */
-export interface IWhatsAppAdapter {
-  readonly channel: string
-  state?: string
-  onQr?: (handler: (qr: string) => void) => void
-  onConnected?: (handler: () => void) => void
-  onDisconnected?: (handler: () => void) => void
-  logout?: () => Promise<void>
-  dispose(): Promise<void>
+interface SessionEntry {
+  adapter: WhatsAppBaileysAdapter
+  latestQr: string | null
+  subscribers: Set<SseSubscriber>
 }
 
-export interface SessionEntry {
-  adapter?:   IWhatsAppAdapter       // undefined hasta que POST /connect lo registre
-  qrBuffer:   string | null          // data-url PNG o cadena QR raw
-  status:     WhatsAppSessionStatus
-  sseClients: Set<Response>          // clientes SSE activos suscritos al QR
+export interface SessionStatus {
+  configId: string
+  state: WhatsAppAdapterState
+  hasQr: boolean
+  subscribers: number
 }
-
-// ── Store ────────────────────────────────────────────────────────────────────
 
 export class WhatsAppSessionStore {
   private readonly sessions = new Map<string, SessionEntry>()
 
-  // ── CRUD ──────────────────────────────────────────────────────────────────
+  async getOrCreate(
+    configId: string,
+    config: Record<string, unknown> = {},
+    secrets: Record<string, unknown> = {},
+  ): Promise<WhatsAppBaileysAdapter> {
+    const existing = this.sessions.get(configId)
+    if (existing) return existing.adapter
 
-  /**
-   * Recupera la sesión existente o crea una nueva entrada vacía (sin adapter).
-   * El adapter se registra después con setAdapter().
-   *
-   * Fix: NO rellena adapter con null — adapter es opcional hasta que
-   *      setAdapter() lo registre. Esto evita que el QR endpoint cree
-   *      entradas con adapter vacío que nunca producen eventos reales.
-   */
-  getOrCreate(configId: string): SessionEntry {
-    if (!this.sessions.has(configId)) {
-      this.sessions.set(configId, {
-        qrBuffer:   null,
-        status:     'disconnected',
-        sseClients: new Set(),
-      })
+    const adapter = new WhatsAppBaileysAdapter()
+    ;(adapter as unknown as Record<string, unknown>)['channelConfigId'] = configId
+
+    await adapter.setup(config, secrets)
+
+    const entry: SessionEntry = {
+      adapter,
+      latestQr: null,
+      subscribers: new Set(),
     }
-    return this.sessions.get(configId)!
+
+    this.sessions.set(configId, entry)
+
+    adapter.onQr((qr) => {
+      entry.latestQr = qr
+      this.fanOut(configId, { type: 'qr', data: qr })
+    })
+
+    adapter.onStateChange((state) => {
+      if (state === 'open' || state === 'closed') {
+        entry.latestQr = null
+      }
+      this.fanOut(configId, { type: 'state', data: state })
+    })
+
+    adapter.onError((err) => {
+      console.error(`[whatsapp-store] Error en adapter configId=${configId}:`, err.message)
+    })
+
+    console.info(`[whatsapp-store] Sesi�n creada (lazy) para configId=${configId}`)
+    return adapter
   }
 
-  get(configId: string): SessionEntry | undefined {
-    return this.sessions.get(configId)
+  subscribe(configId: string, subscriber: SseSubscriber): () => void {
+    const entry = this.sessions.get(configId)
+    if (!entry) {
+      console.warn(`[whatsapp-store] subscribe() llamado para configId=${configId} inexistente`)
+      return () => {}
+    }
+
+    entry.subscribers.add(subscriber)
+
+    if (entry.latestQr) {
+      try {
+        subscriber({ type: 'qr', data: entry.latestQr })
+      } catch (err) {
+        console.warn('[whatsapp-store] Error enviando QR buffered:', err)
+      }
+    }
+
+    try {
+      subscriber({ type: 'state', data: entry.adapter.getState() })
+    } catch {
+      /* cliente ya desconectado */
+    }
+
+    return () => {
+      entry.subscribers.delete(subscriber)
+    }
+  }
+
+  async remove(configId: string): Promise<void> {
+    const entry = this.sessions.get(configId)
+    if (!entry) return
+
+    try {
+      await entry.adapter.dispose()
+    } catch (err) {
+      console.error(`[whatsapp-store] Error en dispose para configId=${configId}:`, err)
+    }
+
+    this.fanOut(configId, { type: 'state', data: 'closed' })
+    this.sessions.delete(configId)
+    console.info(`[whatsapp-store] Sesi�n eliminada para configId=${configId}`)
+  }
+
+  getStatus(configId?: string): SessionStatus[] {
+    if (configId) {
+      const entry = this.sessions.get(configId)
+      if (!entry) return []
+      return [this.toStatus(configId, entry)]
+    }
+    return Array.from(this.sessions.entries()).map(([id, entry]) => this.toStatus(id, entry))
   }
 
   has(configId: string): boolean {
     return this.sessions.has(configId)
   }
 
-  /**
-   * Registra el adapter activo para un configId.
-   * Crea la entrada si no existe y marca la sesión como 'connecting'.
-   */
-  setAdapter(configId: string, adapter: IWhatsAppAdapter): void {
-    const entry = this.getOrCreate(configId)
-    entry.adapter = adapter
-    entry.status  = 'connecting'
+  get(configId: string): WhatsAppBaileysAdapter | null {
+    return this.sessions.get(configId)?.adapter ?? null
   }
 
-  /**
-   * Guarda el QR más reciente y notifica a todos los clientes SSE suscritos.
-   */
-  setQr(configId: string, qr: string): void {
+  private fanOut(configId: string, event: SseEvent): void {
     const entry = this.sessions.get(configId)
-    if (!entry) return
-    entry.qrBuffer = qr
-    entry.status   = 'qr_ready'
-    this.broadcastSse(entry, { event: 'qr', data: qr })
-  }
+    if (!entry || entry.subscribers.size === 0) return
 
-  /**
-   * Actualiza el estado de la sesión y notifica a los clientes SSE.
-   * Si status es 'connecting' y la entrada no existe, la crea
-   * (para reservar el slot antes del primer await en /connect).
-   */
-  setStatus(configId: string, status: WhatsAppSessionStatus): void {
-    if (status === 'connecting' && !this.sessions.has(configId)) {
-      this.sessions.set(configId, {
-        qrBuffer:   null,
-        status:     'connecting',
-        sseClients: new Set(),
-      })
-      return
-    }
-    const entry = this.sessions.get(configId)
-    if (!entry) return
-    entry.status = status
-    if (status === 'connected') {
-      entry.qrBuffer = null   // QR ya no es relevante
-    }
-    this.broadcastSse(entry, { event: 'status', data: status })
-  }
-
-  /**
-   * Elimina la sesión del store.
-   * Cierra todos los streams SSE pendientes antes de borrar.
-   */
-  remove(configId: string): void {
-    const entry = this.sessions.get(configId)
-    if (!entry) return
-    for (const client of entry.sseClients) {
-      try { client.end() } catch { /* ya cerrado */ }
-    }
-    entry.sseClients.clear()
-    this.sessions.delete(configId)
-  }
-
-  /**
-   * Alias semántico de remove() para el flujo de deprovision.
-   * destroy() = remove() + logging explícito.
-   */
-  destroy(configId: string): void {
-    console.info(`[wa-session-store] Destroying session: ${configId}`)
-    this.remove(configId)
-  }
-
-  // ── SSE client management ─────────────────────────────────────────────────
-
-  /**
-   * Registra un cliente SSE (Response de Express) para recibir
-   * eventos QR y de estado de este configId.
-   *
-   * Si ya hay un QR en buffer, lo envía inmediatamente para que
-   * el cliente no tenga que esperar al siguiente ciclo.
-   */
-  addSseClient(configId: string, res: Response): void {
-    const entry = this.getOrCreate(configId)
-    entry.sseClients.add(res)
-
-    // Enviar estado e QR actuales de inmediato
-    this.sendSseEvent(res, { event: 'status', data: entry.status })
-    if (entry.qrBuffer) {
-      this.sendSseEvent(res, { event: 'qr', data: entry.qrBuffer })
-    }
-
-    // Limpiar al cerrar la conexión
-    res.on('close', () => {
-      entry.sseClients.delete(res)
-    })
-  }
-
-  /**
-   * Elimina un cliente SSE específico del set de un configId.
-   * Útil para cleanup explícito en tests o en el route handler.
-   */
-  removeSseClient(configId: string, res: Response): void {
-    const entry = this.sessions.get(configId)
-    if (!entry) return
-    entry.sseClients.delete(res)
-  }
-
-  // ── Helpers SSE ───────────────────────────────────────────────────────────
-
-  private broadcastSse(
-    entry:   SessionEntry,
-    payload: { event: string; data: string },
-  ): void {
-    for (const client of entry.sseClients) {
-      this.sendSseEvent(client, payload)
+    for (const subscriber of entry.subscribers) {
+      try {
+        subscriber(event)
+      } catch (err) {
+        console.warn('[whatsapp-store] Suscriptor roto, eliminando:', err)
+        entry.subscribers.delete(subscriber)
+      }
     }
   }
 
-  private sendSseEvent(
-    res:     Response,
-    payload: { event: string; data: string },
-  ): void {
-    try {
-      res.write(`event: ${payload.event}\ndata: ${payload.data}\n\n`)
-    } catch {
-      /* cliente ya desconectado — se limpiará en el handler 'close' */
+  private toStatus(configId: string, entry: SessionEntry): SessionStatus {
+    return {
+      configId,
+      state: entry.adapter.getState(),
+      hasQr: entry.latestQr !== null,
+      subscribers: entry.subscribers.size,
     }
-  }
-
-  // ── Debug ─────────────────────────────────────────────────────────────────
-
-  /** Lista de configIds con adapter activo (útil para health/debug). */
-  activeSessions(): string[] {
-    return [...this.sessions.entries()]
-      .filter(([, entry]) => !!entry.adapter)
-      .map(([configId]) => configId)
   }
 }
 
-/** Tipo exportado para inyección en WhatsAppDeprovisionService y tests */
-export type WhatsAppSessionStore_t = WhatsAppSessionStore
-
-/** Singleton exportado */
 export const whatsappSessionStore = new WhatsAppSessionStore()


### PR DESCRIPTION
Closes #43

<html> <body> <!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">? <strong>Implementaci?n F3a-21 completada y pusheada.</strong></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="resumen-de-la-implementacin">Resumen de la implementaci?n</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>?? Commit SHA:</strong> <code>bded77b4ede0d011fd3531f9171ac647b523d763</code><br><strong>Branch:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-21-whatsapp-baileys"><span class="text-box-trim-both"><code>feat/F3a-21-whatsapp-baileys</code></span></a></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-entregados-en-este-commit">Archivos entregados en este commit</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>1. <code>apps/gateway/package.json</code></strong> ? Dependencias a?adidas:</p><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>@whiskeysockets/baileys: ^6.7.9</code> ? protocolo WA Web</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>pino: ^9.4.0</code> ? logger requerido por Baileys</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>overrides.ws: ^8.18.0</code> ? resuelve conflicto de peer deps ESM en monorepo</p></li></ul><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>2. <code>apps/gateway/.gitignore</code></strong> ? Nueva entrada:</p><div class="w-full md:max-w-[90vw]"><pre class="not-prose w-full rounded font-mono text-sm font-extralight"><div class="codeWrapper bg-subtle text-light selection:text-super selection:bg-super/10 my-md relative flex flex-col rounded-lg font-mono text-sm font-medium"><div class="translate-y-xs -translate-x-xs bottom-xl mb-xl flex h-0 items-start justify-end sm:sticky sm:top-xs"><div class="overflow-hidden border-subtlest ring-subtlest divide-subtlest bg-base rounded-full"><div class="border-subtlest ring-subtlest divide-subtlest bg-subtle"><button data-testid="copy-code-button" aria-label="Copiar c?digo" type="button" class="focus-visible:bg-quiet hover:bg-quiet text-quiet hover:text-foreground font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-full cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-square" data-state="closed"><div class="flex items-center min-w-0 gap-two justify-center"><div class="flex shrink-0 items-center justify-center size-4"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div></div></button></div></div></div><div class="-mt-xl"><div><div data-testid="code-language-indicator" class="text-quiet bg-quiet py-xs px-sm inline-block rounded-br rounded-tl-lg text-xs font-thin">text</div></div><div><span style="font-size: inherit; font-family: inherit; background: transparent; color: rgb(214, 208, 200); border-radius: 3px; display: flex; line-height: 1.42857; overflow-x: auto; white-space: pre; --scrollbar-thumb: oklch(var(--foreground-color) / 0.15); --scrollbar-track: transparent; scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);"><code style="white-space: pre-wrap; font-size: inherit; font-family: inherit; line-height: 1.66667; padding: 8px;"><span style="opacity: 1; font-size: inherit; line-height: 1.42857; color: rgb(214, 208, 200); background-color: transparent; flex-shrink: 0; padding: 8px; text-align: right; user-select: none;"><span>data/wa-sessions/   # Auth state de Baileys ? NUNCA commitear</span></span></code></span></div></div></div></pre></div><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>3. <code>apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.test.ts</code></strong> ? Suite completa =22 tests:</p><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised"> Grupo | Tests cubiertos -- | -- receive() | DM texto/imagen/audio/archivo/comando; grupo con participante; status@broadcast ignorado; fromMe ignorado; rawPayload sanitizado; replyFn definida; null cuando no hay key/message replyFn() | sendMessage con jid correcto; quoteOriginal ? content.quoted; richContent fusionado send() | N?mero normalizado a JID; JID completo sin modificar; richContent pasado; lanza si sock=null connect() / getState() | Estado inicial idle; idempotente en open; deduplica llamadas paralelas v?a connectPromise QR flow | Emisi?n evento qr; timeout 120s cierra socket y emite error; transiciones idle?connecting?qr Reconexi?n backoff | 1er intento a 1s; 2do intento a 2s (exponencial); maxAttempts ? closed + errorHandler; logout 401 limpia sesi?n sin reconectar dispose() | Cierra socket; cancela QR timeout; idle sin error; durante reconexi?n cancela loop setup() | No conecta (lazy); respeta WA_SESSIONS_DIR env; respeta maxReconnectAttempts config  </div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div></div></body></html><!--EndFragment--> </body> </html>? **Implementaci?n F3a-21 completada y pusheada.**  ***  ## Resumen de la implementaci?n  **?? Commit SHA:** `bded77b4ede0d011fd3531f9171ac647b523d763` **Branch:** [`[feat/F3a-21-whatsapp-baileys](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-21-whatsapp-baileys)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-21-whatsapp-baileys)  ***  ### Archivos entregados en este commit  **1. `apps/gateway/package.json`** ? Dependencias a?adidas: - `@whiskeysockets/baileys: ^6.7.9` ? protocolo WA Web - `pino: ^9.4.0` ? logger requerido por Baileys - `overrides.ws: ^8.18.0` ? resuelve conflicto de peer deps ESM en monorepo  **2. `apps/gateway/.gitignore`** ? Nueva entrada: ``` data/wa-sessions/   # Auth state de Baileys ? NUNCA commitear ```  **3. `apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.test.ts`** ? Suite completa =22 tests:  | Grupo | Tests cubiertos | |---|---| | `receive()` | DM texto/imagen/audio/archivo/comando; grupo con participante; status@broadcast ignorado; fromMe ignorado; rawPayload sanitizado; replyFn definida; null cuando no hay key/message | | `replyFn()` | sendMessage con jid correcto; quoteOriginal ? `content.quoted`; richContent fusionado | | `send()` | N?mero normalizado a JID; JID completo sin modificar; richContent pasado; lanza si sock=null | | `connect() / getState()` | Estado inicial idle; idempotente en open; deduplica llamadas paralelas v?a `connectPromise` | | `QR flow` | Emisi?n evento qr; timeout 120s cierra socket y emite error; transiciones idle?connecting?qr | | `Reconexi?n backoff` | 1er intento a 1s; 2do intento a 2s (exponencial); maxAttempts ? closed + errorHandler; logout 401 limpia sesi?n sin reconectar | | `dispose()` | Cierra socket; cancela QR timeout; idle sin error; durante reconexi?n cancela loop | | `setup()` | No conecta (lazy); respeta `WA_SESSIONS_DIR` env; respeta `maxReconnectAttempts` config |  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp adapter with QR pairing, session lifecycle, and reconnection; Telegram gateway end-to-end dispatch tests.

* **Improvements**
  * Session store and router refactor for subscription-based SSE, session listing, and async session management.
  * Gateway server refactor: /health endpoint, static hosting, tightened middleware and body limits.
  * Channel lifecycle now uses atomic status transitions for start/stop.

* **Chores**
  * Gateway env example, .gitignore, and runtime dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->