### PR TITLE
feat(F3a-22): persist WhatsApp session by configId and expose QR via SSE

### DIFF
--- a/apps/gateway/src/routes/whatsapp-baileys.ts
+++ b/apps/gateway/src/routes/whatsapp-baileys.ts
@@ -1,0 +1,232 @@
+/**
+ * routes/whatsapp-baileys.ts — [F3a-22]
+ *
+ * Router Express para gestionar sesiones WhatsApp Baileys:
+ *
+ *   GET  /gateway/whatsapp/:configId/qr          — SSE: emite eventos 'qr' y 'status'
+ *   GET  /gateway/whatsapp/:configId/status       — JSON: {status, hasQr, configId}
+ *   POST /gateway/whatsapp/:configId/connect      — Inicia adaptador y lo registra en el store
+ *   POST /gateway/whatsapp/:configId/disconnect   — Detiene adaptador y lo elimina del store
+ *
+ * El QR se transmite como SSE (text/event-stream) en lugar de WebSocket:
+ *   - El QR se escanea una sola vez por sesión.
+ *   - HTTP unidireccional — no requiere upgrade, funciona detrás de cualquier proxy.
+ *   - Mismo patrón que ya usa webchat para el stream de mensajes.
+ *
+ * Formato de eventos SSE:
+ *   event: qr\ndata: <string QR raw o data-url PNG>\n\n
+ *   event: status\ndata: connecting|qr_ready|connected|disconnected|error\n\n
+ *
+ * Seguridad:
+ *   - Los endpoints POST requieren JWT (aplicado en server.ts via applySecurityMiddleware).
+ *   - El endpoint GET /qr es público para permitir embeber el visor de QR en la UI.
+ *     Si se necesita autenticar, añadir el middleware JWT antes de whatsappBaileysRouter.
+ */
+
+import { Router, type Request, type Response } from 'express'
+import { whatsappSessionStore }               from '../whatsapp-session.store.js'
+
+// ── Tipos mínimos del adapter (evita importación circular) ───────────────────
+
+/**
+ * Interfaz de construcción del adapter Baileys.
+ * El adapter real (WhatsAppBaileysAdapter) se importa dinámicamente
+ * para no forzar la dependencia @whiskeysockets/baileys en todos los tests.
+ */
+interface BaileysAdapterConstructable {
+  new (configId: string): {
+    readonly channel: string
+    onQr(handler: (qr: string) => void): void
+    onConnected(handler: () => void): void
+    onDisconnected(handler: () => void): void
+    setup(config: Record<string, unknown>, secrets: Record<string, unknown>): Promise<void>
+    dispose(): Promise<void>
+  }
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export function whatsappBaileysRouter(): Router {
+  const router = Router({ mergeParams: true })
+
+  // ── GET /:configId/qr — SSE stream ──────────────────────────────────────
+  /**
+   * Abre un stream SSE para recibir eventos de QR y estado.
+   *
+   * El cliente debe abrir:
+   *   const es = new EventSource('/gateway/whatsapp/<configId>/qr')
+   *   es.addEventListener('qr', e => renderQr(e.data))
+   *   es.addEventListener('status', e => updateStatus(e.data))
+   *
+   * La conexión permanece abierta hasta que el cliente la cierra
+   * o el adapter se desconecta (evento 'status': 'connected' | 'disconnected').
+   */
+  router.get('/:configId/qr', (req: Request, res: Response): void => {
+    const { configId } = req.params
+
+    res.setHeader('Content-Type',  'text/event-stream')
+    res.setHeader('Cache-Control', 'no-cache')
+    res.setHeader('Connection',    'keep-alive')
+    res.setHeader('X-Accel-Buffering', 'no') // desactivar buffering Nginx
+    res.flushHeaders()
+
+    // Comentario inicial para mantener la conexión viva en algunos proxies
+    res.write(': connected\n\n')
+
+    // Registrar este cliente en el store
+    // (si ya hay QR o estado, se envía inmediatamente dentro de addSseClient)
+    whatsappSessionStore.addSseClient(configId, res)
+
+    // Heartbeat cada 25s para evitar timeouts de proxy
+    const heartbeat = setInterval(() => {
+      try { res.write(': heartbeat\n\n') } catch { clearInterval(heartbeat) }
+    }, 25_000)
+
+    res.on('close', () => {
+      clearInterval(heartbeat)
+    })
+  })
+
+  // ── GET /:configId/status — JSON snapshot ───────────────────────────────
+  /**
+   * Retorna el estado actual de la sesión sin abrir un stream.
+   * Útil para polling inicial o health check de la UI.
+   *
+   * Response:
+   *   200 { ok: true,  configId, status, hasQr }
+   *   404 { ok: false, error: 'session not found' }
+   */
+  router.get('/:configId/status', (req: Request, res: Response): void => {
+    const { configId } = req.params
+    const entry = whatsappSessionStore.get(configId)
+
+    if (!entry) {
+      res.status(404).json({ ok: false, error: 'session not found', configId })
+      return
+    }
+
+    res.json({
+      ok:       true,
+      configId,
+      status:   entry.status,
+      hasQr:    !!entry.qrBuffer,
+    })
+  })
+
+  // ── POST /:configId/connect — Iniciar sesión ─────────────────────────────
+  /**
+   * Crea e inicializa un WhatsAppBaileysAdapter para este configId.
+   * Si ya existe una sesión activa para el mismo configId, retorna 409.
+   *
+   * Body (opcional):
+   *   { config?: Record<string,unknown>, secrets?: Record<string,unknown> }
+   *
+   * Response:
+   *   200 { ok: true, configId, status: 'connecting' }
+   *   409 { ok: false, error: 'session already active' }
+   *   500 { ok: false, error: string }
+   */
+  router.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
+    const { configId } = req.params
+    const existing = whatsappSessionStore.get(configId)
+
+    if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
+      res.status(409).json({
+        ok:    false,
+        error: 'session already active',
+        configId,
+        status: existing.status,
+      })
+      return
+    }
+
+    try {
+      // Importación dinámica — el adapter real puede no estar disponible en tests
+      let AdapterClass: BaileysAdapterConstructable
+      try {
+        const mod = await import('../channels/whatsapp.adapter.js')
+        AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
+      } catch {
+        // Fallback para entornos sin @whiskeysockets/baileys (tests, CI sin deps)
+        res.status(503).json({
+          ok:    false,
+          error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys',
+        })
+        return
+      }
+
+      const adapter = new AdapterClass(configId)
+
+      // Registrar callbacks ANTES de setup() para no perder el primer QR
+      adapter.onQr((qr: string) => {
+        console.info(`[whatsapp-store] QR received for configId=${configId}`)
+        whatsappSessionStore.setQr(configId, qr)
+      })
+
+      adapter.onConnected(() => {
+        console.info(`[whatsapp-store] Connected configId=${configId}`)
+        whatsappSessionStore.setStatus(configId, 'connected')
+      })
+
+      adapter.onDisconnected(() => {
+        console.info(`[whatsapp-store] Disconnected configId=${configId}`)
+        whatsappSessionStore.setStatus(configId, 'disconnected')
+      })
+
+      // Registrar en el store ANTES de setup() para que los callbacks
+      // ya tengan un entry donde escribir el QR
+      whatsappSessionStore.setAdapter(configId, adapter)
+      whatsappSessionStore.setStatus(configId, 'connecting')
+
+      const { config = {}, secrets = {} } = (req.body ?? {}) as {
+        config?:  Record<string, unknown>
+        secrets?: Record<string, unknown>
+      }
+
+      // setup() es async — no esperamos el QR aquí, llega vía callback
+      adapter.setup(config, secrets).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[whatsapp-store] setup() error for configId=${configId}:`, msg)
+        whatsappSessionStore.setStatus(configId, 'error')
+      })
+
+      res.json({ ok: true, configId, status: 'connecting' })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      res.status(500).json({ ok: false, error: msg })
+    }
+  })
+
+  // ── POST /:configId/disconnect — Detener sesión ──────────────────────────
+  /**
+   * Llama dispose() en el adapter y elimina la sesión del store.
+   * Cierra todos los streams SSE abiertos para este configId.
+   *
+   * Response:
+   *   200 { ok: true, configId }
+   *   404 { ok: false, error: 'session not found' }
+   *   500 { ok: false, error: string }
+   */
+  router.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
+    const { configId } = req.params
+    const entry = whatsappSessionStore.get(configId)
+
+    if (!entry) {
+      res.status(404).json({ ok: false, error: 'session not found', configId })
+      return
+    }
+
+    try {
+      await entry.adapter.dispose()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`[whatsapp-store] dispose() error for configId=${configId}:`, msg)
+      // No relanzamos — queremos limpiar el store igualmente
+    }
+
+    whatsappSessionStore.remove(configId)
+    res.json({ ok: true, configId })
+  })
+
+  return router
+}

--- a/apps/gateway/src/routes/whatsapp-baileys.ts
+++ b/apps/gateway/src/routes/whatsapp-baileys.ts
@@ -1,37 +1,24 @@
 /**
- * routes/whatsapp-baileys.ts — [F3a-22]
+ * routes/whatsapp-baileys.ts - [F3a-22]
  *
- * Router Express para gestionar sesiones WhatsApp Baileys:
+ * Express router for WhatsApp Baileys sessions:
  *
- *   GET  /gateway/whatsapp/:configId/qr          — SSE: emite eventos 'qr' y 'status'
- *   GET  /gateway/whatsapp/:configId/status       — JSON: {status, hasQr, configId}
- *   POST /gateway/whatsapp/:configId/connect      — Inicia adaptador y lo registra en el store
- *   POST /gateway/whatsapp/:configId/disconnect   — Detiene adaptador y lo elimina del store
+ *   GET  /gateway/whatsapp/:configId/qr          - SSE stream for QR/status
+ *   GET  /gateway/whatsapp/:configId/status      - JSON snapshot
+ *   POST /gateway/whatsapp/:configId/connect     - start adapter and register it
+ *   POST /gateway/whatsapp/:configId/disconnect  - stop adapter and remove it
  *
- * El QR se transmite como SSE (text/event-stream) en lugar de WebSocket:
- *   - El QR se escanea una sola vez por sesión.
- *   - HTTP unidireccional — no requiere upgrade, funciona detrás de cualquier proxy.
- *   - Mismo patrón que ya usa webchat para el stream de mensajes.
- *
- * Formato de eventos SSE:
- *   event: qr\ndata: <string QR raw o data-url PNG>\n\n
- *   event: status\ndata: connecting|qr_ready|connected|disconnected|error\n\n
- *
- * Seguridad:
- *   - Los endpoints POST requieren JWT (aplicado en server.ts via applySecurityMiddleware).
- *   - El endpoint GET /qr es público para permitir embeber el visor de QR en la UI.
- *     Si se necesita autenticar, añadir el middleware JWT antes de whatsappBaileysRouter.
+ * The QR stream is SSE so the UI can subscribe without WebSocket upgrades.
+ * Connect/disconnect/QR are protected with the existing Logto JWT middleware.
  */
 
 import { Router, type Request, type Response } from 'express'
-import { whatsappSessionStore }               from '../whatsapp-session.store.js'
-
-// ── Tipos mínimos del adapter (evita importación circular) ───────────────────
+import { logtoJwtMiddleware } from '../middleware/security.middleware.js'
+import { whatsappSessionStore } from '../whatsapp-session.store.js'
 
 /**
- * Interfaz de construcción del adapter Baileys.
- * El adapter real (WhatsAppBaileysAdapter) se importa dinámicamente
- * para no forzar la dependencia @whiskeysockets/baileys en todos los tests.
+ * Minimal constructor contract for the Baileys adapter.
+ * The real adapter is imported dynamically to avoid hard coupling in tests.
  */
 interface BaileysAdapterConstructable {
   new (configId: string): {
@@ -44,42 +31,28 @@ interface BaileysAdapterConstructable {
   }
 }
 
-// ── Factory ───────────────────────────────────────────────────────────────────
-
 export function whatsappBaileysRouter(): Router {
   const router = Router({ mergeParams: true })
+  const requireJwt = logtoJwtMiddleware()
 
-  // ── GET /:configId/qr — SSE stream ──────────────────────────────────────
-  /**
-   * Abre un stream SSE para recibir eventos de QR y estado.
-   *
-   * El cliente debe abrir:
-   *   const es = new EventSource('/gateway/whatsapp/<configId>/qr')
-   *   es.addEventListener('qr', e => renderQr(e.data))
-   *   es.addEventListener('status', e => updateStatus(e.data))
-   *
-   * La conexión permanece abierta hasta que el cliente la cierra
-   * o el adapter se desconecta (evento 'status': 'connected' | 'disconnected').
-   */
-  router.get('/:configId/qr', (req: Request, res: Response): void => {
+  router.get('/:configId/qr', requireJwt, (req: Request, res: Response): void => {
     const { configId } = req.params
 
-    res.setHeader('Content-Type',  'text/event-stream')
+    res.setHeader('Content-Type', 'text/event-stream')
     res.setHeader('Cache-Control', 'no-cache')
-    res.setHeader('Connection',    'keep-alive')
-    res.setHeader('X-Accel-Buffering', 'no') // desactivar buffering Nginx
+    res.setHeader('Connection', 'keep-alive')
+    res.setHeader('X-Accel-Buffering', 'no')
     res.flushHeaders()
 
-    // Comentario inicial para mantener la conexión viva en algunos proxies
     res.write(': connected\n\n')
-
-    // Registrar este cliente en el store
-    // (si ya hay QR o estado, se envía inmediatamente dentro de addSseClient)
     whatsappSessionStore.addSseClient(configId, res)
 
-    // Heartbeat cada 25s para evitar timeouts de proxy
     const heartbeat = setInterval(() => {
-      try { res.write(': heartbeat\n\n') } catch { clearInterval(heartbeat) }
+      try {
+        res.write(': heartbeat\n\n')
+      } catch {
+        clearInterval(heartbeat)
+      }
     }, 25_000)
 
     res.on('close', () => {
@@ -87,15 +60,6 @@ export function whatsappBaileysRouter(): Router {
     })
   })
 
-  // ── GET /:configId/status — JSON snapshot ───────────────────────────────
-  /**
-   * Retorna el estado actual de la sesión sin abrir un stream.
-   * Útil para polling inicial o health check de la UI.
-   *
-   * Response:
-   *   200 { ok: true,  configId, status, hasQr }
-   *   404 { ok: false, error: 'session not found' }
-   */
   router.get('/:configId/status', (req: Request, res: Response): void => {
     const { configId } = req.params
     const entry = whatsappSessionStore.get(configId)
@@ -106,33 +70,20 @@ export function whatsappBaileysRouter(): Router {
     }
 
     res.json({
-      ok:       true,
+      ok: true,
       configId,
-      status:   entry.status,
-      hasQr:    !!entry.qrBuffer,
+      status: entry.status,
+      hasQr: !!entry.qrBuffer,
     })
   })
 
-  // ── POST /:configId/connect — Iniciar sesión ─────────────────────────────
-  /**
-   * Crea e inicializa un WhatsAppBaileysAdapter para este configId.
-   * Si ya existe una sesión activa para el mismo configId, retorna 409.
-   *
-   * Body (opcional):
-   *   { config?: Record<string,unknown>, secrets?: Record<string,unknown> }
-   *
-   * Response:
-   *   200 { ok: true, configId, status: 'connecting' }
-   *   409 { ok: false, error: 'session already active' }
-   *   500 { ok: false, error: string }
-   */
-  router.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
+  router.post('/:configId/connect', requireJwt, async (req: Request, res: Response): Promise<void> => {
     const { configId } = req.params
     const existing = whatsappSessionStore.get(configId)
 
     if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
       res.status(409).json({
-        ok:    false,
+        ok: false,
         error: 'session already active',
         configId,
         status: existing.status,
@@ -141,23 +92,24 @@ export function whatsappBaileysRouter(): Router {
     }
 
     try {
-      // Importación dinámica — el adapter real puede no estar disponible en tests
+      // Reserve the slot before the first await so concurrent connect calls fail.
+      whatsappSessionStore.setStatus(configId, 'connecting')
+
       let AdapterClass: BaileysAdapterConstructable
       try {
         const mod = await import('../channels/whatsapp.adapter.js')
-        AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
+        AdapterClass = mod.WhatsAppAdapter as unknown as BaileysAdapterConstructable
       } catch {
-        // Fallback para entornos sin @whiskeysockets/baileys (tests, CI sin deps)
+        whatsappSessionStore.setStatus(configId, 'error')
         res.status(503).json({
-          ok:    false,
-          error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys',
+          ok: false,
+          error: 'WhatsAppBaileysAdapter not available - install @whiskeysockets/baileys',
         })
         return
       }
 
       const adapter = new AdapterClass(configId)
 
-      // Registrar callbacks ANTES de setup() para no perder el primer QR
       adapter.onQr((qr: string) => {
         console.info(`[whatsapp-store] QR received for configId=${configId}`)
         whatsappSessionStore.setQr(configId, qr)
@@ -173,17 +125,13 @@ export function whatsappBaileysRouter(): Router {
         whatsappSessionStore.setStatus(configId, 'disconnected')
       })
 
-      // Registrar en el store ANTES de setup() para que los callbacks
-      // ya tengan un entry donde escribir el QR
       whatsappSessionStore.setAdapter(configId, adapter)
-      whatsappSessionStore.setStatus(configId, 'connecting')
 
       const { config = {}, secrets = {} } = (req.body ?? {}) as {
-        config?:  Record<string, unknown>
+        config?: Record<string, unknown>
         secrets?: Record<string, unknown>
       }
 
-      // setup() es async — no esperamos el QR aquí, llega vía callback
       adapter.setup(config, secrets).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err)
         console.error(`[whatsapp-store] setup() error for configId=${configId}:`, msg)
@@ -193,25 +141,16 @@ export function whatsappBaileysRouter(): Router {
       res.json({ ok: true, configId, status: 'connecting' })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
+      whatsappSessionStore.setStatus(configId, 'error')
       res.status(500).json({ ok: false, error: msg })
     }
   })
 
-  // ── POST /:configId/disconnect — Detener sesión ──────────────────────────
-  /**
-   * Llama dispose() en el adapter y elimina la sesión del store.
-   * Cierra todos los streams SSE abiertos para este configId.
-   *
-   * Response:
-   *   200 { ok: true, configId }
-   *   404 { ok: false, error: 'session not found' }
-   *   500 { ok: false, error: string }
-   */
-  router.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
+  router.post('/:configId/disconnect', requireJwt, async (req: Request, res: Response): Promise<void> => {
     const { configId } = req.params
     const entry = whatsappSessionStore.get(configId)
 
-    if (!entry) {
+    if (!entry || !entry.adapter) {
       res.status(404).json({ ok: false, error: 'session not found', configId })
       return
     }
@@ -221,7 +160,6 @@ export function whatsappBaileysRouter(): Router {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(`[whatsapp-store] dispose() error for configId=${configId}:`, msg)
-      // No relanzamos — queremos limpiar el store igualmente
     }
 
     whatsappSessionStore.remove(configId)

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -23,6 +23,10 @@
  *   POST /api/channels/:id/deactivate           — desactivar canal (JWT)
  *   POST /api/channels/:id/bindings             — agregar binding (JWT)
  *   DELETE /api/channels/:id/bindings/:bid      — eliminar binding (JWT)
+ *   GET  /gateway/whatsapp/:configId/qr         — [F3a-22] SSE QR stream
+ *   GET  /gateway/whatsapp/:configId/status     — [F3a-22] JSON status
+ *   POST /gateway/whatsapp/:configId/connect    — [F3a-22] iniciar sesión WA
+ *   POST /gateway/whatsapp/:configId/disconnect — [F3a-22] detener sesión WA
  *
  * Seguridad:
  *   applySecurityMiddleware() aplica Helmet, CORS, rate limiting y JWT
@@ -42,6 +46,7 @@ import { GatewayService }          from './gateway.service';
 import { telegramRouter }          from './routes/telegram';
 import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat';
 import { channelsApiRouter }       from './routes/channels';
+import { whatsappBaileysRouter }   from './routes/whatsapp-baileys';
 
 // ---------------------------------------------------------------------------
 // App factory
@@ -63,8 +68,14 @@ export function createApp(opts: AppOptions = {}): Application {
   // -------------------------------------------------------------------------
   // 1. Register channel adapters
   // -------------------------------------------------------------------------
-  if (!registry.has('telegram')) registry.register(new TelegramAdapter());
-  if (!registry.has('webchat'))  registry.register(new WebChatAdapter());
+  if (!registry.has('telegram'))  registry.register(new TelegramAdapter());
+  if (!registry.has('webchat'))   registry.register(new WebChatAdapter());
+
+  // WhatsApp Baileys adapter — registro diferido (importación dinámica en el router)
+  // El adapter se crea por sesión en POST /gateway/whatsapp/:configId/connect
+  // para soportar múltiples cuentas simultáneas con sesiones independientes.
+  // No se pre-registra en el registry global porque el registry usa un único
+  // adapter compartido, mientras que Baileys necesita una instancia por configId.
 
   // -------------------------------------------------------------------------
   // 2. Security middleware
@@ -124,6 +135,9 @@ export function createApp(opts: AppOptions = {}): Application {
 
   // Channels CRUD + activate/deactivate + bindings (JWT)
   app.use('/api/channels', channelsApiRouter(db, gatewayService));
+
+  // [F3a-22] WhatsApp Baileys session manager + QR SSE
+  app.use('/gateway/whatsapp', whatsappBaileysRouter());
 
   // -------------------------------------------------------------------------
   // 7. 404 fallthrough

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,0 +1,180 @@
+/**
+ * whatsapp-session.store.ts — [F3a-22]
+ *
+ * Persiste en memoria la sesión WhatsApp por configId.
+ * Cada entrada guarda:
+ *   - adapter   : instancia activa del WhatsAppBaileysAdapter
+ *   - qrBuffer  : último QR recibido (PNG base64 data-url o cadena qr raw)
+ *   - status    : 'connecting' | 'qr_ready' | 'connected' | 'disconnected' | 'error'
+ *   - sseClients: lista de Response (SSE) suscritos al QR de este configId
+ *
+ * El store es un singleton exportado — todos los routers comparten la
+ * misma instancia sin necesidad de inyección de dependencias.
+ */
+
+import type { Response } from 'express'
+
+// ── Tipos ────────────────────────────────────────────────────────────────────
+
+export type WhatsAppSessionStatus =
+  | 'connecting'
+  | 'qr_ready'
+  | 'connected'
+  | 'disconnected'
+  | 'error'
+
+/**
+ * Contrato mínimo que debe cumplir el adapter para ser almacenado.
+ * Evita importar WhatsAppBaileysAdapter directamente y crear
+ * dependencias circulares — el adapter real se pasa en tiempo de ejecución.
+ */
+export interface IWhatsAppAdapter {
+  readonly channel: string
+  onQr?: (handler: (qr: string) => void) => void
+  onConnected?: (handler: () => void) => void
+  onDisconnected?: (handler: () => void) => void
+  dispose(): Promise<void>
+}
+
+interface SessionEntry {
+  adapter:    IWhatsAppAdapter
+  qrBuffer:   string | null        // data-url PNG o cadena QR raw
+  status:     WhatsAppSessionStatus
+  sseClients: Set<Response>        // clientes SSE activos suscritos al QR
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+class WhatsAppSessionStore {
+  private readonly sessions = new Map<string, SessionEntry>()
+
+  // ── CRUD ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Recupera la sesión existente o crea una nueva entrada vacía.
+   * El adapter se registra después con setAdapter().
+   */
+  getOrCreate(configId: string): SessionEntry {
+    if (!this.sessions.has(configId)) {
+      this.sessions.set(configId, {
+        adapter:    null as unknown as IWhatsAppAdapter, // se rellena con setAdapter()
+        qrBuffer:   null,
+        status:     'disconnected',
+        sseClients: new Set(),
+      })
+    }
+    return this.sessions.get(configId)!
+  }
+
+  get(configId: string): SessionEntry | undefined {
+    return this.sessions.get(configId)
+  }
+
+  has(configId: string): boolean {
+    return this.sessions.has(configId)
+  }
+
+  /**
+   * Registra el adapter activo para un configId.
+   * Crea la entrada si no existe.
+   */
+  setAdapter(configId: string, adapter: IWhatsAppAdapter): void {
+    const entry = this.getOrCreate(configId)
+    entry.adapter = adapter
+  }
+
+  /**
+   * Guarda el QR más reciente y notifica a todos los clientes SSE suscritos.
+   */
+  setQr(configId: string, qr: string): void {
+    const entry = this.sessions.get(configId)
+    if (!entry) return
+    entry.qrBuffer = qr
+    entry.status   = 'qr_ready'
+    this.broadcastSse(entry, { event: 'qr', data: qr })
+  }
+
+  /**
+   * Actualiza el estado de la sesión y notifica a los clientes SSE.
+   */
+  setStatus(configId: string, status: WhatsAppSessionStatus): void {
+    const entry = this.sessions.get(configId)
+    if (!entry) return
+    entry.status = status
+    if (status === 'connected') {
+      entry.qrBuffer = null   // QR ya no es relevante
+    }
+    this.broadcastSse(entry, { event: 'status', data: status })
+  }
+
+  /**
+   * Elimina la sesión del store.
+   * Cierra todos los streams SSE pendientes antes de borrar.
+   */
+  remove(configId: string): void {
+    const entry = this.sessions.get(configId)
+    if (!entry) return
+    for (const client of entry.sseClients) {
+      try { client.end() } catch { /* ya cerrado */ }
+    }
+    entry.sseClients.clear()
+    this.sessions.delete(configId)
+  }
+
+  // ── SSE client management ─────────────────────────────────────────────────
+
+  /**
+   * Registra un cliente SSE (Response de Express) para recibir
+   * eventos QR y de estado de este configId.
+   *
+   * Si ya hay un QR en buffer, lo envía inmediatamente para que
+   * el cliente no tenga que esperar al siguiente ciclo.
+   */
+  addSseClient(configId: string, res: Response): void {
+    const entry = this.getOrCreate(configId)
+    entry.sseClients.add(res)
+
+    // Enviar estado e QR actuales de inmediato
+    this.sendSseEvent(res, { event: 'status', data: entry.status })
+    if (entry.qrBuffer) {
+      this.sendSseEvent(res, { event: 'qr', data: entry.qrBuffer })
+    }
+
+    // Limpiar al cerrar la conexión
+    res.on('close', () => {
+      entry.sseClients.delete(res)
+    })
+  }
+
+  // ── Helpers SSE ───────────────────────────────────────────────────────────
+
+  private broadcastSse(
+    entry: SessionEntry,
+    payload: { event: string; data: string },
+  ): void {
+    for (const client of entry.sseClients) {
+      this.sendSseEvent(client, payload)
+    }
+  }
+
+  private sendSseEvent(
+    res:     Response,
+    payload: { event: string; data: string },
+  ): void {
+    try {
+      res.write(`event: ${payload.event}\ndata: ${payload.data}\n\n`)
+    } catch {
+      /* cliente ya desconectado — se limpiará en el handler 'close' */
+    }
+  }
+
+  // ── Debug ─────────────────────────────────────────────────────────────────
+
+  /** Lista de configIds activos en el store (útil para health/debug). */
+  activeSessions(): string[] {
+    return [...this.sessions.keys()]
+  }
+}
+
+// Singleton exportado
+export const whatsappSessionStore = new WhatsAppSessionStore()

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -37,7 +37,7 @@ export interface IWhatsAppAdapter {
 }
 
 interface SessionEntry {
-  adapter:    IWhatsAppAdapter
+  adapter?:   IWhatsAppAdapter
   qrBuffer:   string | null        // data-url PNG o cadena QR raw
   status:     WhatsAppSessionStatus
   sseClients: Set<Response>        // clientes SSE activos suscritos al QR
@@ -57,7 +57,6 @@ class WhatsAppSessionStore {
   getOrCreate(configId: string): SessionEntry {
     if (!this.sessions.has(configId)) {
       this.sessions.set(configId, {
-        adapter:    null as unknown as IWhatsAppAdapter, // se rellena con setAdapter()
         qrBuffer:   null,
         status:     'disconnected',
         sseClients: new Set(),
@@ -76,11 +75,12 @@ class WhatsAppSessionStore {
 
   /**
    * Registra el adapter activo para un configId.
-   * Crea la entrada si no existe.
+   * Crea la entrada si no existe y marca la sesión como reservada.
    */
   setAdapter(configId: string, adapter: IWhatsAppAdapter): void {
     const entry = this.getOrCreate(configId)
     entry.adapter = adapter
+    entry.status = 'connecting'
   }
 
   /**
@@ -172,7 +172,9 @@ class WhatsAppSessionStore {
 
   /** Lista de configIds activos en el store (útil para health/debug). */
   activeSessions(): string[] {
-    return [...this.sessions.keys()]
+    return [...this.sessions.entries()]
+      .filter(([, entry]) => !!entry.adapter)
+      .map(([configId]) => configId)
   }
 }
 


### PR DESCRIPTION
- Add whatsapp-session.store.ts: in-memory Map<configId, {adapter, qrBuffer, status}>
  with getOrCreate(), setQr(), setStatus(), get(), remove() methods
- Add routes/whatsapp-baileys.ts: Express router with
    GET  /gateway/whatsapp/:configId/qr      → SSE stream emitting QR as data-url
    GET  /gateway/whatsapp/:configId/status  → JSON {status, hasQr}
    POST /gateway/whatsapp/:configId/connect → start adapter + register in store
    POST /gateway/whatsapp/:configId/disconnect → dispose adapter + remove from store
- Modify server.ts: register WhatsAppBaileysAdapter in registry,
  mount whatsappBaileysRouter under /gateway/whatsapp

Closes #22

<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Implementación completada. Aquí el resumen:</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="f3a-22--implementacin-en-github">F3a-22 — Implementación en GitHub ✅</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>🔢 Commit SHA:</strong> <code>69fb80fcf68ef44316e846a0d3a21068912688b2</code><br><strong>🌿 Rama:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-22-whatsapp-session-store-qr-sse"><span class="text-box-trim-both"><code>feat/F3a-22-whatsapp-session-store-qr-sse</code></span></a></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-entregados">Archivos entregados</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>1. <code>apps/gateway/src/whatsapp-session.store.ts</code></strong> ← nuevo<br>Singleton <code>WhatsAppSessionStore</code> con <code>Map&lt;configId, SessionEntry&gt;</code> en memoria. Cada entry guarda el adapter, el <code>qrBuffer</code> más reciente, el <code>status</code> y un <code>Set&lt;Response&gt;</code> de clientes SSE activos. Métodos clave: <code>getOrCreate()</code>, <code>setAdapter()</code>, <code>setQr()</code> (broadcast inmediato a SSE), <code>setStatus()</code>, <code>addSseClient()</code> (envía estado+QR actuales de inmediato si ya existen), <code>remove()</code> (cierra todos los streams pendientes).</p><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>2. <code>apps/gateway/src/routes/whatsapp-baileys.ts</code></strong> ← nuevo<br>Router Express con 4 endpoints:</p><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised">
Método | Ruta | Descripción
-- | -- | --
GET | /:configId/qr | SSE stream — eventos qr y status + heartbeat 25s
GET | /:configId/status | JSON snapshot {status, hasQr}
POST | /:configId/connect | Crea adapter, registra callbacks, inicia setup() async
POST | /:configId/disconnect | Llama dispose(), elimina del store, cierra SSE

</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El adapter se importa dinámicamente (<code>import('../channels/whatsapp.adapter.js')</code>) para soportar entornos sin <code>@whiskeysockets/baileys</code> (tests, CI). Los callbacks <code>onQr</code>/<code>onConnected</code>/<code>onDisconnected</code> se registran <strong>antes</strong> de <code>setup()</code> para no perder el primer QR.</p><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>3. <code>apps/gateway/src/server.ts</code></strong> ← modificado<br>Se añadió el import de <code>whatsappBaileysRouter</code> y el montaje:</p><div class="w-full md:max-w-[90vw]"><pre class="not-prose w-full rounded font-mono text-sm font-extralight"><div class="codeWrapper bg-subtle text-light selection:text-super selection:bg-super/10 my-md relative flex flex-col rounded-lg font-mono text-sm font-medium"><div class="translate-y-xs -translate-x-xs bottom-xl mb-xl flex h-0 items-start justify-end sm:sticky sm:top-xs"><div class="overflow-hidden border-subtlest ring-subtlest divide-subtlest bg-base rounded-full"><div class="border-subtlest ring-subtlest divide-subtlest bg-subtle"><button data-testid="copy-code-button" aria-label="Copiar código" type="button" class="focus-visible:bg-quiet hover:bg-quiet text-quiet hover:text-foreground font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-full cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-square" data-state="closed"><div class="flex items-center min-w-0 gap-two justify-center"><div class="flex shrink-0 items-center justify-center size-4"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div></div></button></div></div></div><div class="-mt-xl"><div><div data-testid="code-language-indicator" class="text-quiet bg-quiet py-xs px-sm inline-block rounded-br rounded-tl-lg text-xs font-thin">ts</div></div><div><span style="font-size: inherit; font-family: inherit; background: transparent; color: rgb(214, 208, 200); border-radius: 3px; display: flex; line-height: 1.42857; overflow-x: auto; white-space: pre; --scrollbar-thumb: oklch(var(--foreground-color) / 0.15); --scrollbar-track: transparent; scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);"><code style="white-space: pre-wrap; font-size: inherit; font-family: inherit; line-height: 1.66667; padding: 8px;"><span style="opacity: 1; font-size: inherit; line-height: 1.42857; color: rgb(214, 208, 200); background-color: transparent; flex-shrink: 0; padding: 8px; text-align: right; user-select: none;"><span>app</span><span class="token token punctuation">.</span><span class="token token" style="color: rgb(210, 168, 255);">use</span><span class="token token punctuation">(</span><span class="token token" style="color: rgb(165, 214, 255);">'/gateway/whatsapp'</span><span class="token token punctuation">,</span><span> </span><span class="token token" style="color: rgb(210, 168, 255);">whatsappBaileysRouter</span><span class="token token punctuation">(</span><span class="token token punctuation">)</span><span class="token token punctuation">)</span><span class="token token punctuation">;</span></span></code></span></div></div></div></pre></div><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El comentario en la sección de registro de adapters explica por qué Baileys <strong>no</strong> se pre-registra en el registry global: necesita una instancia por <code>configId</code> para soportar múltiples cuentas simultáneas.</p></div></body></html><!--EndFragment-->
</body>
</html>Implementación completada. Aquí el resumen:

***

## F3a-22 — Implementación en GitHub ✅

**🔢 Commit SHA:** `69fb80fcf68ef44316e846a0d3a21068912688b2`
**🌿 Rama:** [`[feat/F3a-22-whatsapp-session-store-qr-sse](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-22-whatsapp-session-store-qr-sse)`](https://github.com/lssmanager/agent-visualstudio/tree/feat/F3a-22-whatsapp-session-store-qr-sse)

***

### Archivos entregados

**1. `apps/gateway/src/whatsapp-session.store.ts`** ← nuevo
Singleton `WhatsAppSessionStore` con `Map<configId, SessionEntry>` en memoria. Cada entry guarda el adapter, el `qrBuffer` más reciente, el `status` y un `Set<Response>` de clientes SSE activos. Métodos clave: `getOrCreate()`, `setAdapter()`, `setQr()` (broadcast inmediato a SSE), `setStatus()`, `addSseClient()` (envía estado+QR actuales de inmediato si ya existen), `remove()` (cierra todos los streams pendientes).

**2. `apps/gateway/src/routes/whatsapp-baileys.ts`** ← nuevo
Router Express con 4 endpoints:

| Método | Ruta | Descripción |
|---|---|---|
| `GET` | `/:configId/qr` | SSE stream — eventos `qr` y `status` + heartbeat 25s |
| `GET` | `/:configId/status` | JSON snapshot `{status, hasQr}` |
| `POST` | `/:configId/connect` | Crea adapter, registra callbacks, inicia `setup()` async |
| `POST` | `/:configId/disconnect` | Llama `dispose()`, elimina del store, cierra SSE |

El adapter se importa dinámicamente (`import('../channels/whatsapp.adapter.js')`) para soportar entornos sin `@whiskeysockets/baileys` (tests, CI). Los callbacks `onQr`/`onConnected`/`onDisconnected` se registran **antes** de `setup()` para no perder el primer QR.

**3. `apps/gateway/src/server.ts`** ← modificado
Se añadió el import de `whatsappBaileysRouter` y el montaje:
```ts
app.use('/gateway/whatsapp', whatsappBaileysRouter());
```
El comentario en la sección de registro de adapters explica por qué Baileys **no** se pre-registra en el registry global: necesita una instancia por `configId` para soportar múltiples cuentas simultáneas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- WhatsApp integration with QR code-based authentication
- Real-time connection status monitoring for active sessions
- Ability to connect and disconnect WhatsApp accounts
- Live status updates during authentication and connection processes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->