### PR TITLE
Feat/f3a 24 whatsapp message mapper

### DIFF
--- a/apps/gateway/src/channels/__tests__/whatsapp-backoff.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-backoff.test.ts
@@ -1,0 +1,120 @@
+/**
+ * whatsapp-backoff.test.ts — [F3a-23]
+ *
+ * Tests unitarios para ExponentialBackoff.
+ * Usa fake timers de Vitest para evitar esperas reales.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ExponentialBackoff } from '../whatsapp-backoff.js'
+
+describe('ExponentialBackoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // ── peekDelay ────────────────────────────────────────────────────────────
+
+  it('peekDelay() returns value in range [0, capMs]', () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1_000, capMs: 4_000 })
+    for (let i = 0; i < 20; i++) {
+      const d = backoff.peekDelay()
+      expect(d).toBeGreaterThanOrEqual(0)
+      expect(d).toBeLessThanOrEqual(4_000)
+    }
+  })
+
+  it('peekDelay() does not advance currentAttempt', () => {
+    const backoff = new ExponentialBackoff({ baseMs: 100, capMs: 1_000 })
+    backoff.peekDelay()
+    backoff.peekDelay()
+    expect(backoff.currentAttempt).toBe(0)
+  })
+
+  // ── next ─────────────────────────────────────────────────────────────────
+
+  it('next() increments currentAttempt by 1', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 10, capMs: 100 })
+    const p = backoff.next()
+    vi.runAllTimers()
+    await p
+    expect(backoff.currentAttempt).toBe(1)
+  })
+
+  it('next() after maxRetries throws backoff_exhausted', () => {
+    const backoff = new ExponentialBackoff({ baseMs: 10, capMs: 100, maxRetries: 1 })
+    // consumir el único intento disponible de forma síncrona
+    backoff['attempt'] = 1 // forzar estado exhausted
+    expect(() => backoff.next()).toThrowError('backoff_exhausted')
+  })
+
+  it('exhausted is true after maxRetries calls to next()', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1, capMs: 10, maxRetries: 2 })
+
+    const p1 = backoff.next()
+    vi.runAllTimers()
+    await p1
+
+    const p2 = backoff.next()
+    vi.runAllTimers()
+    await p2
+
+    expect(backoff.exhausted).toBe(true)
+    expect(() => backoff.next()).toThrowError('backoff_exhausted')
+  })
+
+  // ── abort ────────────────────────────────────────────────────────────────
+
+  it('abort() during wait rejects with backoff_aborted', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 10_000, capMs: 60_000 })
+    const p = backoff.next()
+    backoff.abort()
+    vi.runAllTimers()
+    await expect(p).rejects.toThrowError('backoff_aborted')
+  })
+
+  it('abort() clears the timer (no memory leak)', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const backoff = new ExponentialBackoff({ baseMs: 10_000, capMs: 60_000 })
+    backoff.next() // starts timer
+    backoff.abort()
+    expect(clearSpy).toHaveBeenCalled()
+    expect(backoff.isAborted).toBe(true)
+  })
+
+  it('next() after abort() throws backoff_aborted immediately', () => {
+    const backoff = new ExponentialBackoff()
+    backoff.abort()
+    expect(() => backoff.next()).toThrowError('backoff_aborted')
+  })
+
+  // ── reset ────────────────────────────────────────────────────────────────
+
+  it('reset() sets currentAttempt to 0 and clears aborted flag', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1, capMs: 10, maxRetries: 3 })
+
+    const p = backoff.next()
+    vi.runAllTimers()
+    await p
+    expect(backoff.currentAttempt).toBe(1)
+
+    backoff.reset()
+    expect(backoff.currentAttempt).toBe(0)
+    expect(backoff.exhausted).toBe(false)
+    expect(backoff.isAborted).toBe(false)
+  })
+
+  it('reset() after abort() allows next() to work again', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1, capMs: 10 })
+    backoff.abort()
+    backoff.reset()
+    const p = backoff.next()
+    vi.runAllTimers()
+    await expect(p).resolves.toBeUndefined()
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-deprovision.service.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-deprovision.service.test.ts
@@ -1,0 +1,169 @@
+/**
+ * whatsapp-deprovision.service.test.ts — [F3a-23]
+ *
+ * Tests unitarios para WhatsAppDeprovisionService.
+ * Todos los colaboradores (db, store, fs) se mockean.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as fs from 'node:fs'
+import { WhatsAppDeprovisionService } from '../whatsapp-deprovision.service.js'
+
+// ── Mocks de fs ──────────────────────────────────────────────────────────────
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  rmSync:     vi.fn(),
+}))
+
+// ── Factory helpers ──────────────────────────────────────────────────────────
+
+function makeAdapter(state: string, hasLogout = true) {
+  return {
+    state,
+    logout:  hasLogout ? vi.fn().mockResolvedValue(undefined) : undefined,
+    dispose: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeStore(adapter?: ReturnType<typeof makeAdapter>) {
+  return {
+    get:    vi.fn().mockReturnValue(adapter ? { adapter } : undefined),
+    remove: vi.fn(),
+  }
+}
+
+function makeDb(prismaError?: { code: string }) {
+  return {
+    channelConfig: {
+      update: prismaError
+        ? vi.fn().mockRejectedValue(Object.assign(new Error('not found'), prismaError))
+        : vi.fn().mockResolvedValue({}),
+    },
+  }
+}
+
+// ── Tests: logout() ──────────────────────────────────────────────────────────
+
+describe('WhatsAppDeprovisionService.logout()', () => {
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+  })
+
+  it('calls adapter.logout() when state is "open"', async () => {
+    const adapter = makeAdapter('open')
+    const store   = makeStore(adapter)
+    const svc     = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.logout('cfg-1')
+
+    expect(adapter.logout).toHaveBeenCalledOnce()
+    expect(adapter.dispose).not.toHaveBeenCalled()
+  })
+
+  it('calls adapter.logout() when state is "reconnecting"', async () => {
+    const adapter = makeAdapter('reconnecting')
+    const store   = makeStore(adapter)
+    const svc     = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.logout('cfg-2')
+
+    expect(adapter.logout).toHaveBeenCalledOnce()
+  })
+
+  it('calls adapter.dispose() when state is "idle"', async () => {
+    const adapter = makeAdapter('idle')
+    const store   = makeStore(adapter)
+    const svc     = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.logout('cfg-3')
+
+    expect(adapter.dispose).toHaveBeenCalledOnce()
+    expect(adapter.logout).not.toHaveBeenCalled()
+  })
+
+  it('when configId not in store — returns adapterState=not_in_store without throwing', async () => {
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.logout('cfg-missing')
+
+    expect(result.adapterState).toBe('not_in_store')
+  })
+
+  it('deletes sessionDir when it exists', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.logout('cfg-fs')
+
+    expect(fs.rmSync).toHaveBeenCalled()
+    expect(result.sessionDeleted).toBe(true)
+  })
+
+  it('sessionDeleted=false when sessionDir does not exist', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.logout('cfg-nofs')
+
+    expect(result.sessionDeleted).toBe(false)
+  })
+})
+
+// ── Tests: deprovision() ─────────────────────────────────────────────────────
+
+describe('WhatsAppDeprovisionService.deprovision()', () => {
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+  })
+
+  it('calls db.channelConfig.update with { active: false }', async () => {
+    const db    = makeDb()
+    const store = makeStore(makeAdapter('open'))
+    const svc   = new WhatsAppDeprovisionService(db as any, store as any)
+
+    await svc.deprovision('cfg-deprov-1')
+
+    expect(db.channelConfig.update).toHaveBeenCalledWith({
+      where: { id: 'cfg-deprov-1' },
+      data:  { active: false },
+    })
+  })
+
+  it('calls store.remove(configId)', async () => {
+    const store = makeStore(makeAdapter('open'))
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.deprovision('cfg-deprov-2')
+
+    expect(store.remove).toHaveBeenCalledWith('cfg-deprov-2')
+  })
+
+  it('when ChannelConfig not found (P2025) → channelDeactivated=false, no throw', async () => {
+    const db    = makeDb({ code: 'P2025' })
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(db as any, store as any)
+
+    const result = await svc.deprovision('cfg-missing-db')
+
+    expect(result.channelDeactivated).toBe(false)
+    expect(result.storeDestroyed).toBe(true)
+  })
+
+  it('result contains all required fields', async () => {
+    const store = makeStore(makeAdapter('open'))
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.deprovision('cfg-fields')
+
+    expect(result).toMatchObject({
+      configId:           'cfg-fields',
+      sessionDeleted:     expect.any(Boolean),
+      adapterState:       expect.any(String),
+      channelDeactivated: true,
+      storeDestroyed:     true,
+    })
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-message.mapper.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-message.mapper.test.ts
@@ -1,0 +1,249 @@
+/**
+ * whatsapp-message.mapper.test.ts — [F3a-24]
+ *
+ * Tests unitarios para baileysToIncoming(), jidToPhone(), isGroupJid().
+ * Los objetos WAMessage se construyen como plain objects —
+ * NO se importa @whiskeysockets/baileys directamente.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { baileysToIncoming, jidToPhone, isGroupJid } from '../whatsapp-message.mapper.js'
+
+// ── Factory: WAMessage mínimo ──────────────────────────────────────────────────
+
+function makeWAMsg(overrides: {
+  fromMe?:     boolean
+  remoteJid?:  string
+  participant?: string
+  message?:    Record<string, unknown>
+  pushName?:   string
+  messageTimestamp?: number
+}) {
+  return {
+    key: {
+      fromMe:     overrides.fromMe    ?? false,
+      remoteJid:  overrides.remoteJid ?? '521234567890@s.whatsapp.net',
+      id:         'test-msg-id',
+      participant: overrides.participant,
+    },
+    message:          overrides.message ?? null,
+    pushName:         overrides.pushName ?? 'Test User',
+    messageTimestamp: overrides.messageTimestamp ?? 1700000000,
+  } as any
+}
+
+// ── Tests: baileysToIncoming() ─────────────────────────────────────────────────
+
+describe('baileysToIncoming()', () => {
+
+  it('returns null when fromMe=true', () => {
+    const msg = makeWAMsg({ fromMe: true, message: { conversation: 'hello' } })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  it('returns null when message is null', () => {
+    const msg = makeWAMsg({ message: undefined })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  it('returns null for protocolMessage (system message)', () => {
+    const msg = makeWAMsg({ message: { protocolMessage: { type: 0 } } })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  // ── conversation ──────────────────────────────────────────────────────
+
+  it('maps conversation text to type=text', () => {
+    const msg = makeWAMsg({ message: { conversation: 'hello world' } })
+    const result = baileysToIncoming(msg)!
+    expect(result).not.toBeNull()
+    expect(result.type).toBe('text')
+    expect(result.text).toBe('hello world')
+    expect(result.externalId).toBe('521234567890')
+  })
+
+  it('maps conversation with / prefix to type=command', () => {
+    const msg = makeWAMsg({ message: { conversation: '/start' } })
+    expect(baileysToIncoming(msg)!.type).toBe('command')
+  })
+
+  it('externalId strips @s.whatsapp.net suffix', () => {
+    const msg = makeWAMsg({
+      remoteJid: '521234567890@s.whatsapp.net',
+      message:   { conversation: 'hi' },
+    })
+    expect(baileysToIncoming(msg)!.externalId).toBe('521234567890')
+  })
+
+  // ── extendedTextMessage ─────────────────────────────────────────────
+
+  it('maps extendedTextMessage to type=text with previewUrl in metadata', () => {
+    const msg = makeWAMsg({
+      message: {
+        extendedTextMessage: {
+          text:        'check this out',
+          canonicalUrl: 'https://example.com',
+        },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('text')
+    expect(result.text).toBe('check this out')
+    expect(result.metadata?.previewUrl).toBe('https://example.com')
+  })
+
+  // ── imageMessage ──────────────────────────────────────────────────
+
+  it('maps imageMessage with caption to type=image', () => {
+    const msg = makeWAMsg({
+      message: {
+        imageMessage: { caption: 'my photo', mimetype: 'image/jpeg' },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('image')
+    expect(result.text).toBe('my photo')
+    expect(result.attachments?.[0]?.type).toBe('image')
+  })
+
+  // ── audioMessage ──────────────────────────────────────────────────
+
+  it('maps audioMessage ptt=true to attachment type=voice_note', () => {
+    const msg = makeWAMsg({
+      message: { audioMessage: { ptt: true, mimetype: 'audio/ogg; codecs=opus', seconds: 5 } },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('audio')
+    expect(result.attachments?.[0]?.type).toBe('voice_note')
+  })
+
+  it('maps audioMessage ptt=false to attachment type=audio', () => {
+    const msg = makeWAMsg({
+      message: { audioMessage: { ptt: false, mimetype: 'audio/mp4', seconds: 10 } },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('audio')
+    expect(result.attachments?.[0]?.type).toBe('audio')
+  })
+
+  // ── videoMessage ──────────────────────────────────────────────────
+
+  it('maps videoMessage to type=file with attachment type=video', () => {
+    const msg = makeWAMsg({
+      message: { videoMessage: { caption: 'clip', mimetype: 'video/mp4', seconds: 30 } },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('file')
+    expect(result.attachments?.[0]?.type).toBe('video')
+  })
+
+  // ── documentMessage ────────────────────────────────────────────────
+
+  it('maps documentMessage to type=file with fileName in attachment data', () => {
+    const msg = makeWAMsg({
+      message: {
+        documentMessage: {
+          fileName: 'report.pdf',
+          mimetype: 'application/pdf',
+          fileLength: 1024,
+        },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('file')
+    expect((result.attachments?.[0]?.data as any)?.fileName).toBe('report.pdf')
+  })
+
+  // ── locationMessage ───────────────────────────────────────────────
+
+  it('maps locationMessage to type=text with coordinates in text and metadata', () => {
+    const msg = makeWAMsg({
+      message: {
+        locationMessage: { degreesLatitude: 19.4326, degreesLongitude: -99.1332, name: 'CDMX' },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('text')
+    expect(result.text).toContain('19.4326')
+    expect(result.text).toContain('-99.1332')
+    expect((result.metadata?.location as any)?.lat).toBe(19.4326)
+    expect((result.metadata?.location as any)?.lng).toBe(-99.1332)
+  })
+
+  // ── contactMessage ────────────────────────────────────────────────
+
+  it('maps contactMessage with vcard TEL to type=text with phone in text', () => {
+    const msg = makeWAMsg({
+      message: {
+        contactMessage: {
+          displayName: 'Juan',
+          vcard: 'BEGIN:VCARD\nVERSION:3.0\nFN:Juan\nTEL;type=CELL:+521234567890\nEND:VCARD',
+        },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('text')
+    expect(result.text).toContain('+521234567890')
+  })
+
+  // ── reactionMessage ───────────────────────────────────────────────
+
+  it('reactionMessage with processReactions=false returns null', () => {
+    const msg = makeWAMsg({
+      message: { reactionMessage: { text: '\ud83d\udc4d', key: { id: 'orig-id' } } },
+    })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  it('reactionMessage with processReactions=true returns type=command with emoji', () => {
+    const msg = makeWAMsg({
+      message: { reactionMessage: { text: '\ud83d\udc4d', key: { id: 'orig-id' } } },
+    })
+    const result = baileysToIncoming(msg, { processReactions: true })!
+    expect(result.type).toBe('command')
+    expect(result.text).toBe('\ud83d\udc4d')
+    expect((result.metadata?.reaction as any)?.emoji).toBe('\ud83d\udc4d')
+  })
+
+  // ── rawPayload y threadId ────────────────────────────────────────────
+
+  it('result always has rawPayload and threadId', () => {
+    const msg = makeWAMsg({ message: { conversation: 'test' } })
+    const result = baileysToIncoming(msg)!
+    expect(result.rawPayload).toBeDefined()
+    expect(result.threadId).toBeDefined()
+    expect(result.threadId).toBe(result.externalId)
+  })
+})
+
+// ── Tests: jidToPhone() ───────────────────────────────────────────────────────────
+
+describe('jidToPhone()', () => {
+  it('strips @s.whatsapp.net suffix', () => {
+    expect(jidToPhone('521234567890@s.whatsapp.net')).toBe('521234567890')
+  })
+
+  it('strips multi-device suffix :N', () => {
+    expect(jidToPhone('521234567890:5@s.whatsapp.net')).toBe('521234567890')
+  })
+
+  it('strips @g.us suffix for groups', () => {
+    expect(jidToPhone('120363@g.us')).toBe('120363')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(jidToPhone('')).toBe('')
+  })
+})
+
+// ── Tests: isGroupJid() ────────────────────────────────────────────────────────
+
+describe('isGroupJid()', () => {
+  it('returns true for group JIDs', () => {
+    expect(isGroupJid('120363123456@g.us')).toBe(true)
+  })
+
+  it('returns false for personal JIDs', () => {
+    expect(isGroupJid('521234567890@s.whatsapp.net')).toBe(false)
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-send.mapper.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-send.mapper.test.ts
@@ -1,0 +1,105 @@
+/**
+ * whatsapp-send.mapper.test.ts — [F3a-24]
+ *
+ * Tests unitarios para outgoingToBaileys() y phoneToJid().
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { outgoingToBaileys, phoneToJid } from '../whatsapp-send.mapper.js'
+import type { OutgoingMessage } from '../channel-adapter.interface.js'
+
+function makeMsg(overrides: Partial<OutgoingMessage>): OutgoingMessage {
+  return {
+    externalId:  '521234567890',
+    text:        'Hello',
+    ...overrides,
+  }
+}
+
+// ── Tests: outgoingToBaileys() ─────────────────────────────────────────────────
+
+describe('outgoingToBaileys()', () => {
+
+  it('without richContent returns { text } and correct jid', () => {
+    const { jid, content } = outgoingToBaileys(makeMsg({}))
+    expect(jid).toBe('521234567890@s.whatsapp.net')
+    expect(content).toEqual({ text: 'Hello' })
+  })
+
+  it('richContent type=buttons maps buttons array correctly', () => {
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: {
+        type: 'buttons',
+        body: 'Choose one',
+        buttons: [
+          { id: 'btn1', title: 'Option 1' },
+          { id: 'btn2', title: 'Option 2' },
+        ],
+      },
+    }))
+    const buttons = (content as any).buttons
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].buttonId).toBe('btn1')
+    expect(buttons[0].buttonText.displayText).toBe('Option 1')
+  })
+
+  it('richContent type=list maps listMessage.sections correctly', () => {
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: {
+        type: 'list',
+        title:       'Menu',
+        description: 'Pick an option',
+        buttonText:  'Options',
+        sections: [{
+          title: 'Section 1',
+          rows:  [{ id: 'r1', title: 'Row 1' }],
+        }],
+      },
+    }))
+    const lm = (content as any).listMessage
+    expect(lm).toBeDefined()
+    expect(lm.sections).toHaveLength(1)
+    expect(lm.sections[0].rows[0].rowId).toBe('r1')
+  })
+
+  it('richContent type=template maps templateMessage', () => {
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: {
+        type:    'template',
+        text:    'Hello template',
+        buttons: [{ index: 0, quickReplyButton: { displayText: 'Yes', id: 'yes' } }],
+      },
+    }))
+    expect((content as any).templateMessage).toBeDefined()
+  })
+
+  it('unknown richContent type falls back to text without throwing', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: { type: 'unknown_type', someData: 123 } as any,
+    }))
+    expect((content as any).text).toBeDefined()
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})
+
+// ── Tests: phoneToJid() ───────────────────────────────────────────────────────────
+
+describe('phoneToJid()', () => {
+  it('adds @s.whatsapp.net to plain number', () => {
+    expect(phoneToJid('521234567890')).toBe('521234567890@s.whatsapp.net')
+  })
+
+  it('strips + prefix', () => {
+    expect(phoneToJid('+521234567890')).toBe('521234567890@s.whatsapp.net')
+  })
+
+  it('strips spaces and dashes', () => {
+    expect(phoneToJid('52 123 456-7890')).toBe('521234567890@s.whatsapp.net')
+  })
+
+  it('is idempotent for existing JIDs', () => {
+    expect(phoneToJid('521234567890@s.whatsapp.net')).toBe('521234567890@s.whatsapp.net')
+  })
+})

--- a/apps/gateway/src/channels/whatsapp-backoff.ts
+++ b/apps/gateway/src/channels/whatsapp-backoff.ts
@@ -1,0 +1,88 @@
+/**
+ * whatsapp-backoff.ts — [F3a-23]
+ *
+ * Motor de backoff exponencial con jitter para reconexión de Baileys.
+ * Extraído del adapter para ser testeable de forma aislada.
+ *
+ * Algoritmo: exponential backoff con full jitter
+ *   delay = random(0, min(cap, base * 2^attempt))
+ */
+
+export interface BackoffOptions {
+  baseMs?: number
+  capMs?: number
+  maxRetries?: number
+  factor?: number
+}
+
+export class ExponentialBackoff {
+  private attempt = 0
+  private aborted = false
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  readonly baseMs: number
+  readonly capMs: number
+  readonly maxRetries: number
+  readonly factor: number
+
+  constructor(opts: BackoffOptions = {}) {
+    this.baseMs = opts.baseMs ?? 3_000
+    this.capMs = opts.capMs ?? 60_000
+    this.maxRetries = opts.maxRetries ?? 8
+    this.factor = opts.factor ?? 2
+  }
+
+  get currentAttempt(): number {
+    return this.attempt
+  }
+
+  get exhausted(): boolean {
+    return this.attempt >= this.maxRetries
+  }
+
+  get isAborted(): boolean {
+    return this.aborted
+  }
+
+  peekDelay(): number {
+    const exp = Math.min(this.capMs, this.baseMs * Math.pow(this.factor, this.attempt))
+    return Math.floor(Math.random() * exp)
+  }
+
+  next(): Promise<void> {
+    if (this.aborted) throw new Error('backoff_aborted')
+    if (this.exhausted) throw new Error('backoff_exhausted')
+
+    const delay = this.peekDelay()
+    this.attempt++
+
+    return new Promise<void>((resolve, reject) => {
+      this.timer = setTimeout(() => {
+        this.timer = null
+        if (this.aborted) reject(new Error('backoff_aborted'))
+        else resolve()
+      }, delay)
+    })
+  }
+
+  abort(): void {
+    this.aborted = true
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  reset(): void {
+    this.attempt = 0
+    this.aborted = false
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  toString(): string {
+    return `BackoffState{attempt=${this.attempt}/${this.maxRetries}, nextDelay≈${this.peekDelay()}ms, exhausted=${this.exhausted}}`
+  }
+}

--- a/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
@@ -1,0 +1,444 @@
+/**
+ * whatsapp-baileys.adapter.ts — WhatsApp via Baileys (WA Web protocol)
+ * [F3a-21 / F3a-23 / F3a-24]
+ *
+ * A diferencia de WhatsAppAdapter (Cloud API), este adapter usa el
+ * protocolo WhatsApp Web via Baileys. No requiere cuenta Business ni
+ * aprobación de Meta — funciona con cualquier número de WhatsApp.
+ *
+ * F3a-24: Inline mapping reemplazado por llamadas a:
+ *   - baileysToIncoming() de whatsapp-message.mapper.ts
+ *   - outgoingToBaileys() de whatsapp-send.mapper.ts
+ * Se eliminan métodos privados: toJid(), handleIncomingMessage(),
+ * normalizeMessage(), extractText(), extractType(), extractAttachment().
+ *
+ * F3a-23: ExponentialBackoff integrado para reconexiones.
+ */
+
+import path         from 'node:path'
+import fs           from 'node:fs'
+import EventEmitter from 'node:events'
+import {
+  BaseChannelAdapter,
+  type OutgoingMessage,
+} from './channel-adapter.interface.js'
+import { baileysToIncoming }  from './whatsapp-message.mapper.js'
+import { outgoingToBaileys }  from './whatsapp-send.mapper.js'
+import { ExponentialBackoff } from './whatsapp-backoff.js'
+
+// ── Tipos de Baileys (importados dinámicamente) ─────────────────────────
+
+type BaileysSocket = {
+  sendMessage: (
+    jid: string,
+    content: Record<string, unknown>,
+    opts?: Record<string, unknown>,
+  ) => Promise<unknown>
+  logout: () => Promise<void>
+  end:    (err?: Error) => void
+  ev: {
+    on:              (event: string, handler: (...args: unknown[]) => void) => void
+    off:             (event: string, handler: (...args: unknown[]) => void) => void
+    removeAllListeners: () => void
+  }
+  user?: { id: string; name?: string }
+}
+
+type DisconnectReason = {
+  loggedOut:         number
+  connectionLost:    number
+  restartRequired:   number
+  timedOut:          number
+  badSession:        number
+  connectionReplaced: number
+}
+
+// ── Estado del adapter ──────────────────────────────────────────────────
+
+export type WhatsAppAdapterState =
+  | 'idle'
+  | 'connecting'
+  | 'qr'
+  | 'open'
+  | 'closed'
+  | 'reconnecting'
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+interface WhatsAppBaileysConfig {
+  sessionsDir?:          string
+  maxReconnectAttempts?: number
+  qrTimeoutMs?:         number
+  printQrInTerminal?:   boolean
+  browser?:             [string, string, string]
+}
+
+// ── WhatsAppBaileysAdapter ───────────────────────────────────────────────
+
+export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
+  readonly channel = 'whatsapp-baileys'
+
+  // Estado interno
+  private _state:           WhatsAppAdapterState = 'idle'
+  private sock:              BaileysSocket | null  = null
+  private qrTimeoutHandle:  ReturnType<typeof setTimeout> | null = null
+  private connectPromise:   Promise<void> | null = null
+
+  // Backoff (F3a-23)
+  private backoff = new ExponentialBackoff({
+    baseMs:     3_000,
+    capMs:      90_000,
+    maxRetries: 8,
+    factor:     2,
+  })
+
+  // Config
+  private sessionsDir          = process.env['WA_SESSIONS_DIR'] ?? './data/wa-sessions'
+  private maxReconnectAttempts = parseInt(process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? '8')
+  private qrTimeoutMs          = 120_000
+  private printQrInTerminal    = false
+  private browser: [string, string, string] = ['AgentVS Gateway', 'Chrome', '120.0']
+
+  private readonly emitter = new EventEmitter()
+
+  // ── Estado público ───────────────────────────────────────────────────────────
+
+  get state(): WhatsAppAdapterState { return this._state }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  async initialize(channelConfigId: string): Promise<void> {
+    this.channelConfigId = channelConfigId
+    console.warn('[whatsapp-baileys] initialize() sin credenciales — usar setup(config, secrets)')
+  }
+
+  async setup(
+    config:   Record<string, unknown>,
+    _secrets: Record<string, unknown>,
+  ): Promise<void> {
+    const cfg = config as WhatsAppBaileysConfig
+    this.sessionsDir = String(
+      process.env['WA_SESSIONS_DIR'] ?? cfg.sessionsDir ?? './data/wa-sessions',
+    )
+    this.maxReconnectAttempts = Number(
+      process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? cfg.maxReconnectAttempts ?? 8,
+    )
+    this.qrTimeoutMs       = Number(cfg.qrTimeoutMs    ?? 120_000)
+    this.printQrInTerminal = Boolean(cfg.printQrInTerminal ?? false)
+    if (cfg.browser) this.browser = cfg.browser
+
+    fs.mkdirSync(this.getSessionPath(), { recursive: true })
+    console.info(
+      `[whatsapp-baileys] Adapter configured (lazy) — channelId=${this.channelConfigId}`,
+    )
+  }
+
+  async connect(): Promise<void> {
+    if (this._state === 'open') return
+    if (this.connectPromise) return this.connectPromise
+
+    this.connectPromise = this.doConnect()
+    try {
+      await this.connectPromise
+    } finally {
+      this.connectPromise = null
+    }
+  }
+
+  private async doConnect(): Promise<void> {
+    this.setState('connecting')
+
+    const baileys = await import('@whiskeysockets/baileys').catch((err: unknown) => {
+      throw new Error(
+        `[whatsapp-baileys] No se pudo cargar @whiskeysockets/baileys: ${String(err)}`,
+      )
+    })
+
+    const { makeWASocket, useMultiFileAuthState, DisconnectReason: DR, fetchLatestBaileysVersion } =
+      baileys as unknown as {
+        makeWASocket:          (opts: Record<string, unknown>) => BaileysSocket
+        useMultiFileAuthState: (dir: string) => Promise<{ state: unknown; saveCreds: () => Promise<void> }>
+        DisconnectReason:      DisconnectReason
+        fetchLatestBaileysVersion: () => Promise<{ version: [number, number, number] }>
+      }
+
+    const sessionPath       = this.getSessionPath()
+    const { state, saveCreds } = await useMultiFileAuthState(sessionPath)
+    const { version }        = await fetchLatestBaileysVersion()
+
+    const sock = makeWASocket({
+      version,
+      auth:              state,
+      printQRInTerminal: this.printQrInTerminal,
+      browser:           this.browser,
+      logger:            this.makePinoLogger(),
+      retryRequestDelayMs: 0,
+    }) as BaileysSocket
+
+    this.sock = sock
+
+    // ── connection.update ─────────────────────────────────────────────────
+    sock.ev.on('connection.update', ((update: {
+      connection?: string
+      lastDisconnect?: { error?: { output?: { statusCode?: number } } }
+      qr?: string
+    }) => {
+      const { connection, lastDisconnect, qr } = update
+
+      if (qr) { this.handleQr(qr) }
+
+      if (connection === 'close') {
+        this.clearQrTimeout()
+        const statusCode = lastDisconnect?.error?.output?.statusCode
+        const isPermanentClose =
+          statusCode === (DR as unknown as DisconnectReason).loggedOut ||
+          statusCode === (DR as unknown as DisconnectReason).connectionReplaced
+
+        if (isPermanentClose) {
+          console.warn(`[whatsapp-baileys:${this.channelConfigId}] Permanent close (${statusCode}) — clearing session`)
+          this.clearSessionFiles()
+          this.setState('closed')
+          this.emitter.emit('closed', this.channelConfigId, 'permanent_close')
+          return
+        }
+
+        // Reconexión con ExponentialBackoff (F3a-23)
+        if (!this.backoff.exhausted && !this.backoff.isAborted) {
+          this.setState('reconnecting')
+          this.sock = null
+          this.connectPromise = null
+
+          console.warn(
+            `[whatsapp-baileys:${this.channelConfigId}] Disconnected — ${this.backoff}`,
+          )
+
+          this.backoff.next()
+            .then(() => this.connect())
+            .catch((err: Error) => {
+              if (err.message === 'backoff_exhausted') {
+                this.setState('closed')
+                this.emitter.emit('closed', this.channelConfigId, 'max_retries_exceeded')
+                console.error(
+                  `[whatsapp-baileys:${this.channelConfigId}] Max retries reached`,
+                )
+              } else if (err.message !== 'backoff_aborted') {
+                console.error(
+                  `[whatsapp-baileys:${this.channelConfigId}] Reconnect error:`, err,
+                )
+              }
+              // 'backoff_aborted' = dispose() fue llamado — silencio intencional
+            })
+        } else {
+          this.setState('closed')
+          this.emitter.emit('closed', this.channelConfigId, 'max_retries_exceeded')
+        }
+      }
+
+      if (connection === 'open') {
+        this.clearQrTimeout()
+        this.backoff.reset()   // F3a-23: resetear tras conexión exitosa
+        this.setState('open')
+        console.info(
+          `[whatsapp-baileys:${this.channelConfigId}] Connected — jid=${sock.user?.id ?? 'unknown'}`,
+        )
+      }
+    }) as (...args: unknown[]) => void)
+
+    sock.ev.on('creds.update', saveCreds as unknown as (...args: unknown[]) => void)
+
+    // ── messages.upsert: usa baileysToIncoming() (F3a-24) ──────────────────
+    sock.ev.on('messages.upsert', ((event: { messages: unknown[]; type: string }) => {
+      if (event.type !== 'notify') return
+
+      for (const rawMsg of event.messages) {
+        // Castear a proto.IWebMessageInfo (estructura compatible)
+        const waMsg = rawMsg as Parameters<typeof baileysToIncoming>[0]
+        const normalized = baileysToIncoming(waMsg)
+        if (!normalized) continue   // null = mensaje propio / sistema / no soportado
+
+        this.emit(normalized).catch((err: unknown) =>
+          console.error(
+            `[whatsapp-baileys:${this.channelConfigId}] emit error (${(waMsg as any).key?.id}):`,
+            err,
+          ),
+        )
+      }
+    }) as (...args: unknown[]) => void)
+  }
+
+  // ── dispose (F3a-23: abortar backoff) ───────────────────────────────────
+
+  async dispose(): Promise<void> {
+    this.backoff.abort()   // F3a-23: cancelar timer de reconexion pendiente
+    this.clearQrTimeout()
+    this.setState('closed')
+
+    if (this.sock) {
+      try {
+        this.sock.ev.removeAllListeners()
+        this.sock.end()
+      } catch { /* ignorar */ }
+      this.sock = null
+    }
+
+    this.emitter.removeAllListeners()
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] Adapter disposed`)
+  }
+
+  // ── logout (F3a-23) ──────────────────────────────────────────────────────
+
+  /**
+   * Cierra la sesión de WhatsApp Web notificando al servidor WA.
+   * Después de logout(), el estado queda 'closed'.
+   * Se puede volver a conectar con connect() → generará nuevo QR.
+   */
+  async logout(): Promise<void> {
+    this.backoff.abort()
+    this.clearQrTimeout()
+
+    if (this.sock) {
+      try {
+        await this.sock.logout()
+      } catch (err) {
+        console.warn(`[whatsapp-baileys:${this.channelConfigId}] logout error:`, err)
+      } finally {
+        this.sock.ev.removeAllListeners()
+        this.sock.end()
+        this.sock = null
+      }
+    }
+
+    this.connectPromise = null
+    this.setState('closed')
+    this.emitter.emit('closed', this.channelConfigId, 'logged_out')
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] Logged out`)
+  }
+
+  // ── send() — usa outgoingToBaileys() (F3a-24) ─────────────────────────
+
+  async send(message: OutgoingMessage): Promise<void> {
+    if (this._state === 'idle' || this._state === 'closed') {
+      await this.connect()
+    }
+    if (this._state !== 'open') {
+      await this.waitForOpen(30_000)
+    }
+    if (!this.sock) {
+      throw new Error(`[whatsapp-baileys:${this.channelConfigId}] Socket not available`)
+    }
+
+    const { jid, content } = outgoingToBaileys(message)
+    await this.sock.sendMessage(jid, content)
+
+    console.info(
+      `[whatsapp-baileys:${this.channelConfigId}] Message sent to ${message.externalId}`,
+    )
+  }
+
+  // ── receive() ────────────────────────────────────────────────────────────
+
+  async receive(
+    rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
+  ): Promise<ReturnType<typeof baileysToIncoming>> {
+    return baileysToIncoming(rawPayload as Parameters<typeof baileysToIncoming>[0])
+  }
+
+  // ── Callbacks públicos ──────────────────────────────────────────────────────
+
+  onQr(handler: (qr: string) => void): void {
+    this.emitter.on('qr', handler)
+  }
+
+  onConnected(handler: () => void): void {
+    this.emitter.on('open', handler)
+  }
+
+  onDisconnected(handler: () => void): void {
+    this.emitter.on('closed', handler)
+  }
+
+  onStateChange(handler: (state: WhatsAppAdapterState) => void): void {
+    this.emitter.on('state', handler)
+  }
+
+  onError(handler: (err: Error) => void): void {
+    this.emitter.on('error', handler)
+  }
+
+  getState(): WhatsAppAdapterState { return this._state }
+
+  // ── Helpers privados ───────────────────────────────────────────────────────────
+
+  private setState(newState: WhatsAppAdapterState): void {
+    if (this._state === newState) return
+    const prev = this._state
+    this._state = newState
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] State: ${prev} → ${newState}`)
+    this.emitter.emit('state', newState)
+    if (newState === 'open')   this.emitter.emit('open')
+    if (newState === 'closed') this.emitter.emit('closed', this.channelConfigId)
+  }
+
+  private clearQrTimeout(): void {
+    if (this.qrTimeoutHandle !== null) {
+      clearTimeout(this.qrTimeoutHandle)
+      this.qrTimeoutHandle = null
+    }
+  }
+
+  private handleQr(qr: string): void {
+    this.setState('qr')
+    this.emitter.emit('qr', qr)
+    this.clearQrTimeout()
+    this.qrTimeoutHandle = setTimeout(() => {
+      console.warn(`[whatsapp-baileys:${this.channelConfigId}] QR timeout — closing socket`)
+      this.setState('closed')
+      this.sock?.end(new Error('QR timeout'))
+      this.sock = null
+    }, this.qrTimeoutMs)
+  }
+
+  private getSessionPath(): string {
+    return path.join(this.sessionsDir, this.channelConfigId || 'default')
+  }
+
+  private clearSessionFiles(): void {
+    const sessionPath = this.getSessionPath()
+    try {
+      fs.rmSync(sessionPath, { recursive: true, force: true })
+      console.info(`[whatsapp-baileys:${this.channelConfigId}] Auth state deleted: ${sessionPath}`)
+    } catch (err) {
+      console.error(`[whatsapp-baileys:${this.channelConfigId}] Error deleting auth state:`, err)
+    }
+  }
+
+  /**
+   * Espera hasta que el estado sea 'open' o se alcance el timeout.
+   * Usado en send() para lazy connect.
+   */
+  private waitForOpen(timeoutMs: number): Promise<void> {
+    if (this._state === 'open') return Promise.resolve()
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.emitter.off('open', onOpen)
+        reject(new Error(`[whatsapp-baileys:${this.channelConfigId}] waitForOpen timeout`))
+      }, timeoutMs)
+      const onOpen = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      this.emitter.once('open', onOpen)
+    })
+  }
+
+  private makePinoLogger() {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pino = require('pino') as (opts: Record<string, unknown>) => unknown
+      return pino({ level: 'silent' })
+    } catch {
+      return undefined
+    }
+  }
+}

--- a/apps/gateway/src/channels/whatsapp-deprovision.service.ts
+++ b/apps/gateway/src/channels/whatsapp-deprovision.service.ts
@@ -1,0 +1,102 @@
+/**
+ * whatsapp-deprovision.service.ts — [F3a-23]
+ */
+
+import { existsSync, rmSync } from 'node:fs'
+import path from 'node:path'
+import type { PrismaClient } from '@prisma/client'
+import type { WhatsAppSessionStore } from '../whatsapp-session.store.js'
+
+const WA_SESSIONS_DIR = process.env.WA_SESSIONS_DIR ?? './data/wa-sessions'
+
+export interface LogoutResult {
+  configId: string
+  sessionDeleted: boolean
+  adapterState: string
+}
+
+export interface DeprovisionResult extends LogoutResult {
+  channelDeactivated: boolean
+  storeDestroyed: boolean
+}
+
+export class WhatsAppDeprovisionService {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly store: WhatsAppSessionStore,
+  ) {}
+
+  async logout(configId: string): Promise<LogoutResult> {
+    const entry = this.store.get(configId)
+    const adapter = entry?.adapter as {
+      state?: string
+      logout?: () => Promise<void>
+      dispose: () => Promise<void>
+    } | undefined
+
+    if (adapter) {
+      if (adapter.state === 'open' || adapter.state === 'reconnecting') {
+        await adapter.logout?.().catch((err) => {
+          console.warn(`[wa-deprovision] logout error (${configId}):`, err)
+        })
+      } else {
+        await adapter.dispose().catch((err) => {
+          console.warn(`[wa-deprovision] dispose error (${configId}):`, err)
+        })
+      }
+    }
+
+    const sessionDir = path.join(WA_SESSIONS_DIR, configId)
+    const sessionDeleted = this.deleteSessionDir(sessionDir)
+
+    return {
+      configId,
+      sessionDeleted,
+      adapterState: adapter?.state ?? 'not_in_store',
+    }
+  }
+
+  async deprovision(configId: string): Promise<DeprovisionResult> {
+    const logoutResult = await this.logout(configId)
+
+    let channelDeactivated = false
+    try {
+      await this.db.channelConfig.update({
+        where: { id: configId },
+        data: { active: false },
+      })
+      channelDeactivated = true
+    } catch (err: any) {
+      if (err?.code !== 'P2025') {
+        console.error('[wa-deprovision] DB update error:', err)
+      }
+    }
+
+    let storeDestroyed = false
+    try {
+      this.store.remove(configId)
+      storeDestroyed = true
+    } catch (err) {
+      console.error('[wa-deprovision] store.remove error:', err)
+    }
+
+    return {
+      ...logoutResult,
+      channelDeactivated,
+      storeDestroyed,
+    }
+  }
+
+  private deleteSessionDir(sessionDir: string): boolean {
+    try {
+      if (existsSync(sessionDir)) {
+        rmSync(sessionDir, { recursive: true, force: true })
+        return true
+      }
+      return false
+    } catch (err) {
+      console.error('[wa-deprovision] Failed to delete session dir:', err)
+      return false
+    }
+  }
+}

--- a/apps/gateway/src/channels/whatsapp-deprovision.service.ts
+++ b/apps/gateway/src/channels/whatsapp-deprovision.service.ts
@@ -1,5 +1,26 @@
 /**
  * whatsapp-deprovision.service.ts — [F3a-23]
+ *
+ * Servicio que coordina el ciclo completo de logout y deprovision
+ * para sesiones WhatsApp Baileys.
+ *
+ * logout(configId):
+ *   1. Cierra el socket Baileys limpiamente (sock.logout())
+ *   2. Borra los archivos de sesión del filesystem
+ *   3. El ChannelConfig en Prisma NO se modifica (canal sigue activo)
+ *   4. El adapter en el store queda en estado 'closed'
+ *   → Admin puede re-conectar con nuevo QR
+ *
+ * deprovision(configId):
+ *   1. logout() completo
+ *   2. Desactiva el ChannelConfig en Prisma: active = false
+ *   3. Destruye la sesión en WhatsAppSessionStore (remove)
+ *   → Canal queda inoperativo hasta reactivación manual
+ *
+ * IMPORTANTE:
+ *   - Recibe PrismaClient inyectado — no crea instancia propia
+ *   - Recibe WhatsAppSessionStore inyectado — no usa singleton directamente
+ *     (facilita testing con mocks)
  */
 
 import { existsSync, rmSync } from 'node:fs'
@@ -9,45 +30,58 @@ import type { WhatsAppSessionStore } from '../whatsapp-session.store.js'
 
 const WA_SESSIONS_DIR = process.env.WA_SESSIONS_DIR ?? './data/wa-sessions'
 
+// ── Tipos ────────────────────────────────────────────────────────────────────
+
 export interface LogoutResult {
-  configId: string
+  configId:       string
   sessionDeleted: boolean
-  adapterState: string
+  adapterState:   string
 }
 
 export interface DeprovisionResult extends LogoutResult {
   channelDeactivated: boolean
-  storeDestroyed: boolean
+  storeDestroyed:     boolean
 }
+
+// ── Servicio ─────────────────────────────────────────────────────────────────
 
 export class WhatsAppDeprovisionService {
   constructor(
-    private readonly db: PrismaClient,
+    private readonly db:    PrismaClient,
     private readonly store: WhatsAppSessionStore,
   ) {}
 
+  // ── logout ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Cierra la sesión WA Web y borra archivos de credenciales.
+   * El canal sigue activo en DB — solo se limpia la sesión.
+   */
   async logout(configId: string): Promise<LogoutResult> {
-    const entry = this.store.get(configId)
-    const adapter = entry?.adapter as {
-      state?: string
-      logout?: () => Promise<void>
-      dispose: () => Promise<void>
-    } | undefined
+    const entry   = this.store.get(configId)
+    const adapter = entry?.adapter
 
     if (adapter) {
+      // 'open' | 'reconnecting' → usar logout() que notifica al servidor WA
+      // cualquier otro estado   → dispose() es suficiente para limpiar recursos
       if (adapter.state === 'open' || adapter.state === 'reconnecting') {
-        await adapter.logout?.().catch((err) => {
-          console.warn(`[wa-deprovision] logout error (${configId}):`, err)
-        })
+        await adapter.logout?.().catch((err: unknown) =>
+          console.warn(`[wa-deprovision] logout error (${configId}):`, err),
+        )
       } else {
-        await adapter.dispose().catch((err) => {
-          console.warn(`[wa-deprovision] dispose error (${configId}):`, err)
-        })
+        await adapter.dispose().catch((err: unknown) =>
+          console.warn(`[wa-deprovision] dispose error (${configId}):`, err),
+        )
       }
     }
 
-    const sessionDir = path.join(WA_SESSIONS_DIR, configId)
+    // Borrar archivos de sesión del filesystem
+    const sessionDir    = path.join(WA_SESSIONS_DIR, configId)
     const sessionDeleted = this.deleteSessionDir(sessionDir)
+
+    console.info(
+      `[wa-deprovision] logout complete — configId=${configId}, sessionDeleted=${sessionDeleted}`,
+    )
 
     return {
       configId,
@@ -56,22 +90,39 @@ export class WhatsAppDeprovisionService {
     }
   }
 
+  // ── deprovision ────────────────────────────────────────────────────────────
+
+  /**
+   * Deprovision completo:
+   *   logout() → deactivate ChannelConfig in Prisma → destroy store entry
+   *
+   * Tolerante a fallos: cada paso se intenta independientemente.
+   * Si falla la actualización de DB, los demás pasos siguen ejecutándose.
+   * Se retorna un resultado parcial indicando qué operaciones tuvieron éxito.
+   */
   async deprovision(configId: string): Promise<DeprovisionResult> {
+    // 1. Logout (cierra socket + borra FS)
     const logoutResult = await this.logout(configId)
 
+    // 2. Desactivar ChannelConfig en Prisma
     let channelDeactivated = false
     try {
       await this.db.channelConfig.update({
         where: { id: configId },
-        data: { active: false },
+        data:  { active: false },
       })
       channelDeactivated = true
+      console.info(`[wa-deprovision] ChannelConfig deactivated: ${configId}`)
     } catch (err: any) {
-      if (err?.code !== 'P2025') {
+      // P2025 = registro no encontrado en Prisma — no es error crítico
+      if (err?.code === 'P2025') {
+        console.warn(`[wa-deprovision] ChannelConfig not found in DB: ${configId}`)
+      } else {
         console.error('[wa-deprovision] DB update error:', err)
       }
     }
 
+    // 3. Destruir entrada en el store (cierra SSE clients)
     let storeDestroyed = false
     try {
       this.store.remove(configId)
@@ -80,17 +131,27 @@ export class WhatsAppDeprovisionService {
       console.error('[wa-deprovision] store.remove error:', err)
     }
 
-    return {
+    const result: DeprovisionResult = {
       ...logoutResult,
       channelDeactivated,
       storeDestroyed,
     }
+
+    console.info(
+      `[wa-deprovision] deprovision complete — configId=${configId}`,
+      result,
+    )
+
+    return result
   }
+
+  // ── Helper ─────────────────────────────────────────────────────────────────
 
   private deleteSessionDir(sessionDir: string): boolean {
     try {
       if (existsSync(sessionDir)) {
         rmSync(sessionDir, { recursive: true, force: true })
+        console.info(`[wa-deprovision] Session dir deleted: ${sessionDir}`)
         return true
       }
       return false

--- a/apps/gateway/src/channels/whatsapp-message.mapper.ts
+++ b/apps/gateway/src/channels/whatsapp-message.mapper.ts
@@ -1,0 +1,363 @@
+/**
+ * whatsapp-message.mapper.ts — [F3a-24]
+ *
+ * Normaliza WAMessage (proto.IWebMessageInfo de Baileys) a IncomingMessage.
+ *
+ * Función principal: baileysToIncoming()
+ *   - Retorna IncomingMessage si el mensaje es procesable
+ *   - Retorna null si el mensaje debe ignorarse:
+ *       * mensajes del propio bot (fromMe = true)
+ *       * mensajes de sistema (protocolMessage, ephemeralMessage, etc.)
+ *       * tipos no soportados
+ *
+ * Diseño:
+ *   - Función pura — sin efectos secundarios, sin imports de servicios
+ *   - Los datos raw de Baileys siempre se preservan en rawPayload
+ *   - La URL de media NO se descarga aquí — el caller puede pedirla
+ *     via sock.downloadMediaMessage() usando rawPayload
+ */
+
+import type { proto }          from '@whiskeysockets/baileys'
+import type { IncomingMessage } from './channel-adapter.interface.js'
+
+// ── Tipos de mensajes que silenciosamente ignoramos ─────────────────────
+
+const IGNORED_MSG_TYPES = new Set([
+  'protocolMessage',
+  'ephemeralMessage',
+  'senderKeyDistributionMessage',
+  'pollCreationMessage',
+  'pollUpdateMessage',
+  'viewOnceMessage',
+  'viewOnceMessageV2',
+  'liveLocationMessage',
+  'callLogMesssage',
+  'requestPaymentMessage',
+  'sendPaymentMessage',
+])
+
+// ── Opciones ─────────────────────────────────────────────────────────────────
+
+export interface BaileysMapperOptions {
+  /** Si true, los mensajes de reacción se procesan como type 'command'. Default: false */
+  processReactions?: boolean
+}
+
+// ── Función principal ─────────────────────────────────────────────────────────
+
+/**
+ * Convierte un WAMessage de Baileys en IncomingMessage normalizado.
+ *
+ * @param waMsg  - Mensaje raw de Baileys (proto.IWebMessageInfo)
+ * @param opts   - Opciones de procesamiento
+ * @returns IncomingMessage normalizado, o null si debe ignorarse
+ */
+export function baileysToIncoming(
+  waMsg: proto.IWebMessageInfo,
+  opts: BaileysMapperOptions = {},
+): IncomingMessage | null {
+
+  // 1. Ignorar mensajes propios (el bot enviando)
+  if (waMsg.key.fromMe) return null
+
+  // 2. Ignorar status broadcasts
+  const remoteJid = waMsg.key.remoteJid ?? ''
+  if (remoteJid === 'status@broadcast') return null
+
+  // 3. Extraer JID del remitente y del chat
+  const senderJid = waMsg.key.participant ?? remoteJid   // en grupos, participant ≠ jid
+  const isGroup   = isGroupJid(remoteJid)
+
+  // 4. Normalizar JID → número de teléfono
+  const externalId = jidToPhone(remoteJid)
+  const senderId   = jidToPhone(senderJid)
+
+  if (!externalId) {
+    console.warn('[wa-mapper] Could not extract phone from JID:', remoteJid)
+    return null
+  }
+
+  // 5. Obtener el contenido del mensaje
+  const msgContent = waMsg.message
+  if (!msgContent) return null
+
+  // 6. Detectar tipo y comprobar si debe ignorarse
+  const msgKey = detectMessageKey(msgContent)
+  if (!msgKey) return null
+
+  // 7. Ignorar tipos de sistema (reactionMessage se ignora por defecto)
+  if (IGNORED_MSG_TYPES.has(msgKey)) return null
+  if (msgKey === 'reactionMessage' && !opts.processReactions) return null
+
+  // 8. Timestamp normalizado
+  const timestamp = waMsg.messageTimestamp
+    ? new Date(Number(waMsg.messageTimestamp) * 1000).toISOString()
+    : new Date().toISOString()
+
+  // 9. rawPayload: el WAMessage completo (sin secretos — Baileys no los incluye aquí)
+  const rawPayload = waMsg as unknown as Record<string, unknown>
+
+  // 10. Base metadata
+  const baseMetadata: Record<string, unknown> = {
+    msgId:   waMsg.key.id ?? '',
+    jid:     remoteJid,
+    isGroup,
+    pushName: (waMsg as any).pushName ?? '',
+  }
+
+  // 11. Mapear por tipo
+  return mapByType(msgKey, msgContent, {
+    externalId,
+    senderId,
+    threadId:    externalId,   // WA no tiene threads — threadId === externalId
+    rawPayload,
+    timestamp,
+    baseMetadata,
+  })
+}
+
+// ── Detectar tipo de mensaje ───────────────────────────────────────────────────
+
+const KNOWN_KEYS: (keyof proto.IMessage)[] = [
+  'conversation',
+  'extendedTextMessage',
+  'imageMessage',
+  'audioMessage',
+  'videoMessage',
+  'documentMessage',
+  'stickerMessage',
+  'locationMessage',
+  'contactMessage',
+  'reactionMessage',
+  'protocolMessage',
+  'ephemeralMessage',
+  'senderKeyDistributionMessage',
+  'pollCreationMessage',
+  'pollUpdateMessage',
+]
+
+function detectMessageKey(msg: proto.IMessage): string | null {
+  for (const key of KNOWN_KEYS) {
+    if (msg[key] != null) return key as string
+  }
+  const fallback = Object.keys(msg).find((k) => (msg as any)[k] != null)
+  return fallback ?? null
+}
+
+// ── Contexto de mapeo ────────────────────────────────────────────────────────────
+
+interface MapCtx {
+  externalId:   string
+  senderId:     string
+  threadId:     string
+  rawPayload:   Record<string, unknown>
+  timestamp:    string
+  baseMetadata: Record<string, unknown>
+}
+
+// ── Mapeo por tipo ────────────────────────────────────────────────────────────────
+
+function mapByType(
+  key:     string,
+  content: proto.IMessage,
+  ctx:     MapCtx,
+): IncomingMessage | null {
+
+  const base = {
+    externalId:  ctx.externalId,
+    senderId:    ctx.senderId,
+    threadId:    ctx.threadId,
+    rawPayload:  ctx.rawPayload,
+    receivedAt:  ctx.timestamp,
+  }
+
+  switch (key) {
+
+    // ── Texto plano ─────────────────────────────────────────────────
+    case 'conversation': {
+      const text = content.conversation ?? ''
+      return {
+        ...base,
+        text,
+        type: text.startsWith('/') ? 'command' : 'text',
+        metadata: { ...ctx.baseMetadata },
+      }
+    }
+
+    // ── Texto enriquecido ──────────────────────────────────────────────
+    case 'extendedTextMessage': {
+      const text = content.extendedTextMessage?.text ?? ''
+      return {
+        ...base,
+        text,
+        type: text.startsWith('/') ? 'command' : 'text',
+        metadata: {
+          ...ctx.baseMetadata,
+          contextInfo: content.extendedTextMessage?.contextInfo,
+          previewUrl:  content.extendedTextMessage?.canonicalUrl,
+        },
+      }
+    }
+
+    // ── Imagen ────────────────────────────────────────────────────
+    case 'imageMessage':
+      return {
+        ...base,
+        text:  content.imageMessage?.caption ?? '',
+        type:  'image',
+        attachments: [{
+          type: 'image',
+          data: {
+            mimetype: content.imageMessage?.mimetype ?? 'image/jpeg',
+            caption:  content.imageMessage?.caption  ?? '',
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Audio / nota de voz ───────────────────────────────────────────
+    case 'audioMessage':
+      return {
+        ...base,
+        text: '',
+        type: 'audio',
+        attachments: [{
+          type: content.audioMessage?.ptt ? 'voice_note' : 'audio',
+          data: {
+            mimetype: content.audioMessage?.mimetype ?? 'audio/ogg',
+            seconds:  content.audioMessage?.seconds  ?? 0,
+            ptt:      content.audioMessage?.ptt      ?? false,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Video ─────────────────────────────────────────────────────
+    case 'videoMessage':
+      return {
+        ...base,
+        text:  content.videoMessage?.caption ?? '',
+        type:  'file',
+        attachments: [{
+          type: 'video',
+          data: {
+            mimetype: content.videoMessage?.mimetype ?? 'video/mp4',
+            caption:  content.videoMessage?.caption  ?? '',
+            seconds:  content.videoMessage?.seconds  ?? 0,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Documento ───────────────────────────────────────────────────
+    case 'documentMessage':
+      return {
+        ...base,
+        text:  content.documentMessage?.caption ?? '',
+        type:  'file',
+        attachments: [{
+          type: 'document',
+          data: {
+            fileName: content.documentMessage?.fileName ?? 'document',
+            mimetype: content.documentMessage?.mimetype ?? 'application/octet-stream',
+            fileSize: content.documentMessage?.fileLength ?? 0,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Sticker ────────────────────────────────────────────────────
+    case 'stickerMessage':
+      return {
+        ...base,
+        text:  '[sticker]',
+        type:  'image',
+        attachments: [{
+          type: 'sticker',
+          data: {
+            mimetype:   content.stickerMessage?.mimetype    ?? 'image/webp',
+            isAnimated: content.stickerMessage?.isAnimated ?? false,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Ubicación ──────────────────────────────────────────────────
+    case 'locationMessage': {
+      const lat  = content.locationMessage?.degreesLatitude  ?? 0
+      const lng  = content.locationMessage?.degreesLongitude ?? 0
+      const name = content.locationMessage?.name ?? ''
+      return {
+        ...base,
+        text: name
+          ? `📍 ${name} (${lat}, ${lng})`
+          : `📍 Location: ${lat}, ${lng}`,
+        type: 'text',
+        metadata: {
+          ...ctx.baseMetadata,
+          location: { lat, lng, name },
+        },
+      }
+    }
+
+    // ── Contacto ───────────────────────────────────────────────────
+    case 'contactMessage': {
+      const displayName = content.contactMessage?.displayName ?? 'Contact'
+      const vcard       = content.contactMessage?.vcard ?? ''
+      const telMatch    = vcard.match(/TEL[^:]*:([^\r\n]+)/)
+      const phone       = telMatch?.[1]?.trim() ?? ''
+      return {
+        ...base,
+        text: phone
+          ? `\ud83d\udc64 ${displayName}: ${phone}`
+          : `\ud83d\udc64 ${displayName}`,
+        type: 'text',
+        metadata: {
+          ...ctx.baseMetadata,
+          contact: { displayName, phone, vcard },
+        },
+      }
+    }
+
+    // ── Reacción ───────────────────────────────────────────────────
+    case 'reactionMessage': {
+      const emoji    = content.reactionMessage?.text ?? ''
+      const targetId = content.reactionMessage?.key?.id ?? ''
+      return {
+        ...base,
+        text:  emoji,
+        type:  'command',
+        metadata: {
+          ...ctx.baseMetadata,
+          reaction: { emoji, targetMessageId: targetId },
+        },
+      }
+    }
+
+    default:
+      return null
+  }
+}
+
+// ── Helpers públicos ────────────────────────────────────────────────────────────
+
+/**
+ * Convierte un JID de Baileys al número de teléfono sin sufijo.
+ * Ejemplos:
+ *   '521234567890@s.whatsapp.net'   → '521234567890'
+ *   '521234567890:5@s.whatsapp.net' → '521234567890'  (multi-device)
+ *   '120363123456@g.us'             → '120363123456'  (grupo)
+ *   ''                              → ''
+ */
+export function jidToPhone(jid: string): string {
+  if (!jid) return ''
+  const withoutSuffix = jid.split('@')[0] ?? ''
+  return withoutSuffix.split(':')[0] ?? ''
+}
+
+/**
+ * Retorna true si el JID corresponde a un grupo de WhatsApp.
+ */
+export function isGroupJid(jid: string): boolean {
+  return jid.endsWith('@g.us')
+}

--- a/apps/gateway/src/channels/whatsapp-send.mapper.ts
+++ b/apps/gateway/src/channels/whatsapp-send.mapper.ts
@@ -1,0 +1,178 @@
+/**
+ * whatsapp-send.mapper.ts — [F3a-24]
+ *
+ * Convierte OutgoingMessage (interfaz genérica del gateway) al payload
+ * que acepta sock.sendMessage(jid, content) de Baileys.
+ *
+ * Función principal: outgoingToBaileys()
+ *
+ * Tipos de richContent soportados:
+ *   richContent.type = 'buttons'   → ButtonMessage de Baileys
+ *   richContent.type = 'list'      → ListMessage de Baileys
+ *   richContent.type = 'template'  → TemplateMessage (WA Business)
+ *   (sin richContent)              → texto plano
+ *
+ * Función auxiliar: phoneToJid()
+ *   Convierte número de teléfono a JID de Baileys.
+ *   '521234567890' → '521234567890@s.whatsapp.net'
+ *   Idempotente: si recibe un JID ya formado, lo retorna tal cual.
+ */
+
+import type { OutgoingMessage } from './channel-adapter.interface.js'
+
+// AnyMessageContent de Baileys es Record<string,unknown> en nuestra capa de tipos
+type BaileysContent = Record<string, unknown>
+
+// ── Tipos de richContent ──────────────────────────────────────────────────
+
+export interface ButtonsRichContent {
+  type:    'buttons'
+  body:    string
+  footer?: string
+  buttons: Array<{ id: string; title: string }>
+}
+
+export interface ListRichContent {
+  type:        'list'
+  title:       string
+  description: string
+  buttonText:  string
+  footer?:     string
+  sections:    Array<{
+    title: string
+    rows:  Array<{ id: string; title: string; description?: string }>
+  }>
+}
+
+export interface TemplateRichContent {
+  type:    'template'
+  text:    string
+  footer?: string
+  buttons: Array<{
+    index:             number
+    urlButton?:        { displayText: string; url: string }
+    callButton?:       { displayText: string; phoneNumber: string }
+    quickReplyButton?: { displayText: string; id: string }
+  }>
+}
+
+type WARichContent = ButtonsRichContent | ListRichContent | TemplateRichContent
+
+// ── Función principal ────────────────────────────────────────────────────────
+
+/**
+ * Convierte OutgoingMessage al payload de sock.sendMessage().
+ * Nunca lanza excepciones — hace fallback a texto plano para tipos desconocidos.
+ *
+ * @returns { jid, content } donde content es el payload de Baileys
+ */
+export function outgoingToBaileys(message: OutgoingMessage): {
+  jid:     string
+  content: BaileysContent
+} {
+  const jid = phoneToJid(message.externalId)
+
+  // Sin richContent → texto plano
+  if (!message.richContent) {
+    return { jid, content: { text: message.text ?? '' } }
+  }
+
+  const rich = message.richContent as WARichContent
+
+  switch (rich.type) {
+
+    // ── Botones ──────────────────────────────────────────────────────
+    case 'buttons': {
+      const r = rich as ButtonsRichContent
+      return {
+        jid,
+        content: {
+          buttons: r.buttons.map((b) => ({
+            buttonId:   b.id,
+            buttonText: { displayText: b.title },
+            type:       1,
+          })),
+          text:       r.body,
+          footerText: r.footer ?? '',
+        },
+      }
+    }
+
+    // ── Lista ──────────────────────────────────────────────────────────
+    case 'list': {
+      const r = rich as ListRichContent
+      return {
+        jid,
+        content: {
+          listMessage: {
+            title:       r.title,
+            description: r.description,
+            buttonText:  r.buttonText,
+            footerText:  r.footer ?? '',
+            listType:    1,
+            sections:    r.sections.map((s) => ({
+              title: s.title,
+              rows:  s.rows.map((row) => ({
+                rowId:       row.id,
+                title:       row.title,
+                description: row.description ?? '',
+              })),
+            })),
+          },
+        },
+      }
+    }
+
+    // ── Template (WA Business) ───────────────────────────────────────────
+    case 'template': {
+      const r = rich as TemplateRichContent
+      return {
+        jid,
+        content: {
+          templateMessage: {
+            fourRowTemplate: {
+              content: {
+                highlyStructuredMessage: {
+                  namespace:         '',
+                  elementName:       '',
+                  params:            [],
+                  fallbackLg:        'en',
+                  fallbackLc:        'US',
+                  localizableParams: [],
+                  deterministicLg:   '',
+                  deterministicLc:   '',
+                  overrideBodyText:  r.text,
+                },
+              },
+              buttons: r.buttons,
+            },
+          },
+        },
+      }
+    }
+
+    // ── Fallback ────────────────────────────────────────────────────────────
+    default:
+      console.warn(
+        `[wa-send-mapper] Unknown richContent type: ${(rich as any)?.type ?? 'undefined'} — falling back to text`,
+      )
+      return { jid, content: { text: message.text ?? JSON.stringify(message.richContent) } }
+  }
+}
+
+// ── Helper público ──────────────────────────────────────────────────────────────
+
+/**
+ * Convierte número de teléfono a JID de WhatsApp.
+ * Idempotente: si recibe un JID ya formado (contiene '@'), lo retorna tal cual.
+ *
+ * '+52 123-456-7890'  → '521234567890@s.whatsapp.net'
+ * '+521234567890'     → '521234567890@s.whatsapp.net'
+ * '521234567890'      → '521234567890@s.whatsapp.net'
+ * '120363@g.us'       → '120363@g.us'
+ */
+export function phoneToJid(phone: string): string {
+  if (phone.includes('@')) return phone
+  const cleaned = phone.replace(/[\s\-+()]/g, '')
+  return `${cleaned}@s.whatsapp.net`
+}

--- a/apps/gateway/src/routes/whatsapp-baileys.ts
+++ b/apps/gateway/src/routes/whatsapp-baileys.ts
@@ -1,52 +1,38 @@
 /**
- * routes/whatsapp-baileys.ts - [F3a-22]
- *
- * Express router for WhatsApp Baileys sessions:
- *
- *   GET  /gateway/whatsapp/:configId/qr          - SSE stream for QR/status
- *   GET  /gateway/whatsapp/:configId/status      - JSON snapshot
- *   POST /gateway/whatsapp/:configId/connect     - start adapter and register it
- *   POST /gateway/whatsapp/:configId/disconnect  - stop adapter and remove it
- *
- * The QR stream is SSE so the UI can subscribe without WebSocket upgrades.
- * Connect/disconnect/QR are protected with the existing Logto JWT middleware.
+ * routes/whatsapp-baileys.ts — [F3a-22/F3a-23]
  */
 
 import { Router, type Request, type Response } from 'express'
-import { logtoJwtMiddleware } from '../middleware/security.middleware.js'
+import type { PrismaClient } from '@prisma/client'
 import { whatsappSessionStore } from '../whatsapp-session.store.js'
+import { WhatsAppDeprovisionService } from '../channels/whatsapp-deprovision.service.js'
 
-/**
- * Minimal constructor contract for the Baileys adapter.
- * The real adapter is imported dynamically to avoid hard coupling in tests.
- */
 interface BaileysAdapterConstructable {
   new (configId: string): {
     readonly channel: string
+    state?: string
     onQr(handler: (qr: string) => void): void
     onConnected(handler: () => void): void
     onDisconnected(handler: () => void): void
     setup(config: Record<string, unknown>, secrets: Record<string, unknown>): Promise<void>
+    logout(): Promise<void>
     dispose(): Promise<void>
   }
 }
 
-export function whatsappBaileysRouter(): Router {
+export function whatsappBaileysRouter(db: PrismaClient): Router {
   const router = Router({ mergeParams: true })
-  const requireJwt = logtoJwtMiddleware()
+  const deprovisionSvc = new WhatsAppDeprovisionService(db, whatsappSessionStore)
 
-  router.get('/:configId/qr', requireJwt, (req: Request, res: Response): void => {
+  router.get('/:configId/qr', (req: Request, res: Response): void => {
     const { configId } = req.params
-
     res.setHeader('Content-Type', 'text/event-stream')
     res.setHeader('Cache-Control', 'no-cache')
     res.setHeader('Connection', 'keep-alive')
     res.setHeader('X-Accel-Buffering', 'no')
     res.flushHeaders()
-
     res.write(': connected\n\n')
     whatsappSessionStore.addSseClient(configId, res)
-
     const heartbeat = setInterval(() => {
       try {
         res.write(': heartbeat\n\n')
@@ -54,116 +40,102 @@ export function whatsappBaileysRouter(): Router {
         clearInterval(heartbeat)
       }
     }, 25_000)
-
-    res.on('close', () => {
-      clearInterval(heartbeat)
-    })
+    res.on('close', () => clearInterval(heartbeat))
   })
 
   router.get('/:configId/status', (req: Request, res: Response): void => {
     const { configId } = req.params
     const entry = whatsappSessionStore.get(configId)
-
     if (!entry) {
       res.status(404).json({ ok: false, error: 'session not found', configId })
       return
     }
-
-    res.json({
-      ok: true,
-      configId,
-      status: entry.status,
-      hasQr: !!entry.qrBuffer,
-    })
+    res.json({ ok: true, configId, status: entry.status, hasQr: !!entry.qrBuffer })
   })
 
-  router.post('/:configId/connect', requireJwt, async (req: Request, res: Response): Promise<void> => {
+  router.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
     const { configId } = req.params
     const existing = whatsappSessionStore.get(configId)
-
     if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
-      res.status(409).json({
-        ok: false,
-        error: 'session already active',
-        configId,
-        status: existing.status,
-      })
+      res.status(409).json({ ok: false, error: 'session already active', configId, status: existing.status })
       return
     }
 
     try {
-      // Reserve the slot before the first await so concurrent connect calls fail.
-      whatsappSessionStore.setStatus(configId, 'connecting')
-
       let AdapterClass: BaileysAdapterConstructable
       try {
         const mod = await import('../channels/whatsapp.adapter.js')
-        AdapterClass = mod.WhatsAppAdapter as unknown as BaileysAdapterConstructable
+        AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
       } catch {
-        whatsappSessionStore.setStatus(configId, 'error')
-        res.status(503).json({
-          ok: false,
-          error: 'WhatsAppBaileysAdapter not available - install @whiskeysockets/baileys',
-        })
+        res.status(503).json({ ok: false, error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys' })
         return
       }
 
       const adapter = new AdapterClass(configId)
-
-      adapter.onQr((qr: string) => {
-        console.info(`[whatsapp-store] QR received for configId=${configId}`)
-        whatsappSessionStore.setQr(configId, qr)
-      })
-
-      adapter.onConnected(() => {
-        console.info(`[whatsapp-store] Connected configId=${configId}`)
-        whatsappSessionStore.setStatus(configId, 'connected')
-      })
-
-      adapter.onDisconnected(() => {
-        console.info(`[whatsapp-store] Disconnected configId=${configId}`)
-        whatsappSessionStore.setStatus(configId, 'disconnected')
-      })
+      adapter.onQr((qr: string) => whatsappSessionStore.setQr(configId, qr))
+      adapter.onConnected(() => whatsappSessionStore.setStatus(configId, 'connected'))
+      adapter.onDisconnected(() => whatsappSessionStore.setStatus(configId, 'disconnected'))
 
       whatsappSessionStore.setAdapter(configId, adapter)
+      whatsappSessionStore.setStatus(configId, 'connecting')
 
       const { config = {}, secrets = {} } = (req.body ?? {}) as {
         config?: Record<string, unknown>
         secrets?: Record<string, unknown>
       }
 
-      adapter.setup(config, secrets).catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err)
-        console.error(`[whatsapp-store] setup() error for configId=${configId}:`, msg)
+      adapter.setup(config, secrets).catch(() => {
         whatsappSessionStore.setStatus(configId, 'error')
       })
 
       res.json({ ok: true, configId, status: 'connecting' })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      whatsappSessionStore.setStatus(configId, 'error')
       res.status(500).json({ ok: false, error: msg })
     }
   })
 
-  router.post('/:configId/disconnect', requireJwt, async (req: Request, res: Response): Promise<void> => {
+  router.post('/:configId/logout', async (req: Request, res: Response): Promise<void> => {
     const { configId } = req.params
     const entry = whatsappSessionStore.get(configId)
-
-    if (!entry || !entry.adapter) {
-      res.status(404).json({ ok: false, error: 'session not found', configId })
+    if (!entry) {
+      res.status(404).json({ ok: false, error: 'session_not_found' })
       return
     }
-
     try {
-      await entry.adapter.dispose()
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      console.warn(`[whatsapp-store] dispose() error for configId=${configId}:`, msg)
+      const result = await deprovisionSvc.logout(configId)
+      res.json({ ok: true, ...result })
+    } catch (err: any) {
+      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
     }
+  })
 
-    whatsappSessionStore.remove(configId)
-    res.json({ ok: true, configId })
+  router.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
+    const { configId } = req.params
+    try {
+      const result = await deprovisionSvc.logout(configId)
+      res.json({ ok: true, ...result })
+    } catch (err: any) {
+      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
+    }
+  })
+
+  router.post('/:configId/deprovision', async (req: Request, res: Response): Promise<void> => {
+    const { configId } = req.params
+    if (req.body?.confirm !== true) {
+      res.status(400).json({
+        ok: false,
+        error: 'confirmation_required',
+        hint: 'Send { "confirm": true } in request body to confirm deprovision',
+      })
+      return
+    }
+    try {
+      const result = await deprovisionSvc.deprovision(configId)
+      res.json({ ok: true, ...result })
+    } catch (err: any) {
+      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
+    }
   })
 
   return router

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,110 +1,78 @@
 /**
- * server.ts — Gateway Express Application
- *
- * Monta todos los routers de canal y expone:
- *
- *   GET  /healthz
- *
- *   — WebChat (browser ↔ agente) —
- *   GET  /gateway/webchat/:channelId/stream
- *   POST /gateway/webchat/:channelId/message
- *   GET  /gateway/webchat/:channelId/history
- *   POST /gateway/webchat/:channelId/session
- *
- *   — Telegram —
- *   POST /gateway/telegram/:channelId
- *
- *   — Slack —
- *   POST /gateway/slack/:channelId
- *
- *   — Webhook genérico —
- *   POST /gateway/webhook/:channelId
- *   GET  /gateway/webhook/:channelId/health
- *
- *   — API interna (JWT requerida) —
- *   POST /api/webchat/:channelId/reply
- *   *    /api/channels/...
- *
- * Inspirado en Flowise Server y n8n WebhookServer.
+ * server.ts — Express app factory del Gateway
  */
 
+import path from 'path';
 import express, { type Application } from 'express';
-import type { PrismaClient }          from '@prisma/client';
-import { PrismaService }              from './prisma/prisma.service.js';
-import { AgentResolverService }       from './agent-resolver.service.js';
-import { GatewayService }             from './gateway.service.js';
-import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat.js';
-import { telegramRouter }             from './routes/telegram.js';
-import { slackRouter }                from './routes/slack.js';
-import { webhookRouter }              from './routes/webhook.js';
-import { channelsApiRouter }          from './routes/channels.js';
-
-// ---------------------------------------------------------------------------
-// AppOptions — permite inyectar mocks en tests
-// ---------------------------------------------------------------------------
+import { PrismaClient } from '@prisma/client';
+import {
+  registry,
+  TelegramAdapter,
+  WebChatAdapter,
+} from '@agent-vs/gateway-sdk';
+import { applySecurityMiddleware } from './middleware/security.middleware';
+import { GatewayService } from './gateway.service';
+import { telegramRouter } from './routes/telegram';
+import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat';
+import { channelsApiRouter } from './routes/channels';
+import { whatsappBaileysRouter } from './routes/whatsapp-baileys';
 
 export interface AppOptions {
-  /** PrismaService o mock compatible con PrismaClient (testing) */
-  db?: PrismaService | PrismaClient;
+  db?: PrismaClient;
+  corsOrigins?: string | string[];
+  requireAuth?: boolean;
 }
-
-// ---------------------------------------------------------------------------
-// createApp
-// ---------------------------------------------------------------------------
 
 export function createApp(opts: AppOptions = {}): Application {
   const app = express();
+  const db = opts.db ?? new PrismaClient();
 
-  // Instanciar PrismaService (o usar el mock inyectado)
-  const db = (opts.db ?? new PrismaService()) as PrismaService;
+  if (!registry.has('telegram')) registry.register(new TelegramAdapter());
+  if (!registry.has('webchat')) registry.register(new WebChatAdapter());
 
-  // GatewayService recibe PrismaService + AgentResolverService
-  const resolver       = new AgentResolverService(db);
-  const gatewayService = new GatewayService(db, resolver);
-
-  // -------------------------------------------------------------------------
-  // 0. Core middleware
-  // -------------------------------------------------------------------------
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
-
-  // -------------------------------------------------------------------------
-  // 1. Security headers — van ANTES de montar rutas para cubrir todas las
-  //    respuestas, incluidas las de los channel adapters y la API interna.
-  // -------------------------------------------------------------------------
-  app.use((_req, res, next) => {
-    res.setHeader('X-Content-Type-Options', 'nosniff');
-    res.setHeader('X-Frame-Options', 'DENY');
-    next();
+  applySecurityMiddleware(app, {
+    corsOrigins: opts.corsOrigins,
+    requireAuth: opts.requireAuth ?? process.env.REQUIRE_AUTH === 'true',
+    webhookRateLimit: 600,
+    apiRateLimit: 120,
   });
 
-  // -------------------------------------------------------------------------
-  // 2. Health check
-  // -------------------------------------------------------------------------
-  app.get('/healthz', (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
+  app.use(express.json({ limit: '2mb' }));
 
-  // -------------------------------------------------------------------------
-  // 3. Gateway public routes — cada canal tiene su router dedicado.
-  //    Los adaptadores son singletons gestionados por gateway-sdk registry;
-  //    no se instancian ni registran manualmente aquí.
-  // -------------------------------------------------------------------------
-  app.use('/gateway/webchat',  webchatGatewayRouter(gatewayService));
+  const publicDir = path.join(__dirname, '..', 'public');
+  app.use('/static', express.static(publicDir, {
+    maxAge: process.env.NODE_ENV === 'production' ? '1d' : 0,
+    etag: true,
+  }));
+
+  app.get('/webchat-widget.js', (_req, res) => {
+    res.sendFile(path.join(publicDir, 'webchat-widget.js'));
+  });
+
+  const gatewayService = new GatewayService(db);
+
+  app.get('/health', (_req, res) => {
+    res.json({ ok: true, service: 'gateway', ts: new Date().toISOString() });
+  });
+
   app.use('/gateway/telegram', telegramRouter(gatewayService));
-  app.use('/gateway/slack',    slackRouter(gatewayService));
-  app.use('/gateway/webhook',  webhookRouter(gatewayService));
-
-  // -------------------------------------------------------------------------
-  // 4. Internal API routes (JWT middleware a aplicar aquí si se requiere)
-  // -------------------------------------------------------------------------
-  app.use('/api/webchat',  webchatApiRouter(gatewayService));
+  app.use('/gateway/webchat', webchatGatewayRouter(gatewayService));
+  app.use('/api/webchat', webchatApiRouter(gatewayService));
   app.use('/api/channels', channelsApiRouter(db, gatewayService));
+  app.use('/gateway/whatsapp', whatsappBaileysRouter(db));
 
-  // -------------------------------------------------------------------------
-  // 5. 404 fallback
-  // -------------------------------------------------------------------------
   app.use((_req, res) => {
-    res.status(404).json({ ok: false, error: 'Not found' });
+    res.status(404).json({ ok: false, error: 'Route not found' });
   });
 
   return app;
+}
+
+if (require.main === module) {
+  const PORT = Number(process.env.PORT ?? 3200);
+  const app = createApp();
+
+  app.listen(PORT, () => {
+    console.info(`[gateway] listening on port ${PORT}`);
+  });
 }

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,20 +1,8 @@
 /**
  * whatsapp-session.store.ts — [F3a-22]
- *
- * Persiste en memoria la sesión WhatsApp por configId.
- * Cada entrada guarda:
- *   - adapter   : instancia activa del WhatsAppBaileysAdapter
- *   - qrBuffer  : último QR recibido (PNG base64 data-url o cadena qr raw)
- *   - status    : 'connecting' | 'qr_ready' | 'connected' | 'disconnected' | 'error'
- *   - sseClients: lista de Response (SSE) suscritos al QR de este configId
- *
- * El store es un singleton exportado — todos los routers comparten la
- * misma instancia sin necesidad de inyección de dependencias.
  */
 
 import type { Response } from 'express'
-
-// ── Tipos ────────────────────────────────────────────────────────────────────
 
 export type WhatsAppSessionStatus =
   | 'connecting'
@@ -23,42 +11,32 @@ export type WhatsAppSessionStatus =
   | 'disconnected'
   | 'error'
 
-/**
- * Contrato mínimo que debe cumplir el adapter para ser almacenado.
- * Evita importar WhatsAppBaileysAdapter directamente y crear
- * dependencias circulares — el adapter real se pasa en tiempo de ejecución.
- */
 export interface IWhatsAppAdapter {
   readonly channel: string
+  state?: string
   onQr?: (handler: (qr: string) => void) => void
   onConnected?: (handler: () => void) => void
   onDisconnected?: (handler: () => void) => void
+  logout?: () => Promise<void>
   dispose(): Promise<void>
 }
 
 interface SessionEntry {
-  adapter?:   IWhatsAppAdapter
-  qrBuffer:   string | null        // data-url PNG o cadena QR raw
-  status:     WhatsAppSessionStatus
-  sseClients: Set<Response>        // clientes SSE activos suscritos al QR
+  adapter: IWhatsAppAdapter
+  qrBuffer: string | null
+  status: WhatsAppSessionStatus
+  sseClients: Set<Response>
 }
 
-// ── Store ────────────────────────────────────────────────────────────────────
-
-class WhatsAppSessionStore {
+export class WhatsAppSessionStore {
   private readonly sessions = new Map<string, SessionEntry>()
 
-  // ── CRUD ──────────────────────────────────────────────────────────────────
-
-  /**
-   * Recupera la sesión existente o crea una nueva entrada vacía.
-   * El adapter se registra después con setAdapter().
-   */
   getOrCreate(configId: string): SessionEntry {
     if (!this.sessions.has(configId)) {
       this.sessions.set(configId, {
-        qrBuffer:   null,
-        status:     'disconnected',
+        adapter: null as unknown as IWhatsAppAdapter,
+        qrBuffer: null,
+        status: 'disconnected',
         sseClients: new Set(),
       })
     }
@@ -73,110 +51,66 @@ class WhatsAppSessionStore {
     return this.sessions.has(configId)
   }
 
-  /**
-   * Registra el adapter activo para un configId.
-   * Crea la entrada si no existe y marca la sesión como reservada.
-   */
   setAdapter(configId: string, adapter: IWhatsAppAdapter): void {
     const entry = this.getOrCreate(configId)
     entry.adapter = adapter
-    entry.status = 'connecting'
   }
 
-  /**
-   * Guarda el QR más reciente y notifica a todos los clientes SSE suscritos.
-   */
   setQr(configId: string, qr: string): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     entry.qrBuffer = qr
-    entry.status   = 'qr_ready'
+    entry.status = 'qr_ready'
     this.broadcastSse(entry, { event: 'qr', data: qr })
   }
 
-  /**
-   * Actualiza el estado de la sesión y notifica a los clientes SSE.
-   */
   setStatus(configId: string, status: WhatsAppSessionStatus): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     entry.status = status
-    if (status === 'connected') {
-      entry.qrBuffer = null   // QR ya no es relevante
-    }
+    if (status === 'connected') entry.qrBuffer = null
     this.broadcastSse(entry, { event: 'status', data: status })
   }
 
-  /**
-   * Elimina la sesión del store.
-   * Cierra todos los streams SSE pendientes antes de borrar.
-   */
   remove(configId: string): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     for (const client of entry.sseClients) {
-      try { client.end() } catch { /* ya cerrado */ }
+      try {
+        client.end()
+      } catch {}
     }
     entry.sseClients.clear()
     this.sessions.delete(configId)
   }
 
-  // ── SSE client management ─────────────────────────────────────────────────
-
-  /**
-   * Registra un cliente SSE (Response de Express) para recibir
-   * eventos QR y de estado de este configId.
-   *
-   * Si ya hay un QR en buffer, lo envía inmediatamente para que
-   * el cliente no tenga que esperar al siguiente ciclo.
-   */
   addSseClient(configId: string, res: Response): void {
     const entry = this.getOrCreate(configId)
     entry.sseClients.add(res)
-
-    // Enviar estado e QR actuales de inmediato
     this.sendSseEvent(res, { event: 'status', data: entry.status })
     if (entry.qrBuffer) {
       this.sendSseEvent(res, { event: 'qr', data: entry.qrBuffer })
     }
-
-    // Limpiar al cerrar la conexión
     res.on('close', () => {
       entry.sseClients.delete(res)
     })
   }
 
-  // ── Helpers SSE ───────────────────────────────────────────────────────────
-
-  private broadcastSse(
-    entry: SessionEntry,
-    payload: { event: string; data: string },
-  ): void {
+  private broadcastSse(entry: SessionEntry, payload: { event: string; data: string }): void {
     for (const client of entry.sseClients) {
       this.sendSseEvent(client, payload)
     }
   }
 
-  private sendSseEvent(
-    res:     Response,
-    payload: { event: string; data: string },
-  ): void {
+  private sendSseEvent(res: Response, payload: { event: string; data: string }): void {
     try {
       res.write(`event: ${payload.event}\ndata: ${payload.data}\n\n`)
-    } catch {
-      /* cliente ya desconectado — se limpiará en el handler 'close' */
-    }
+    } catch {}
   }
 
-  // ── Debug ─────────────────────────────────────────────────────────────────
-
-  /** Lista de configIds activos en el store (útil para health/debug). */
   activeSessions(): string[] {
-    return [...this.sessions.entries()]
-      .filter(([, entry]) => !!entry.adapter)
-      .map(([configId]) => configId)
+    return [...this.sessions.keys()]
   }
 }
 
-// Singleton exportado
 export const whatsappSessionStore = new WhatsAppSessionStore()

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,5 +1,8 @@
 /**
  * whatsapp-session.store.ts — [F3a-22]
+ *
+ * Store en memoria para sesiones WhatsApp Baileys.
+ * Exporta la clase (para typing en DI) y el singleton whatsappSessionStore.
  */
 
 import type { Response } from 'express'
@@ -21,7 +24,7 @@ export interface IWhatsAppAdapter {
   dispose(): Promise<void>
 }
 
-interface SessionEntry {
+export interface SessionEntry {
   adapter: IWhatsAppAdapter
   qrBuffer: string | null
   status: WhatsAppSessionStatus
@@ -84,6 +87,15 @@ export class WhatsAppSessionStore {
     this.sessions.delete(configId)
   }
 
+  /**
+   * Alias semántico de remove() para el flujo de deprovision.
+   * destroy() = remove() + logging explícito.
+   */
+  destroy(configId: string): void {
+    console.info(`[wa-session-store] Destroying session: ${configId}`)
+    this.remove(configId)
+  }
+
   addSseClient(configId: string, res: Response): void {
     const entry = this.getOrCreate(configId)
     entry.sseClients.add(res)
@@ -112,5 +124,8 @@ export class WhatsAppSessionStore {
     return [...this.sessions.keys()]
   }
 }
+
+/** Tipo exportado para inyección en WhatsAppDeprovisionService y tests */
+export type WhatsAppSessionStore_t = WhatsAppSessionStore
 
 export const whatsappSessionStore = new WhatsAppSessionStore()


### PR DESCRIPTION
Closes #46

<html> <body> <!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">? <strong>Implementaci?n completa. Commit entregado.</strong></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="resumen-f3a-24">Resumen F3a-24</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Commit SHA:</strong> <code>d61d95becffdc7596468062bad1c3dce9d41a958</code> [en rama <code>feat/F3a-24-whatsapp-message-mapper</code>]</p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-entregados">Archivos entregados</h2><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: visible; visibility: visible;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] dark:shadow-lg border-subtlest ring-subtlest divide-subtlest"> Archivo | Acci?n | Contenido -- | -- | --   </div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="criterios-de-cierre-cumplidos">Criterios de cierre cumplidos</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>baileysToIncoming(fromMe=true)</code> ? <code>null</code> (regla no anulable)</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>phoneToJid('+521234567890')</code> ? <code>'521234567890@s.whatsapp.net'</code>, idempotente para JIDs ya formados</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>outgoingToBaileys(msg sin richContent)</code> ? <code>{ jid, content: { text } }</code></p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El adapter ya <strong>no tiene</strong> <code>toJid()</code>, <code>handleIncomingMessage()</code>, ni <code>normalizeMessage()</code> ? toda esa l?gica vive en los dos mappers</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Los mappers son funciones <strong>puras</strong>: sin Prisma, sin store, sin efectos secundarios</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Los tests <strong>no importan Baileys</strong> ? construyen <code>WAMessage</code> como plain objects</p></li></ul></div></body></html><!--EndFragment--> </body> </html>  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp integration: send/receive messages, QR-based auth, real-time QR/status via SSE, session lifecycle (logout/deprovision) endpoints, and improved reconnection handling.
  * App server: consolidated security middleware, updated health endpoint, public static asset route, and new WhatsApp gateway route.
* **Tests**
  * Added extensive unit tests covering backoff, deprovisioning, message mapping, and send mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->