### PR TITLE
Feat/f3a 26 discord adapter lifecycle

### DIFF
--- a/apps/gateway/src/channels/__tests__/whatsapp-backoff.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-backoff.test.ts
@@ -1,0 +1,120 @@
+/**
+ * whatsapp-backoff.test.ts — [F3a-23]
+ *
+ * Tests unitarios para ExponentialBackoff.
+ * Usa fake timers de Vitest para evitar esperas reales.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ExponentialBackoff } from '../whatsapp-backoff.js'
+
+describe('ExponentialBackoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // ── peekDelay ────────────────────────────────────────────────────────────
+
+  it('peekDelay() returns value in range [0, capMs]', () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1_000, capMs: 4_000 })
+    for (let i = 0; i < 20; i++) {
+      const d = backoff.peekDelay()
+      expect(d).toBeGreaterThanOrEqual(0)
+      expect(d).toBeLessThanOrEqual(4_000)
+    }
+  })
+
+  it('peekDelay() does not advance currentAttempt', () => {
+    const backoff = new ExponentialBackoff({ baseMs: 100, capMs: 1_000 })
+    backoff.peekDelay()
+    backoff.peekDelay()
+    expect(backoff.currentAttempt).toBe(0)
+  })
+
+  // ── next ─────────────────────────────────────────────────────────────────
+
+  it('next() increments currentAttempt by 1', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 10, capMs: 100 })
+    const p = backoff.next()
+    vi.runAllTimers()
+    await p
+    expect(backoff.currentAttempt).toBe(1)
+  })
+
+  it('next() after maxRetries throws backoff_exhausted', () => {
+    const backoff = new ExponentialBackoff({ baseMs: 10, capMs: 100, maxRetries: 1 })
+    // consumir el único intento disponible de forma síncrona
+    backoff['attempt'] = 1 // forzar estado exhausted
+    expect(() => backoff.next()).toThrowError('backoff_exhausted')
+  })
+
+  it('exhausted is true after maxRetries calls to next()', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1, capMs: 10, maxRetries: 2 })
+
+    const p1 = backoff.next()
+    vi.runAllTimers()
+    await p1
+
+    const p2 = backoff.next()
+    vi.runAllTimers()
+    await p2
+
+    expect(backoff.exhausted).toBe(true)
+    expect(() => backoff.next()).toThrowError('backoff_exhausted')
+  })
+
+  // ── abort ────────────────────────────────────────────────────────────────
+
+  it('abort() during wait rejects with backoff_aborted', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 10_000, capMs: 60_000 })
+    const p = backoff.next()
+    backoff.abort()
+    vi.runAllTimers()
+    await expect(p).rejects.toThrowError('backoff_aborted')
+  })
+
+  it('abort() clears the timer (no memory leak)', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const backoff = new ExponentialBackoff({ baseMs: 10_000, capMs: 60_000 })
+    backoff.next() // starts timer
+    backoff.abort()
+    expect(clearSpy).toHaveBeenCalled()
+    expect(backoff.isAborted).toBe(true)
+  })
+
+  it('next() after abort() throws backoff_aborted immediately', () => {
+    const backoff = new ExponentialBackoff()
+    backoff.abort()
+    expect(() => backoff.next()).toThrowError('backoff_aborted')
+  })
+
+  // ── reset ────────────────────────────────────────────────────────────────
+
+  it('reset() sets currentAttempt to 0 and clears aborted flag', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1, capMs: 10, maxRetries: 3 })
+
+    const p = backoff.next()
+    vi.runAllTimers()
+    await p
+    expect(backoff.currentAttempt).toBe(1)
+
+    backoff.reset()
+    expect(backoff.currentAttempt).toBe(0)
+    expect(backoff.exhausted).toBe(false)
+    expect(backoff.isAborted).toBe(false)
+  })
+
+  it('reset() after abort() allows next() to work again', async () => {
+    const backoff = new ExponentialBackoff({ baseMs: 1, capMs: 10 })
+    backoff.abort()
+    backoff.reset()
+    const p = backoff.next()
+    vi.runAllTimers()
+    await expect(p).resolves.toBeUndefined()
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-deprovision.service.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-deprovision.service.test.ts
@@ -1,0 +1,169 @@
+/**
+ * whatsapp-deprovision.service.test.ts — [F3a-23]
+ *
+ * Tests unitarios para WhatsAppDeprovisionService.
+ * Todos los colaboradores (db, store, fs) se mockean.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as fs from 'node:fs'
+import { WhatsAppDeprovisionService } from '../whatsapp-deprovision.service.js'
+
+// ── Mocks de fs ──────────────────────────────────────────────────────────────
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  rmSync:     vi.fn(),
+}))
+
+// ── Factory helpers ──────────────────────────────────────────────────────────
+
+function makeAdapter(state: string, hasLogout = true) {
+  return {
+    state,
+    logout:  hasLogout ? vi.fn().mockResolvedValue(undefined) : undefined,
+    dispose: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeStore(adapter?: ReturnType<typeof makeAdapter>) {
+  return {
+    get:    vi.fn().mockReturnValue(adapter ? { adapter } : undefined),
+    remove: vi.fn(),
+  }
+}
+
+function makeDb(prismaError?: { code: string }) {
+  return {
+    channelConfig: {
+      update: prismaError
+        ? vi.fn().mockRejectedValue(Object.assign(new Error('not found'), prismaError))
+        : vi.fn().mockResolvedValue({}),
+    },
+  }
+}
+
+// ── Tests: logout() ──────────────────────────────────────────────────────────
+
+describe('WhatsAppDeprovisionService.logout()', () => {
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+  })
+
+  it('calls adapter.logout() when state is "open"', async () => {
+    const adapter = makeAdapter('open')
+    const store   = makeStore(adapter)
+    const svc     = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.logout('cfg-1')
+
+    expect(adapter.logout).toHaveBeenCalledOnce()
+    expect(adapter.dispose).not.toHaveBeenCalled()
+  })
+
+  it('calls adapter.logout() when state is "reconnecting"', async () => {
+    const adapter = makeAdapter('reconnecting')
+    const store   = makeStore(adapter)
+    const svc     = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.logout('cfg-2')
+
+    expect(adapter.logout).toHaveBeenCalledOnce()
+  })
+
+  it('calls adapter.dispose() when state is "idle"', async () => {
+    const adapter = makeAdapter('idle')
+    const store   = makeStore(adapter)
+    const svc     = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.logout('cfg-3')
+
+    expect(adapter.dispose).toHaveBeenCalledOnce()
+    expect(adapter.logout).not.toHaveBeenCalled()
+  })
+
+  it('when configId not in store — returns adapterState=not_in_store without throwing', async () => {
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.logout('cfg-missing')
+
+    expect(result.adapterState).toBe('not_in_store')
+  })
+
+  it('deletes sessionDir when it exists', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.logout('cfg-fs')
+
+    expect(fs.rmSync).toHaveBeenCalled()
+    expect(result.sessionDeleted).toBe(true)
+  })
+
+  it('sessionDeleted=false when sessionDir does not exist', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.logout('cfg-nofs')
+
+    expect(result.sessionDeleted).toBe(false)
+  })
+})
+
+// ── Tests: deprovision() ─────────────────────────────────────────────────────
+
+describe('WhatsAppDeprovisionService.deprovision()', () => {
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+  })
+
+  it('calls db.channelConfig.update with { active: false }', async () => {
+    const db    = makeDb()
+    const store = makeStore(makeAdapter('open'))
+    const svc   = new WhatsAppDeprovisionService(db as any, store as any)
+
+    await svc.deprovision('cfg-deprov-1')
+
+    expect(db.channelConfig.update).toHaveBeenCalledWith({
+      where: { id: 'cfg-deprov-1' },
+      data:  { active: false },
+    })
+  })
+
+  it('calls store.remove(configId)', async () => {
+    const store = makeStore(makeAdapter('open'))
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    await svc.deprovision('cfg-deprov-2')
+
+    expect(store.remove).toHaveBeenCalledWith('cfg-deprov-2')
+  })
+
+  it('when ChannelConfig not found (P2025) → channelDeactivated=false, no throw', async () => {
+    const db    = makeDb({ code: 'P2025' })
+    const store = makeStore(undefined)
+    const svc   = new WhatsAppDeprovisionService(db as any, store as any)
+
+    const result = await svc.deprovision('cfg-missing-db')
+
+    expect(result.channelDeactivated).toBe(false)
+    expect(result.storeDestroyed).toBe(true)
+  })
+
+  it('result contains all required fields', async () => {
+    const store = makeStore(makeAdapter('open'))
+    const svc   = new WhatsAppDeprovisionService(makeDb() as any, store as any)
+
+    const result = await svc.deprovision('cfg-fields')
+
+    expect(result).toMatchObject({
+      configId:           'cfg-fields',
+      sessionDeleted:     expect.any(Boolean),
+      adapterState:       expect.any(String),
+      channelDeactivated: true,
+      storeDestroyed:     true,
+    })
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-message.mapper.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-message.mapper.test.ts
@@ -1,0 +1,249 @@
+/**
+ * whatsapp-message.mapper.test.ts — [F3a-24]
+ *
+ * Tests unitarios para baileysToIncoming(), jidToPhone(), isGroupJid().
+ * Los objetos WAMessage se construyen como plain objects —
+ * NO se importa @whiskeysockets/baileys directamente.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { baileysToIncoming, jidToPhone, isGroupJid } from '../whatsapp-message.mapper.js'
+
+// ── Factory: WAMessage mínimo ──────────────────────────────────────────────────
+
+function makeWAMsg(overrides: {
+  fromMe?:     boolean
+  remoteJid?:  string
+  participant?: string
+  message?:    Record<string, unknown>
+  pushName?:   string
+  messageTimestamp?: number
+}) {
+  return {
+    key: {
+      fromMe:     overrides.fromMe    ?? false,
+      remoteJid:  overrides.remoteJid ?? '521234567890@s.whatsapp.net',
+      id:         'test-msg-id',
+      participant: overrides.participant,
+    },
+    message:          overrides.message ?? null,
+    pushName:         overrides.pushName ?? 'Test User',
+    messageTimestamp: overrides.messageTimestamp ?? 1700000000,
+  } as any
+}
+
+// ── Tests: baileysToIncoming() ─────────────────────────────────────────────────
+
+describe('baileysToIncoming()', () => {
+
+  it('returns null when fromMe=true', () => {
+    const msg = makeWAMsg({ fromMe: true, message: { conversation: 'hello' } })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  it('returns null when message is null', () => {
+    const msg = makeWAMsg({ message: undefined })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  it('returns null for protocolMessage (system message)', () => {
+    const msg = makeWAMsg({ message: { protocolMessage: { type: 0 } } })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  // ── conversation ──────────────────────────────────────────────────────
+
+  it('maps conversation text to type=text', () => {
+    const msg = makeWAMsg({ message: { conversation: 'hello world' } })
+    const result = baileysToIncoming(msg)!
+    expect(result).not.toBeNull()
+    expect(result.type).toBe('text')
+    expect(result.text).toBe('hello world')
+    expect(result.externalId).toBe('521234567890')
+  })
+
+  it('maps conversation with / prefix to type=command', () => {
+    const msg = makeWAMsg({ message: { conversation: '/start' } })
+    expect(baileysToIncoming(msg)!.type).toBe('command')
+  })
+
+  it('externalId strips @s.whatsapp.net suffix', () => {
+    const msg = makeWAMsg({
+      remoteJid: '521234567890@s.whatsapp.net',
+      message:   { conversation: 'hi' },
+    })
+    expect(baileysToIncoming(msg)!.externalId).toBe('521234567890')
+  })
+
+  // ── extendedTextMessage ─────────────────────────────────────────────
+
+  it('maps extendedTextMessage to type=text with previewUrl in metadata', () => {
+    const msg = makeWAMsg({
+      message: {
+        extendedTextMessage: {
+          text:        'check this out',
+          canonicalUrl: 'https://example.com',
+        },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('text')
+    expect(result.text).toBe('check this out')
+    expect(result.metadata?.previewUrl).toBe('https://example.com')
+  })
+
+  // ── imageMessage ──────────────────────────────────────────────────
+
+  it('maps imageMessage with caption to type=image', () => {
+    const msg = makeWAMsg({
+      message: {
+        imageMessage: { caption: 'my photo', mimetype: 'image/jpeg' },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('image')
+    expect(result.text).toBe('my photo')
+    expect(result.attachments?.[0]?.type).toBe('image')
+  })
+
+  // ── audioMessage ──────────────────────────────────────────────────
+
+  it('maps audioMessage ptt=true to attachment type=voice_note', () => {
+    const msg = makeWAMsg({
+      message: { audioMessage: { ptt: true, mimetype: 'audio/ogg; codecs=opus', seconds: 5 } },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('audio')
+    expect(result.attachments?.[0]?.type).toBe('voice_note')
+  })
+
+  it('maps audioMessage ptt=false to attachment type=audio', () => {
+    const msg = makeWAMsg({
+      message: { audioMessage: { ptt: false, mimetype: 'audio/mp4', seconds: 10 } },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('audio')
+    expect(result.attachments?.[0]?.type).toBe('audio')
+  })
+
+  // ── videoMessage ──────────────────────────────────────────────────
+
+  it('maps videoMessage to type=file with attachment type=video', () => {
+    const msg = makeWAMsg({
+      message: { videoMessage: { caption: 'clip', mimetype: 'video/mp4', seconds: 30 } },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('file')
+    expect(result.attachments?.[0]?.type).toBe('video')
+  })
+
+  // ── documentMessage ────────────────────────────────────────────────
+
+  it('maps documentMessage to type=file with fileName in attachment data', () => {
+    const msg = makeWAMsg({
+      message: {
+        documentMessage: {
+          fileName: 'report.pdf',
+          mimetype: 'application/pdf',
+          fileLength: 1024,
+        },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('file')
+    expect((result.attachments?.[0]?.data as any)?.fileName).toBe('report.pdf')
+  })
+
+  // ── locationMessage ───────────────────────────────────────────────
+
+  it('maps locationMessage to type=text with coordinates in text and metadata', () => {
+    const msg = makeWAMsg({
+      message: {
+        locationMessage: { degreesLatitude: 19.4326, degreesLongitude: -99.1332, name: 'CDMX' },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('text')
+    expect(result.text).toContain('19.4326')
+    expect(result.text).toContain('-99.1332')
+    expect((result.metadata?.location as any)?.lat).toBe(19.4326)
+    expect((result.metadata?.location as any)?.lng).toBe(-99.1332)
+  })
+
+  // ── contactMessage ────────────────────────────────────────────────
+
+  it('maps contactMessage with vcard TEL to type=text with phone in text', () => {
+    const msg = makeWAMsg({
+      message: {
+        contactMessage: {
+          displayName: 'Juan',
+          vcard: 'BEGIN:VCARD\nVERSION:3.0\nFN:Juan\nTEL;type=CELL:+521234567890\nEND:VCARD',
+        },
+      },
+    })
+    const result = baileysToIncoming(msg)!
+    expect(result.type).toBe('text')
+    expect(result.text).toContain('+521234567890')
+  })
+
+  // ── reactionMessage ───────────────────────────────────────────────
+
+  it('reactionMessage with processReactions=false returns null', () => {
+    const msg = makeWAMsg({
+      message: { reactionMessage: { text: '\ud83d\udc4d', key: { id: 'orig-id' } } },
+    })
+    expect(baileysToIncoming(msg)).toBeNull()
+  })
+
+  it('reactionMessage with processReactions=true returns type=command with emoji', () => {
+    const msg = makeWAMsg({
+      message: { reactionMessage: { text: '\ud83d\udc4d', key: { id: 'orig-id' } } },
+    })
+    const result = baileysToIncoming(msg, { processReactions: true })!
+    expect(result.type).toBe('command')
+    expect(result.text).toBe('\ud83d\udc4d')
+    expect((result.metadata?.reaction as any)?.emoji).toBe('\ud83d\udc4d')
+  })
+
+  // ── rawPayload y threadId ────────────────────────────────────────────
+
+  it('result always has rawPayload and threadId', () => {
+    const msg = makeWAMsg({ message: { conversation: 'test' } })
+    const result = baileysToIncoming(msg)!
+    expect(result.rawPayload).toBeDefined()
+    expect(result.threadId).toBeDefined()
+    expect(result.threadId).toBe(result.externalId)
+  })
+})
+
+// ── Tests: jidToPhone() ───────────────────────────────────────────────────────────
+
+describe('jidToPhone()', () => {
+  it('strips @s.whatsapp.net suffix', () => {
+    expect(jidToPhone('521234567890@s.whatsapp.net')).toBe('521234567890')
+  })
+
+  it('strips multi-device suffix :N', () => {
+    expect(jidToPhone('521234567890:5@s.whatsapp.net')).toBe('521234567890')
+  })
+
+  it('strips @g.us suffix for groups', () => {
+    expect(jidToPhone('120363@g.us')).toBe('120363')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(jidToPhone('')).toBe('')
+  })
+})
+
+// ── Tests: isGroupJid() ────────────────────────────────────────────────────────
+
+describe('isGroupJid()', () => {
+  it('returns true for group JIDs', () => {
+    expect(isGroupJid('120363123456@g.us')).toBe(true)
+  })
+
+  it('returns false for personal JIDs', () => {
+    expect(isGroupJid('521234567890@s.whatsapp.net')).toBe(false)
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-send.mapper.test.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-send.mapper.test.ts
@@ -1,0 +1,105 @@
+/**
+ * whatsapp-send.mapper.test.ts — [F3a-24]
+ *
+ * Tests unitarios para outgoingToBaileys() y phoneToJid().
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { outgoingToBaileys, phoneToJid } from '../whatsapp-send.mapper.js'
+import type { OutgoingMessage } from '../channel-adapter.interface.js'
+
+function makeMsg(overrides: Partial<OutgoingMessage>): OutgoingMessage {
+  return {
+    externalId:  '521234567890',
+    text:        'Hello',
+    ...overrides,
+  }
+}
+
+// ── Tests: outgoingToBaileys() ─────────────────────────────────────────────────
+
+describe('outgoingToBaileys()', () => {
+
+  it('without richContent returns { text } and correct jid', () => {
+    const { jid, content } = outgoingToBaileys(makeMsg({}))
+    expect(jid).toBe('521234567890@s.whatsapp.net')
+    expect(content).toEqual({ text: 'Hello' })
+  })
+
+  it('richContent type=buttons maps buttons array correctly', () => {
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: {
+        type: 'buttons',
+        body: 'Choose one',
+        buttons: [
+          { id: 'btn1', title: 'Option 1' },
+          { id: 'btn2', title: 'Option 2' },
+        ],
+      },
+    }))
+    const buttons = (content as any).buttons
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0].buttonId).toBe('btn1')
+    expect(buttons[0].buttonText.displayText).toBe('Option 1')
+  })
+
+  it('richContent type=list maps listMessage.sections correctly', () => {
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: {
+        type: 'list',
+        title:       'Menu',
+        description: 'Pick an option',
+        buttonText:  'Options',
+        sections: [{
+          title: 'Section 1',
+          rows:  [{ id: 'r1', title: 'Row 1' }],
+        }],
+      },
+    }))
+    const lm = (content as any).listMessage
+    expect(lm).toBeDefined()
+    expect(lm.sections).toHaveLength(1)
+    expect(lm.sections[0].rows[0].rowId).toBe('r1')
+  })
+
+  it('richContent type=template maps templateMessage', () => {
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: {
+        type:    'template',
+        text:    'Hello template',
+        buttons: [{ index: 0, quickReplyButton: { displayText: 'Yes', id: 'yes' } }],
+      },
+    }))
+    expect((content as any).templateMessage).toBeDefined()
+  })
+
+  it('unknown richContent type falls back to text without throwing', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { content } = outgoingToBaileys(makeMsg({
+      richContent: { type: 'unknown_type', someData: 123 } as any,
+    }))
+    expect((content as any).text).toBeDefined()
+    expect(consoleSpy).toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})
+
+// ── Tests: phoneToJid() ───────────────────────────────────────────────────────────
+
+describe('phoneToJid()', () => {
+  it('adds @s.whatsapp.net to plain number', () => {
+    expect(phoneToJid('521234567890')).toBe('521234567890@s.whatsapp.net')
+  })
+
+  it('strips + prefix', () => {
+    expect(phoneToJid('+521234567890')).toBe('521234567890@s.whatsapp.net')
+  })
+
+  it('strips spaces and dashes', () => {
+    expect(phoneToJid('52 123 456-7890')).toBe('521234567890@s.whatsapp.net')
+  })
+
+  it('is idempotent for existing JIDs', () => {
+    expect(phoneToJid('521234567890@s.whatsapp.net')).toBe('521234567890@s.whatsapp.net')
+  })
+})

--- a/apps/gateway/src/channels/channel-adapter.interface.ts
+++ b/apps/gateway/src/channels/channel-adapter.interface.ts
@@ -1,5 +1,5 @@
 /**
- * [F3a-02] channel-adapter.interface.ts
+ * channel-adapter.interface.ts — [F3a-02]
  *
  * Contrato base de todos los adaptadores de canal del Gateway.
  * Todo canal (WebChat, Telegram, WhatsApp, Discord, Slack, n8n webhook)
@@ -10,7 +10,7 @@
  *        debe ir en el adapter concreto, inyectado por constructor.
  */
 
-// ── Tipos de canal ──────────────────────────────────────────────────────────────────────────────────
+// ── Tipos de canal ───────────────────────────────────────────────────────────
 
 /**
  * Nombres canónicos de canal — deben coincidir con
@@ -24,7 +24,15 @@ export type ChannelType =
   | 'slack'
   | 'webhook'
 
-// ── IncomingMessage ───────────────────────────────────────────────────────────────────────────
+// ── AdapterMode ──────────────────────────────────────────────────────────────
+
+/**
+ * 'gateway'  → el adaptador abre conexión activa (WebSocket, polling, bot login)
+ * 'http'     → el adaptador solo procesa webhooks HTTP entrantes
+ */
+export type AdapterMode = 'gateway' | 'http'
+
+// ── IncomingMessage ──────────────────────────────────────────────────────────
 
 /**
  * Mensaje normalizado que llega de cualquier canal externo.
@@ -41,10 +49,13 @@ export interface IncomingMessage {
    * Tipo de canal — necesario para que AgentResolver filtre
    * ChannelBinding por canal.
    */
-  channelType: ChannelType
+  channelType: ChannelType | string
 
   /** ID de la conversación/thread en el canal externo */
   externalId: string
+
+  /** ID del thread cuando exista; fallback al canal/conversación */
+  threadId?: string
 
   /** ID de quien envía (user ID del canal) */
   senderId: string
@@ -58,17 +69,29 @@ export interface IncomingMessage {
   /** Adjuntos opcionales */
   attachments?: Array<{ type: string; url?: string; data?: unknown }>
 
+  /** URL del adjunto legacy (cuando aplica) */
+  attachmentUrl?: string
+
+  /** Nombre de archivo del adjunto legacy (cuando aplica) */
+  attachmentName?: string
+
+  /** ID del mensaje en el canal externo */
+  msgId?: string
+
   /**
    * Payload raw del canal externo.
    * Telegram: Update object. WebChat: req.body. Slack: payload completo.
    */
   metadata?: Record<string, unknown>
 
+  /** Payload original sin normalizar (para debugging / fallback) */
+  rawPayload?: unknown
+
   /** Timestamp ISO 8601 de recepción */
-  receivedAt: string
+  receivedAt?: string
 }
 
-// ── RichContent ────────────────────────────────────────────────────────────────────────────
+// ── RichContent ──────────────────────────────────────────────────────────────
 
 export interface QuickReply {
   label: string
@@ -87,8 +110,10 @@ export type RichContent =
   | { type: 'card';          card:    CardContent   }
   | { type: 'image';         url:     string; altText?: string }
   | { type: 'file';          url:     string; filename: string }
+  // Legacy flat shape (discord, older adapters)
+  | { title?: string; description?: string; imageUrl?: string; buttons?: Array<{ label: string; value: string }>; footer?: string }
 
-// ── OutgoingMessage ──────────────────────────────────────────────────────────────────────────
+// ── OutgoingMessage ──────────────────────────────────────────────────────────
 
 export interface OutgoingMessage {
   /** ID de la conversación de destino en el canal externo */
@@ -110,7 +135,7 @@ export interface OutgoingMessage {
   metadata?: Record<string, unknown>
 }
 
-// ── IChannelAdapter ─────────────────────────────────────────────────────────────────────────────
+// ── IChannelAdapter ──────────────────────────────────────────────────────────
 
 export interface IChannelAdapter {
   readonly channel: ChannelType
@@ -121,7 +146,7 @@ export interface IChannelAdapter {
   dispose(): Promise<void>
 }
 
-// ── IHttpChannelAdapter ─────────────────────────────────────────────────────────────────────────
+// ── IHttpChannelAdapter ──────────────────────────────────────────────────────
 
 /**
  * Extensión para canales que exponen rutas HTTP.
@@ -132,7 +157,26 @@ export interface IHttpChannelAdapter extends IChannelAdapter {
   getRouter(): import('express').Router
 }
 
-// ── BaseChannelAdapter ────────────────────────────────────────────────────────────────────────────────
+// ── ChannelAdapter (legacy alias) ────────────────────────────────────────────
+
+/**
+ * Alias de IChannelAdapter para compatibilidad con adaptadores del PR#161
+ * que usan la firma sync initialize() + setup() separado.
+ */
+export interface ChannelAdapter {
+  initialize(channelConfigId: string): void
+  setup(
+    config:  Record<string, unknown>,
+    secrets: Record<string, unknown>,
+    mode?:   AdapterMode,
+  ): Promise<void>
+  send(message: OutgoingMessage): Promise<void>
+  dispose(): Promise<void>
+  onMessage(handler: (msg: IncomingMessage) => void): void
+  onError(handler: (err: Error) => void): void
+}
+
+// ── BaseChannelAdapter ────────────────────────────────────────────────────────
 
 export abstract class BaseChannelAdapter implements IChannelAdapter {
   abstract readonly channel: ChannelType

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -1,163 +1,496 @@
 /**
- * discord.adapter.ts — Adaptador Discord (Interactions Endpoint)
+ * discord.adapter.ts — [F3a-26]
  *
- * Recibe slash commands e interacciones via HTTP endpoint.
- * Discord requiere verificación Ed25519 de cada request.
+ * Adaptador de canal Discord.
+ * - mode='gateway': instancia discord.js Client y hace login.
+ * - mode='http':    procesa webhooks de interacciones (slash commands, buttons).
  *
- * Credentials en ChannelConfig.credentials:
- *   { botToken, applicationId, publicKey }
- *
- * Endpoints:
- *   POST /gateway/discord/interactions — interacciones de Discord
- *
- * Inspirado en n8n DiscordTrigger y Semantic Kernel Discord plugin.
+ * Características:
+ * - Chunking de mensajes > 2000 chars (gateway y REST)
+ * - Reconexión exponencial: 5s → 15s → 45s → 120s
+ * - Verificación Ed25519 via node:crypto nativo (SPKI DER)
+ * - send() con interaction token usa PATCH al followup
  */
 
-import { createVerify } from 'node:crypto';
-import { Router, type Request, type Response } from 'express';
-import { getPrisma } from '../../lib/prisma.js';
+import { EventEmitter }                                    from 'node:events'
+import { verify as cryptoVerify, createPublicKey }         from 'node:crypto'
+import { Router, type Request, type Response }             from 'express'
 import {
-  BaseChannelAdapter,
-  type ChannelType,
-  type IncomingMessage,
-  type OutgoingMessage,
-} from './channel-adapter.interface';
+  Client,
+  GatewayIntentBits,
+  Partials,
+  type Message,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js'
 
-const DISCORD_API = 'https://discord.com/api/v10';
+import type { ChannelAdapter, IncomingMessage, OutgoingMessage, AdapterMode } from './channel-adapter.interface.js'
+import {
+  messageToIncoming,
+  buttonInteractionToIncoming,
+  selectMenuToIncoming,
+} from './discord-message.mapper.js'
 
-interface DiscordCredentials {
-  botToken:       string;
-  applicationId:  string;
-  publicKey:      string;
+// ── Constantes ────────────────────────────────────────────────────────────────
+
+const DISCORD_API        = 'https://discord.com/api/v10'
+const MAX_MESSAGE_LENGTH = 2000
+const RECONNECT_DELAYS   = [5_000, 15_000, 45_000, 120_000] as const
+
+// ── Tipos internos ────────────────────────────────────────────────────────────
+
+export interface DiscordSecrets {
+  botToken?:  string
+  publicKey?: string
 }
 
-const INTERACTION_TYPE          = { PING: 1, APPLICATION_COMMAND: 2, MESSAGE_COMPONENT: 3 };
-const INTERACTION_RESPONSE_TYPE = { PONG: 1, CHANNEL_MESSAGE_WITH_SOURCE: 4 };
+export interface DiscordConfig {
+  applicationId?: string
+  guildId?:       string
+}
 
-export class DiscordAdapter extends BaseChannelAdapter {
-  readonly channel = 'discord' as const satisfies ChannelType;
-  private botToken      = '';
-  private applicationId = '';
-  private publicKey     = '';
+// ── Helper: split message en chunks ──────────────────────────────────────────
 
-  // ── Lifecycle ─────────────────────────────────────────────────────────────────────
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text]
+  const chunks: string[] = []
+  let remaining = text
+  while (remaining.length > maxLen) {
+    let idx = remaining.lastIndexOf(' ', maxLen)
+    if (idx <= 0) idx = maxLen
+    chunks.push(remaining.slice(0, idx))
+    remaining = remaining.slice(idx).trimStart()
+  }
+  if (remaining.length > 0) chunks.push(remaining)
+  return chunks
+}
 
-  async initialize(channelConfigId: string): Promise<void> {
-    this.channelConfigId = channelConfigId;
-    const db     = getPrisma();
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } });
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`);
+// ── Helper: richContent → Discord embed ──────────────────────────────────────
 
-    const creds          = config.credentials as DiscordCredentials;
-    this.botToken        = creds.botToken;
-    this.applicationId   = creds.applicationId;
-    this.publicKey       = creds.publicKey;
-    this.credentials     = config.credentials as Record<string, unknown>;
+function richContentToEmbed(rc: OutgoingMessage['richContent']): Record<string, unknown> {
+  if (!rc) return {}
+  // Handle legacy flat shape
+  const flat = rc as Record<string, unknown>
+  const embed: Record<string, unknown> = {}
+  if (flat['title'])       embed['title']       = flat['title']
+  if (flat['description']) embed['description'] = flat['description']
+  if (flat['imageUrl'])    embed['image']        = { url: flat['imageUrl'] }
+  if (flat['footer'])      embed['footer']       = { text: flat['footer'] }
+  const buttons = flat['buttons'] as Array<{ label: string; value: string }> | undefined
+  if (buttons?.length) {
+    embed['components'] = [{
+      type:       1,
+      components: buttons.map(b => ({
+        type:      2,
+        style:     1,
+        label:     b.label,
+        custom_id: b.value,
+      })),
+    }]
+  }
+  return embed
+}
 
-    console.info(`[discord] Initialized app ${this.applicationId}`);
+// ── Adaptador ─────────────────────────────────────────────────────────────────
+
+export class DiscordAdapter implements ChannelAdapter {
+
+  private channelConfigId = ''
+  private mode: AdapterMode = 'http'
+  private secrets: DiscordSecrets = {}
+  private config:  DiscordConfig  = {}
+
+  private client?: Client
+  private reconnectTimer?: ReturnType<typeof setTimeout>
+  private reconnectAttempt = 0
+
+  private readonly emitter = new EventEmitter()
+
+  // ── ChannelAdapter: initialize ─────────────────────────────────────────────
+
+  initialize(channelConfigId: string): void {
+    this.channelConfigId = channelConfigId
   }
 
-  async dispose(): Promise<void> {
-    console.info('[discord] Adapter disposed');
-  }
+  // ── ChannelAdapter: setup ──────────────────────────────────────────────────
 
-  // ── Send ────────────────────────────────────────────────────────────────────────
+  async setup(
+    config:  Record<string, unknown>,
+    secrets: Record<string, unknown>,
+    mode:    AdapterMode = 'http',
+  ): Promise<void> {
+    this.mode    = mode
+    this.secrets = secrets as DiscordSecrets
+    this.config  = config  as DiscordConfig
 
-  async send(message: OutgoingMessage): Promise<void> {
-    const url  = `${DISCORD_API}/channels/${message.externalId}/messages`;
-    const body: Record<string, unknown> = { content: message.text };
-    if (message.richContent) body.embeds = [message.richContent];
-
-    const res = await fetch(url, {
-      method:  'POST',
-      headers: {
-        Authorization:  `Bot ${this.botToken}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
-      const err = await res.text();
-      console.error(`[discord] send failed: ${err}`);
-      throw new Error(`Discord send failed: ${err}`);
+    if (mode === 'gateway') {
+      await this._startGateway()
     }
   }
 
-  // ── Router ────────────────────────────────────────────────────────────────────
+  // ── ChannelAdapter: send ───────────────────────────────────────────────────
 
-  getRouter(): Router {
-    const router = Router();
+  async send(message: OutgoingMessage): Promise<void> {
+    const interactionToken = message.metadata?.['interactionToken'] as string | undefined
+    const channelId        = message.externalId
+    const text             = message.text ?? ''
 
-    router.post('/interactions', async (req: Request, res: Response) => {
-      const timestamp = req.headers['x-signature-timestamp'] as string;
-      const sig       = req.headers['x-signature-ed25519']   as string;
+    if (interactionToken && this.config.applicationId) {
+      await this._sendViaFollowup(interactionToken, text, message)
+      return
+    }
 
-      if (!this._verifySignature(JSON.stringify(req.body), timestamp, sig)) {
-        res.status(401).json({ error: 'Invalid request signature' });
-        return;
-      }
-
-      const interaction = req.body as {
-        type:            number;
-        id:              string;
-        token:           string;
-        application_id:  string;
-        data?:           { name?: string; options?: Array<{ name: string; value: unknown }> };
-        member?:         { user?: { id: string; username?: string } };
-        user?:           { id: string; username?: string };
-        channel_id?:     string;
-      };
-
-      if (interaction.type === INTERACTION_TYPE.PING) {
-        res.json({ type: INTERACTION_RESPONSE_TYPE.PONG });
-        return;
-      }
-
-      if (interaction.type === INTERACTION_TYPE.APPLICATION_COMMAND) {
-        const commandName = interaction.data?.name ?? 'unknown';
-        const options     = interaction.data?.options ?? [];
-        const userInput   = (options.find((o) => o.name === 'prompt')?.value as string) ?? commandName;
-        const userId      = interaction.member?.user?.id ?? interaction.user?.id ?? interaction.id;
-        const channelId   = interaction.channel_id ?? interaction.id;
-
-        res.json({
-          type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-          data: { content: '⏳ Procesando...', flags: 64 },
-        });
-
-        const msg: IncomingMessage = {
-          channelConfigId: this.channelConfigId,
-          channelType:     'discord',
-          externalId:      channelId,
-          senderId:        userId,
-          text:            userInput,
-          type:            'command',
-          metadata:        { interactionId: interaction.id, interactionToken: interaction.token, commandName, raw: interaction },
-          receivedAt:      this.makeTimestamp(),
-        };
-        this.emit(msg).catch((err) => console.error('[discord] emit error:', err));
-        return;
-      }
-
-      res.json({
-        type: INTERACTION_RESPONSE_TYPE.CHANNEL_MESSAGE_WITH_SOURCE,
-        data: { content: 'Interacción no soportada', flags: 64 },
-      });
-    });
-
-    return router;
+    if (this.client) {
+      await this._sendViaClient(channelId, text, message)
+    } else {
+      await this._sendViaRestApi(channelId, text, message)
+    }
   }
 
-  // ── Helpers ──────────────────────────────────────────────────────────────────────
+  // ── ChannelAdapter: dispose ────────────────────────────────────────────────
 
+  async dispose(): Promise<void> {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = undefined
+    }
+    if (this.client) {
+      this.client.destroy()
+      this.client = undefined
+    }
+  }
+
+  // ── ChannelAdapter: listeners ──────────────────────────────────────────────
+
+  onMessage(handler: (msg: IncomingMessage) => void): void {
+    this.emitter.on('message', handler)
+  }
+
+  onError(handler: (err: Error) => void): void {
+    this.emitter.on('error', handler)
+  }
+
+  // ── HTTP webhook router ────────────────────────────────────────────────────
+
+  buildHttpRouter(): Router {
+    const router = Router()
+
+    router.post('/', async (req: Request, res: Response) => {
+      const timestamp = req.headers['x-signature-timestamp'] as string
+      const signature = req.headers['x-signature-ed25519']  as string
+
+      const rawBody = typeof req.body === 'string'
+        ? req.body
+        : JSON.stringify(req.body)
+
+      if (!this._verifySignature(rawBody, timestamp, signature)) {
+        res.status(401).json({ error: 'Invalid signature' })
+        return
+      }
+
+      const body = typeof req.body === 'string'
+        ? JSON.parse(req.body)
+        : req.body
+
+      // Ping de Discord
+      if (body.type === 1) {
+        if (!this.secrets.botToken) {
+          res.status(503).json({ error: 'Bot not ready' })
+          return
+        }
+        res.json({ type: 1 })
+        return
+      }
+
+      // APPLICATION_COMMAND (type=2)
+      if (body.type === 2) {
+        const incoming = this._interactionBodyToIncoming(body)
+        if (incoming) this.emitter.emit('message', incoming)
+        res.json({ type: 5 }) // DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
+        return
+      }
+
+      // MESSAGE_COMPONENT (type=3)
+      if (body.type === 3) {
+        const incoming = this._componentBodyToIncoming(body)
+        if (incoming) this.emitter.emit('message', incoming)
+        res.json({ type: 6 }) // DEFERRED_UPDATE_MESSAGE
+        return
+      }
+
+      res.status(400).json({ error: 'Unknown interaction type' })
+    })
+
+    return router
+  }
+
+  // Alias para compatibilidad con IHttpChannelAdapter
+  getRouter(): Router {
+    return this.buildHttpRouter()
+  }
+
+  // ── Gateway: iniciar client ────────────────────────────────────────────────
+
+  private async _startGateway(): Promise<void> {
+    const intents = [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+      GatewayIntentBits.DirectMessages,
+    ]
+
+    this.client = new Client({
+      intents,
+      partials: [Partials.Channel, Partials.Message],
+    })
+
+    this.client.on('messageCreate', (msg: Message) => {
+      const incoming = messageToIncoming(msg, this.channelConfigId)
+      if (incoming) this.emitter.emit('message', incoming)
+    })
+
+    this.client.on('interactionCreate', (interaction) => {
+      let incoming: IncomingMessage | null = null
+
+      if (interaction.isButton()) {
+        incoming = buttonInteractionToIncoming(
+          interaction as ButtonInteraction,
+          this.channelConfigId,
+        )
+      } else if (interaction.isStringSelectMenu()) {
+        incoming = selectMenuToIncoming(
+          interaction as StringSelectMenuInteraction,
+          this.channelConfigId,
+        )
+      }
+
+      if (incoming) this.emitter.emit('message', incoming)
+    })
+
+    this.client.on('ready', () => {
+      console.info(`[discord] Gateway ready — ${this.client?.user?.tag}`)
+      this.reconnectAttempt = 0
+    })
+
+    this.client.on('error', (err: Error) => {
+      console.error('[discord] Client error:', err.message)
+      this.emitter.emit('error', err)
+    })
+
+    this.client.on('shardDisconnect', () => {
+      console.warn('[discord] Disconnected — scheduling reconnect')
+      this._scheduleReconnect()
+    })
+
+    await this.client.login(this.secrets.botToken)
+  }
+
+  // ── Gateway: reconexión exponencial ───────────────────────────────────────
+
+  private _scheduleReconnect(): void {
+    if (this.reconnectTimer) return
+    const delay = RECONNECT_DELAYS[
+      Math.min(this.reconnectAttempt, RECONNECT_DELAYS.length - 1)
+    ]!
+    console.info(`[discord] Reconnect in ${delay / 1000}s (attempt ${this.reconnectAttempt + 1})`)
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = undefined
+      this.reconnectAttempt++
+      try {
+        if (this.client) {
+          this.client.destroy()
+          this.client = undefined
+        }
+        await this._startGateway()
+      } catch (err) {
+        console.error('[discord] Reconnect failed:', err)
+        this._scheduleReconnect()
+      }
+    }, delay)
+  }
+
+  // ── Send helpers ──────────────────────────────────────────────────────────
+
+  private async _sendViaClient(
+    channelId: string,
+    text:      string,
+    message:   OutgoingMessage,
+  ): Promise<void> {
+    const channel = await this.client!.channels.fetch(channelId)
+    if (!channel?.isTextBased()) {
+      throw new Error(`[discord] Channel ${channelId} is not a text channel`)
+    }
+
+    const chunks = splitMessage(text, MAX_MESSAGE_LENGTH)
+    for (let i = 0; i < chunks.length; i++) {
+      const isLast = i === chunks.length - 1
+      if (isLast && message.richContent) {
+        await (channel as any).send({
+          content: chunks[i],
+          embeds:  [richContentToEmbed(message.richContent)],
+        })
+      } else {
+        await (channel as any).send({ content: chunks[i] })
+      }
+    }
+  }
+
+  private async _sendViaRestApi(
+    channelId: string,
+    text:      string,
+    message:   OutgoingMessage,
+  ): Promise<void> {
+    const chunks = splitMessage(text, MAX_MESSAGE_LENGTH)
+    for (let i = 0; i < chunks.length; i++) {
+      const isLast = i === chunks.length - 1
+      const body: Record<string, unknown> = { content: chunks[i] }
+      if (isLast && message.richContent) {
+        body['embeds'] = [richContentToEmbed(message.richContent)]
+      }
+
+      const res = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bot ${this.secrets.botToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+
+      if (!res.ok) {
+        const err = await res.text()
+        throw new Error(`[discord] REST send failed (${res.status}): ${err}`)
+      }
+    }
+  }
+
+  private async _sendViaFollowup(
+    interactionToken: string,
+    text:             string,
+    message:          OutgoingMessage,
+  ): Promise<void> {
+    const body: Record<string, unknown> = { content: text.slice(0, MAX_MESSAGE_LENGTH) }
+    if (message.richContent) body['embeds'] = [richContentToEmbed(message.richContent)]
+
+    const res = await fetch(
+      `${DISCORD_API}/webhooks/${this.config.applicationId}/${interactionToken}/messages/@original`,
+      {
+        method:  'PATCH',
+        headers: {
+          Authorization:  `Bot ${this.secrets.botToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      },
+    )
+
+    if (!res.ok) {
+      const err = await res.text()
+      throw new Error(`[discord] Followup PATCH failed (${res.status}): ${err}`)
+    }
+  }
+
+  // ── Signature verification (Ed25519) ──────────────────────────────────────
+
+  /**
+   * Verifica la firma Ed25519 de Discord usando node:crypto nativo.
+   * Discord provee la clave pública como hex (32 bytes) — se envuelve en SPKI DER.
+   *
+   * Fix: createVerify('ed25519') es incorrecto para Ed25519 raw keys.
+   * Usar createPublicKey con SPKI DER header + cryptoVerify(null, ...).
+   */
   private _verifySignature(body: string, timestamp: string, signature: string): boolean {
+    if (!timestamp || !signature || !this.secrets.publicKey) return false
     try {
-      const verify = createVerify('ed25519');
-      verify.update(timestamp + body);
-      return verify.verify(Buffer.from(this.publicKey, 'hex'), Buffer.from(signature, 'hex'));
+      const keyBuffer = Buffer.from(this.secrets.publicKey, 'hex')
+      // SPKI DER header para Ed25519 (OID 1.3.101.112)
+      const spkiHeader = Buffer.from('302a300506032b657003210000', 'hex')
+      const spkiDer    = Buffer.concat([spkiHeader, keyBuffer])
+      const publicKey  = createPublicKey({ key: spkiDer, format: 'der', type: 'spki' })
+      return cryptoVerify(
+        null,
+        Buffer.from(timestamp + body),
+        publicKey,
+        Buffer.from(signature, 'hex'),
+      )
     } catch {
-      return false;
+      return false
+    }
+  }
+
+  // ── Interaction body → IncomingMessage ────────────────────────────────────
+
+  private _interactionBodyToIncoming(
+    body: Record<string, unknown>,
+  ): IncomingMessage | null {
+    const data = body['data'] as Record<string, unknown> | undefined
+    if (!data) return null
+
+    const commandName = data['name']    as string | undefined
+    const options     = data['options'] as Array<{ name: string; value: unknown }> | undefined
+    const text        = options?.map(o => String(o.value)).join(' ') ?? commandName ?? ''
+    const channelId   = body['channel_id'] as string | undefined
+    const member      = body['member']     as Record<string, unknown> | undefined
+    const user        = (member?.['user'] ?? body['user']) as Record<string, unknown> | undefined
+    const userId      = user?.['id'] as string | undefined
+
+    if (!channelId || !userId) return null
+
+    return {
+      channelConfigId: this.channelConfigId,
+      channelType:     'discord',
+      externalId:      channelId,
+      threadId:        channelId,
+      senderId:        userId,
+      text:            commandName ? `${commandName} ${text}`.trim() : text,
+      type:            'command',
+      msgId:           body['id'] as string | undefined,
+      metadata: {
+        interactionToken: body['token'],
+        guildId:          body['guild_id'],
+        username:         user?.['username'],
+      },
+      rawPayload:  body,
+      receivedAt:  new Date().toISOString(),
+    }
+  }
+
+  private _componentBodyToIncoming(
+    body: Record<string, unknown>,
+  ): IncomingMessage | null {
+    const data      = body['data']       as Record<string, unknown> | undefined
+    const channelId = body['channel_id'] as string | undefined
+    const member    = body['member']     as Record<string, unknown> | undefined
+    const user      = (member?.['user'] ?? body['user']) as Record<string, unknown> | undefined
+    const userId    = user?.['id']       as string | undefined
+
+    if (!channelId || !userId || !data) return null
+
+    const customId      = data['custom_id']      as string | undefined ?? ''
+    const componentType = data['component_type'] as number | undefined
+    const values        = data['values']         as string[] | undefined
+
+    const isSelectMenu = componentType === 3
+    const text         = isSelectMenu ? (values?.[0] ?? '') : customId
+
+    return {
+      channelConfigId: this.channelConfigId,
+      channelType:     'discord',
+      externalId:      channelId,
+      threadId:        channelId,
+      senderId:        userId,
+      text,
+      type:    'command',
+      msgId:   body['id'] as string | undefined,
+      metadata: {
+        subtype:          isSelectMenu ? 'quick_reply' : 'button_click',
+        selectedValues:   values,
+        interactionToken: body['token'],
+        guildId:          body['guild_id'],
+        username:         user?.['username'],
+      },
+      rawPayload:  body,
+      receivedAt:  new Date().toISOString(),
     }
   }
 }

--- a/apps/gateway/src/channels/whatsapp-backoff.ts
+++ b/apps/gateway/src/channels/whatsapp-backoff.ts
@@ -1,0 +1,88 @@
+/**
+ * whatsapp-backoff.ts — [F3a-23]
+ *
+ * Motor de backoff exponencial con jitter para reconexión de Baileys.
+ * Extraído del adapter para ser testeable de forma aislada.
+ *
+ * Algoritmo: exponential backoff con full jitter
+ *   delay = random(0, min(cap, base * 2^attempt))
+ */
+
+export interface BackoffOptions {
+  baseMs?: number
+  capMs?: number
+  maxRetries?: number
+  factor?: number
+}
+
+export class ExponentialBackoff {
+  private attempt = 0
+  private aborted = false
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  readonly baseMs: number
+  readonly capMs: number
+  readonly maxRetries: number
+  readonly factor: number
+
+  constructor(opts: BackoffOptions = {}) {
+    this.baseMs = opts.baseMs ?? 3_000
+    this.capMs = opts.capMs ?? 60_000
+    this.maxRetries = opts.maxRetries ?? 8
+    this.factor = opts.factor ?? 2
+  }
+
+  get currentAttempt(): number {
+    return this.attempt
+  }
+
+  get exhausted(): boolean {
+    return this.attempt >= this.maxRetries
+  }
+
+  get isAborted(): boolean {
+    return this.aborted
+  }
+
+  peekDelay(): number {
+    const exp = Math.min(this.capMs, this.baseMs * Math.pow(this.factor, this.attempt))
+    return Math.floor(Math.random() * exp)
+  }
+
+  next(): Promise<void> {
+    if (this.aborted) throw new Error('backoff_aborted')
+    if (this.exhausted) throw new Error('backoff_exhausted')
+
+    const delay = this.peekDelay()
+    this.attempt++
+
+    return new Promise<void>((resolve, reject) => {
+      this.timer = setTimeout(() => {
+        this.timer = null
+        if (this.aborted) reject(new Error('backoff_aborted'))
+        else resolve()
+      }, delay)
+    })
+  }
+
+  abort(): void {
+    this.aborted = true
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  reset(): void {
+    this.attempt = 0
+    this.aborted = false
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  toString(): string {
+    return `BackoffState{attempt=${this.attempt}/${this.maxRetries}, nextDelay≈${this.peekDelay()}ms, exhausted=${this.exhausted}}`
+  }
+}

--- a/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
@@ -1,0 +1,444 @@
+/**
+ * whatsapp-baileys.adapter.ts — WhatsApp via Baileys (WA Web protocol)
+ * [F3a-21 / F3a-23 / F3a-24]
+ *
+ * A diferencia de WhatsAppAdapter (Cloud API), este adapter usa el
+ * protocolo WhatsApp Web via Baileys. No requiere cuenta Business ni
+ * aprobación de Meta — funciona con cualquier número de WhatsApp.
+ *
+ * F3a-24: Inline mapping reemplazado por llamadas a:
+ *   - baileysToIncoming() de whatsapp-message.mapper.ts
+ *   - outgoingToBaileys() de whatsapp-send.mapper.ts
+ * Se eliminan métodos privados: toJid(), handleIncomingMessage(),
+ * normalizeMessage(), extractText(), extractType(), extractAttachment().
+ *
+ * F3a-23: ExponentialBackoff integrado para reconexiones.
+ */
+
+import path         from 'node:path'
+import fs           from 'node:fs'
+import EventEmitter from 'node:events'
+import {
+  BaseChannelAdapter,
+  type OutgoingMessage,
+} from './channel-adapter.interface.js'
+import { baileysToIncoming }  from './whatsapp-message.mapper.js'
+import { outgoingToBaileys }  from './whatsapp-send.mapper.js'
+import { ExponentialBackoff } from './whatsapp-backoff.js'
+
+// ── Tipos de Baileys (importados dinámicamente) ─────────────────────────
+
+type BaileysSocket = {
+  sendMessage: (
+    jid: string,
+    content: Record<string, unknown>,
+    opts?: Record<string, unknown>,
+  ) => Promise<unknown>
+  logout: () => Promise<void>
+  end:    (err?: Error) => void
+  ev: {
+    on:              (event: string, handler: (...args: unknown[]) => void) => void
+    off:             (event: string, handler: (...args: unknown[]) => void) => void
+    removeAllListeners: () => void
+  }
+  user?: { id: string; name?: string }
+}
+
+type DisconnectReason = {
+  loggedOut:         number
+  connectionLost:    number
+  restartRequired:   number
+  timedOut:          number
+  badSession:        number
+  connectionReplaced: number
+}
+
+// ── Estado del adapter ──────────────────────────────────────────────────
+
+export type WhatsAppAdapterState =
+  | 'idle'
+  | 'connecting'
+  | 'qr'
+  | 'open'
+  | 'closed'
+  | 'reconnecting'
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+interface WhatsAppBaileysConfig {
+  sessionsDir?:          string
+  maxReconnectAttempts?: number
+  qrTimeoutMs?:         number
+  printQrInTerminal?:   boolean
+  browser?:             [string, string, string]
+}
+
+// ── WhatsAppBaileysAdapter ───────────────────────────────────────────────
+
+export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
+  readonly channel = 'whatsapp-baileys'
+
+  // Estado interno
+  private _state:           WhatsAppAdapterState = 'idle'
+  private sock:              BaileysSocket | null  = null
+  private qrTimeoutHandle:  ReturnType<typeof setTimeout> | null = null
+  private connectPromise:   Promise<void> | null = null
+
+  // Backoff (F3a-23)
+  private backoff = new ExponentialBackoff({
+    baseMs:     3_000,
+    capMs:      90_000,
+    maxRetries: 8,
+    factor:     2,
+  })
+
+  // Config
+  private sessionsDir          = process.env['WA_SESSIONS_DIR'] ?? './data/wa-sessions'
+  private maxReconnectAttempts = parseInt(process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? '8')
+  private qrTimeoutMs          = 120_000
+  private printQrInTerminal    = false
+  private browser: [string, string, string] = ['AgentVS Gateway', 'Chrome', '120.0']
+
+  private readonly emitter = new EventEmitter()
+
+  // ── Estado público ───────────────────────────────────────────────────────────
+
+  get state(): WhatsAppAdapterState { return this._state }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  async initialize(channelConfigId: string): Promise<void> {
+    this.channelConfigId = channelConfigId
+    console.warn('[whatsapp-baileys] initialize() sin credenciales — usar setup(config, secrets)')
+  }
+
+  async setup(
+    config:   Record<string, unknown>,
+    _secrets: Record<string, unknown>,
+  ): Promise<void> {
+    const cfg = config as WhatsAppBaileysConfig
+    this.sessionsDir = String(
+      process.env['WA_SESSIONS_DIR'] ?? cfg.sessionsDir ?? './data/wa-sessions',
+    )
+    this.maxReconnectAttempts = Number(
+      process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? cfg.maxReconnectAttempts ?? 8,
+    )
+    this.qrTimeoutMs       = Number(cfg.qrTimeoutMs    ?? 120_000)
+    this.printQrInTerminal = Boolean(cfg.printQrInTerminal ?? false)
+    if (cfg.browser) this.browser = cfg.browser
+
+    fs.mkdirSync(this.getSessionPath(), { recursive: true })
+    console.info(
+      `[whatsapp-baileys] Adapter configured (lazy) — channelId=${this.channelConfigId}`,
+    )
+  }
+
+  async connect(): Promise<void> {
+    if (this._state === 'open') return
+    if (this.connectPromise) return this.connectPromise
+
+    this.connectPromise = this.doConnect()
+    try {
+      await this.connectPromise
+    } finally {
+      this.connectPromise = null
+    }
+  }
+
+  private async doConnect(): Promise<void> {
+    this.setState('connecting')
+
+    const baileys = await import('@whiskeysockets/baileys').catch((err: unknown) => {
+      throw new Error(
+        `[whatsapp-baileys] No se pudo cargar @whiskeysockets/baileys: ${String(err)}`,
+      )
+    })
+
+    const { makeWASocket, useMultiFileAuthState, DisconnectReason: DR, fetchLatestBaileysVersion } =
+      baileys as unknown as {
+        makeWASocket:          (opts: Record<string, unknown>) => BaileysSocket
+        useMultiFileAuthState: (dir: string) => Promise<{ state: unknown; saveCreds: () => Promise<void> }>
+        DisconnectReason:      DisconnectReason
+        fetchLatestBaileysVersion: () => Promise<{ version: [number, number, number] }>
+      }
+
+    const sessionPath       = this.getSessionPath()
+    const { state, saveCreds } = await useMultiFileAuthState(sessionPath)
+    const { version }        = await fetchLatestBaileysVersion()
+
+    const sock = makeWASocket({
+      version,
+      auth:              state,
+      printQRInTerminal: this.printQrInTerminal,
+      browser:           this.browser,
+      logger:            this.makePinoLogger(),
+      retryRequestDelayMs: 0,
+    }) as BaileysSocket
+
+    this.sock = sock
+
+    // ── connection.update ─────────────────────────────────────────────────
+    sock.ev.on('connection.update', ((update: {
+      connection?: string
+      lastDisconnect?: { error?: { output?: { statusCode?: number } } }
+      qr?: string
+    }) => {
+      const { connection, lastDisconnect, qr } = update
+
+      if (qr) { this.handleQr(qr) }
+
+      if (connection === 'close') {
+        this.clearQrTimeout()
+        const statusCode = lastDisconnect?.error?.output?.statusCode
+        const isPermanentClose =
+          statusCode === (DR as unknown as DisconnectReason).loggedOut ||
+          statusCode === (DR as unknown as DisconnectReason).connectionReplaced
+
+        if (isPermanentClose) {
+          console.warn(`[whatsapp-baileys:${this.channelConfigId}] Permanent close (${statusCode}) — clearing session`)
+          this.clearSessionFiles()
+          this.setState('closed')
+          this.emitter.emit('closed', this.channelConfigId, 'permanent_close')
+          return
+        }
+
+        // Reconexión con ExponentialBackoff (F3a-23)
+        if (!this.backoff.exhausted && !this.backoff.isAborted) {
+          this.setState('reconnecting')
+          this.sock = null
+          this.connectPromise = null
+
+          console.warn(
+            `[whatsapp-baileys:${this.channelConfigId}] Disconnected — ${this.backoff}`,
+          )
+
+          this.backoff.next()
+            .then(() => this.connect())
+            .catch((err: Error) => {
+              if (err.message === 'backoff_exhausted') {
+                this.setState('closed')
+                this.emitter.emit('closed', this.channelConfigId, 'max_retries_exceeded')
+                console.error(
+                  `[whatsapp-baileys:${this.channelConfigId}] Max retries reached`,
+                )
+              } else if (err.message !== 'backoff_aborted') {
+                console.error(
+                  `[whatsapp-baileys:${this.channelConfigId}] Reconnect error:`, err,
+                )
+              }
+              // 'backoff_aborted' = dispose() fue llamado — silencio intencional
+            })
+        } else {
+          this.setState('closed')
+          this.emitter.emit('closed', this.channelConfigId, 'max_retries_exceeded')
+        }
+      }
+
+      if (connection === 'open') {
+        this.clearQrTimeout()
+        this.backoff.reset()   // F3a-23: resetear tras conexión exitosa
+        this.setState('open')
+        console.info(
+          `[whatsapp-baileys:${this.channelConfigId}] Connected — jid=${sock.user?.id ?? 'unknown'}`,
+        )
+      }
+    }) as (...args: unknown[]) => void)
+
+    sock.ev.on('creds.update', saveCreds as unknown as (...args: unknown[]) => void)
+
+    // ── messages.upsert: usa baileysToIncoming() (F3a-24) ──────────────────
+    sock.ev.on('messages.upsert', ((event: { messages: unknown[]; type: string }) => {
+      if (event.type !== 'notify') return
+
+      for (const rawMsg of event.messages) {
+        // Castear a proto.IWebMessageInfo (estructura compatible)
+        const waMsg = rawMsg as Parameters<typeof baileysToIncoming>[0]
+        const normalized = baileysToIncoming(waMsg)
+        if (!normalized) continue   // null = mensaje propio / sistema / no soportado
+
+        this.emit(normalized).catch((err: unknown) =>
+          console.error(
+            `[whatsapp-baileys:${this.channelConfigId}] emit error (${(waMsg as any).key?.id}):`,
+            err,
+          ),
+        )
+      }
+    }) as (...args: unknown[]) => void)
+  }
+
+  // ── dispose (F3a-23: abortar backoff) ───────────────────────────────────
+
+  async dispose(): Promise<void> {
+    this.backoff.abort()   // F3a-23: cancelar timer de reconexion pendiente
+    this.clearQrTimeout()
+    this.setState('closed')
+
+    if (this.sock) {
+      try {
+        this.sock.ev.removeAllListeners()
+        this.sock.end()
+      } catch { /* ignorar */ }
+      this.sock = null
+    }
+
+    this.emitter.removeAllListeners()
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] Adapter disposed`)
+  }
+
+  // ── logout (F3a-23) ──────────────────────────────────────────────────────
+
+  /**
+   * Cierra la sesión de WhatsApp Web notificando al servidor WA.
+   * Después de logout(), el estado queda 'closed'.
+   * Se puede volver a conectar con connect() → generará nuevo QR.
+   */
+  async logout(): Promise<void> {
+    this.backoff.abort()
+    this.clearQrTimeout()
+
+    if (this.sock) {
+      try {
+        await this.sock.logout()
+      } catch (err) {
+        console.warn(`[whatsapp-baileys:${this.channelConfigId}] logout error:`, err)
+      } finally {
+        this.sock.ev.removeAllListeners()
+        this.sock.end()
+        this.sock = null
+      }
+    }
+
+    this.connectPromise = null
+    this.setState('closed')
+    this.emitter.emit('closed', this.channelConfigId, 'logged_out')
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] Logged out`)
+  }
+
+  // ── send() — usa outgoingToBaileys() (F3a-24) ─────────────────────────
+
+  async send(message: OutgoingMessage): Promise<void> {
+    if (this._state === 'idle' || this._state === 'closed') {
+      await this.connect()
+    }
+    if (this._state !== 'open') {
+      await this.waitForOpen(30_000)
+    }
+    if (!this.sock) {
+      throw new Error(`[whatsapp-baileys:${this.channelConfigId}] Socket not available`)
+    }
+
+    const { jid, content } = outgoingToBaileys(message)
+    await this.sock.sendMessage(jid, content)
+
+    console.info(
+      `[whatsapp-baileys:${this.channelConfigId}] Message sent to ${message.externalId}`,
+    )
+  }
+
+  // ── receive() ────────────────────────────────────────────────────────────
+
+  async receive(
+    rawPayload: Record<string, unknown>,
+    _secrets:   Record<string, unknown>,
+  ): Promise<ReturnType<typeof baileysToIncoming>> {
+    return baileysToIncoming(rawPayload as Parameters<typeof baileysToIncoming>[0])
+  }
+
+  // ── Callbacks públicos ──────────────────────────────────────────────────────
+
+  onQr(handler: (qr: string) => void): void {
+    this.emitter.on('qr', handler)
+  }
+
+  onConnected(handler: () => void): void {
+    this.emitter.on('open', handler)
+  }
+
+  onDisconnected(handler: () => void): void {
+    this.emitter.on('closed', handler)
+  }
+
+  onStateChange(handler: (state: WhatsAppAdapterState) => void): void {
+    this.emitter.on('state', handler)
+  }
+
+  onError(handler: (err: Error) => void): void {
+    this.emitter.on('error', handler)
+  }
+
+  getState(): WhatsAppAdapterState { return this._state }
+
+  // ── Helpers privados ───────────────────────────────────────────────────────────
+
+  private setState(newState: WhatsAppAdapterState): void {
+    if (this._state === newState) return
+    const prev = this._state
+    this._state = newState
+    console.info(`[whatsapp-baileys:${this.channelConfigId}] State: ${prev} → ${newState}`)
+    this.emitter.emit('state', newState)
+    if (newState === 'open')   this.emitter.emit('open')
+    if (newState === 'closed') this.emitter.emit('closed', this.channelConfigId)
+  }
+
+  private clearQrTimeout(): void {
+    if (this.qrTimeoutHandle !== null) {
+      clearTimeout(this.qrTimeoutHandle)
+      this.qrTimeoutHandle = null
+    }
+  }
+
+  private handleQr(qr: string): void {
+    this.setState('qr')
+    this.emitter.emit('qr', qr)
+    this.clearQrTimeout()
+    this.qrTimeoutHandle = setTimeout(() => {
+      console.warn(`[whatsapp-baileys:${this.channelConfigId}] QR timeout — closing socket`)
+      this.setState('closed')
+      this.sock?.end(new Error('QR timeout'))
+      this.sock = null
+    }, this.qrTimeoutMs)
+  }
+
+  private getSessionPath(): string {
+    return path.join(this.sessionsDir, this.channelConfigId || 'default')
+  }
+
+  private clearSessionFiles(): void {
+    const sessionPath = this.getSessionPath()
+    try {
+      fs.rmSync(sessionPath, { recursive: true, force: true })
+      console.info(`[whatsapp-baileys:${this.channelConfigId}] Auth state deleted: ${sessionPath}`)
+    } catch (err) {
+      console.error(`[whatsapp-baileys:${this.channelConfigId}] Error deleting auth state:`, err)
+    }
+  }
+
+  /**
+   * Espera hasta que el estado sea 'open' o se alcance el timeout.
+   * Usado en send() para lazy connect.
+   */
+  private waitForOpen(timeoutMs: number): Promise<void> {
+    if (this._state === 'open') return Promise.resolve()
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.emitter.off('open', onOpen)
+        reject(new Error(`[whatsapp-baileys:${this.channelConfigId}] waitForOpen timeout`))
+      }, timeoutMs)
+      const onOpen = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      this.emitter.once('open', onOpen)
+    })
+  }
+
+  private makePinoLogger() {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pino = require('pino') as (opts: Record<string, unknown>) => unknown
+      return pino({ level: 'silent' })
+    } catch {
+      return undefined
+    }
+  }
+}

--- a/apps/gateway/src/channels/whatsapp-deprovision.service.ts
+++ b/apps/gateway/src/channels/whatsapp-deprovision.service.ts
@@ -1,0 +1,102 @@
+/**
+ * whatsapp-deprovision.service.ts — [F3a-23]
+ */
+
+import { existsSync, rmSync } from 'node:fs'
+import path from 'node:path'
+import type { PrismaClient } from '@prisma/client'
+import type { WhatsAppSessionStore } from '../whatsapp-session.store.js'
+
+const WA_SESSIONS_DIR = process.env.WA_SESSIONS_DIR ?? './data/wa-sessions'
+
+export interface LogoutResult {
+  configId: string
+  sessionDeleted: boolean
+  adapterState: string
+}
+
+export interface DeprovisionResult extends LogoutResult {
+  channelDeactivated: boolean
+  storeDestroyed: boolean
+}
+
+export class WhatsAppDeprovisionService {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly store: WhatsAppSessionStore,
+  ) {}
+
+  async logout(configId: string): Promise<LogoutResult> {
+    const entry = this.store.get(configId)
+    const adapter = entry?.adapter as {
+      state?: string
+      logout?: () => Promise<void>
+      dispose: () => Promise<void>
+    } | undefined
+
+    if (adapter) {
+      if (adapter.state === 'open' || adapter.state === 'reconnecting') {
+        await adapter.logout?.().catch((err) => {
+          console.warn(`[wa-deprovision] logout error (${configId}):`, err)
+        })
+      } else {
+        await adapter.dispose().catch((err) => {
+          console.warn(`[wa-deprovision] dispose error (${configId}):`, err)
+        })
+      }
+    }
+
+    const sessionDir = path.join(WA_SESSIONS_DIR, configId)
+    const sessionDeleted = this.deleteSessionDir(sessionDir)
+
+    return {
+      configId,
+      sessionDeleted,
+      adapterState: adapter?.state ?? 'not_in_store',
+    }
+  }
+
+  async deprovision(configId: string): Promise<DeprovisionResult> {
+    const logoutResult = await this.logout(configId)
+
+    let channelDeactivated = false
+    try {
+      await this.db.channelConfig.update({
+        where: { id: configId },
+        data: { active: false },
+      })
+      channelDeactivated = true
+    } catch (err: any) {
+      if (err?.code !== 'P2025') {
+        console.error('[wa-deprovision] DB update error:', err)
+      }
+    }
+
+    let storeDestroyed = false
+    try {
+      this.store.remove(configId)
+      storeDestroyed = true
+    } catch (err) {
+      console.error('[wa-deprovision] store.remove error:', err)
+    }
+
+    return {
+      ...logoutResult,
+      channelDeactivated,
+      storeDestroyed,
+    }
+  }
+
+  private deleteSessionDir(sessionDir: string): boolean {
+    try {
+      if (existsSync(sessionDir)) {
+        rmSync(sessionDir, { recursive: true, force: true })
+        return true
+      }
+      return false
+    } catch (err) {
+      console.error('[wa-deprovision] Failed to delete session dir:', err)
+      return false
+    }
+  }
+}

--- a/apps/gateway/src/channels/whatsapp-deprovision.service.ts
+++ b/apps/gateway/src/channels/whatsapp-deprovision.service.ts
@@ -1,5 +1,26 @@
 /**
  * whatsapp-deprovision.service.ts — [F3a-23]
+ *
+ * Servicio que coordina el ciclo completo de logout y deprovision
+ * para sesiones WhatsApp Baileys.
+ *
+ * logout(configId):
+ *   1. Cierra el socket Baileys limpiamente (sock.logout())
+ *   2. Borra los archivos de sesión del filesystem
+ *   3. El ChannelConfig en Prisma NO se modifica (canal sigue activo)
+ *   4. El adapter en el store queda en estado 'closed'
+ *   → Admin puede re-conectar con nuevo QR
+ *
+ * deprovision(configId):
+ *   1. logout() completo
+ *   2. Desactiva el ChannelConfig en Prisma: active = false
+ *   3. Destruye la sesión en WhatsAppSessionStore (remove)
+ *   → Canal queda inoperativo hasta reactivación manual
+ *
+ * IMPORTANTE:
+ *   - Recibe PrismaClient inyectado — no crea instancia propia
+ *   - Recibe WhatsAppSessionStore inyectado — no usa singleton directamente
+ *     (facilita testing con mocks)
  */
 
 import { existsSync, rmSync } from 'node:fs'
@@ -9,45 +30,58 @@ import type { WhatsAppSessionStore } from '../whatsapp-session.store.js'
 
 const WA_SESSIONS_DIR = process.env.WA_SESSIONS_DIR ?? './data/wa-sessions'
 
+// ── Tipos ────────────────────────────────────────────────────────────────────
+
 export interface LogoutResult {
-  configId: string
+  configId:       string
   sessionDeleted: boolean
-  adapterState: string
+  adapterState:   string
 }
 
 export interface DeprovisionResult extends LogoutResult {
   channelDeactivated: boolean
-  storeDestroyed: boolean
+  storeDestroyed:     boolean
 }
+
+// ── Servicio ─────────────────────────────────────────────────────────────────
 
 export class WhatsAppDeprovisionService {
   constructor(
-    private readonly db: PrismaClient,
+    private readonly db:    PrismaClient,
     private readonly store: WhatsAppSessionStore,
   ) {}
 
+  // ── logout ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Cierra la sesión WA Web y borra archivos de credenciales.
+   * El canal sigue activo en DB — solo se limpia la sesión.
+   */
   async logout(configId: string): Promise<LogoutResult> {
-    const entry = this.store.get(configId)
-    const adapter = entry?.adapter as {
-      state?: string
-      logout?: () => Promise<void>
-      dispose: () => Promise<void>
-    } | undefined
+    const entry   = this.store.get(configId)
+    const adapter = entry?.adapter
 
     if (adapter) {
+      // 'open' | 'reconnecting' → usar logout() que notifica al servidor WA
+      // cualquier otro estado   → dispose() es suficiente para limpiar recursos
       if (adapter.state === 'open' || adapter.state === 'reconnecting') {
-        await adapter.logout?.().catch((err) => {
-          console.warn(`[wa-deprovision] logout error (${configId}):`, err)
-        })
+        await adapter.logout?.().catch((err: unknown) =>
+          console.warn(`[wa-deprovision] logout error (${configId}):`, err),
+        )
       } else {
-        await adapter.dispose().catch((err) => {
-          console.warn(`[wa-deprovision] dispose error (${configId}):`, err)
-        })
+        await adapter.dispose().catch((err: unknown) =>
+          console.warn(`[wa-deprovision] dispose error (${configId}):`, err),
+        )
       }
     }
 
-    const sessionDir = path.join(WA_SESSIONS_DIR, configId)
+    // Borrar archivos de sesión del filesystem
+    const sessionDir    = path.join(WA_SESSIONS_DIR, configId)
     const sessionDeleted = this.deleteSessionDir(sessionDir)
+
+    console.info(
+      `[wa-deprovision] logout complete — configId=${configId}, sessionDeleted=${sessionDeleted}`,
+    )
 
     return {
       configId,
@@ -56,22 +90,39 @@ export class WhatsAppDeprovisionService {
     }
   }
 
+  // ── deprovision ────────────────────────────────────────────────────────────
+
+  /**
+   * Deprovision completo:
+   *   logout() → deactivate ChannelConfig in Prisma → destroy store entry
+   *
+   * Tolerante a fallos: cada paso se intenta independientemente.
+   * Si falla la actualización de DB, los demás pasos siguen ejecutándose.
+   * Se retorna un resultado parcial indicando qué operaciones tuvieron éxito.
+   */
   async deprovision(configId: string): Promise<DeprovisionResult> {
+    // 1. Logout (cierra socket + borra FS)
     const logoutResult = await this.logout(configId)
 
+    // 2. Desactivar ChannelConfig en Prisma
     let channelDeactivated = false
     try {
       await this.db.channelConfig.update({
         where: { id: configId },
-        data: { active: false },
+        data:  { active: false },
       })
       channelDeactivated = true
+      console.info(`[wa-deprovision] ChannelConfig deactivated: ${configId}`)
     } catch (err: any) {
-      if (err?.code !== 'P2025') {
+      // P2025 = registro no encontrado en Prisma — no es error crítico
+      if (err?.code === 'P2025') {
+        console.warn(`[wa-deprovision] ChannelConfig not found in DB: ${configId}`)
+      } else {
         console.error('[wa-deprovision] DB update error:', err)
       }
     }
 
+    // 3. Destruir entrada en el store (cierra SSE clients)
     let storeDestroyed = false
     try {
       this.store.remove(configId)
@@ -80,17 +131,27 @@ export class WhatsAppDeprovisionService {
       console.error('[wa-deprovision] store.remove error:', err)
     }
 
-    return {
+    const result: DeprovisionResult = {
       ...logoutResult,
       channelDeactivated,
       storeDestroyed,
     }
+
+    console.info(
+      `[wa-deprovision] deprovision complete — configId=${configId}`,
+      result,
+    )
+
+    return result
   }
+
+  // ── Helper ─────────────────────────────────────────────────────────────────
 
   private deleteSessionDir(sessionDir: string): boolean {
     try {
       if (existsSync(sessionDir)) {
         rmSync(sessionDir, { recursive: true, force: true })
+        console.info(`[wa-deprovision] Session dir deleted: ${sessionDir}`)
         return true
       }
       return false

--- a/apps/gateway/src/channels/whatsapp-message.mapper.ts
+++ b/apps/gateway/src/channels/whatsapp-message.mapper.ts
@@ -1,0 +1,363 @@
+/**
+ * whatsapp-message.mapper.ts — [F3a-24]
+ *
+ * Normaliza WAMessage (proto.IWebMessageInfo de Baileys) a IncomingMessage.
+ *
+ * Función principal: baileysToIncoming()
+ *   - Retorna IncomingMessage si el mensaje es procesable
+ *   - Retorna null si el mensaje debe ignorarse:
+ *       * mensajes del propio bot (fromMe = true)
+ *       * mensajes de sistema (protocolMessage, ephemeralMessage, etc.)
+ *       * tipos no soportados
+ *
+ * Diseño:
+ *   - Función pura — sin efectos secundarios, sin imports de servicios
+ *   - Los datos raw de Baileys siempre se preservan en rawPayload
+ *   - La URL de media NO se descarga aquí — el caller puede pedirla
+ *     via sock.downloadMediaMessage() usando rawPayload
+ */
+
+import type { proto }          from '@whiskeysockets/baileys'
+import type { IncomingMessage } from './channel-adapter.interface.js'
+
+// ── Tipos de mensajes que silenciosamente ignoramos ─────────────────────
+
+const IGNORED_MSG_TYPES = new Set([
+  'protocolMessage',
+  'ephemeralMessage',
+  'senderKeyDistributionMessage',
+  'pollCreationMessage',
+  'pollUpdateMessage',
+  'viewOnceMessage',
+  'viewOnceMessageV2',
+  'liveLocationMessage',
+  'callLogMesssage',
+  'requestPaymentMessage',
+  'sendPaymentMessage',
+])
+
+// ── Opciones ─────────────────────────────────────────────────────────────────
+
+export interface BaileysMapperOptions {
+  /** Si true, los mensajes de reacción se procesan como type 'command'. Default: false */
+  processReactions?: boolean
+}
+
+// ── Función principal ─────────────────────────────────────────────────────────
+
+/**
+ * Convierte un WAMessage de Baileys en IncomingMessage normalizado.
+ *
+ * @param waMsg  - Mensaje raw de Baileys (proto.IWebMessageInfo)
+ * @param opts   - Opciones de procesamiento
+ * @returns IncomingMessage normalizado, o null si debe ignorarse
+ */
+export function baileysToIncoming(
+  waMsg: proto.IWebMessageInfo,
+  opts: BaileysMapperOptions = {},
+): IncomingMessage | null {
+
+  // 1. Ignorar mensajes propios (el bot enviando)
+  if (waMsg.key.fromMe) return null
+
+  // 2. Ignorar status broadcasts
+  const remoteJid = waMsg.key.remoteJid ?? ''
+  if (remoteJid === 'status@broadcast') return null
+
+  // 3. Extraer JID del remitente y del chat
+  const senderJid = waMsg.key.participant ?? remoteJid   // en grupos, participant ≠ jid
+  const isGroup   = isGroupJid(remoteJid)
+
+  // 4. Normalizar JID → número de teléfono
+  const externalId = jidToPhone(remoteJid)
+  const senderId   = jidToPhone(senderJid)
+
+  if (!externalId) {
+    console.warn('[wa-mapper] Could not extract phone from JID:', remoteJid)
+    return null
+  }
+
+  // 5. Obtener el contenido del mensaje
+  const msgContent = waMsg.message
+  if (!msgContent) return null
+
+  // 6. Detectar tipo y comprobar si debe ignorarse
+  const msgKey = detectMessageKey(msgContent)
+  if (!msgKey) return null
+
+  // 7. Ignorar tipos de sistema (reactionMessage se ignora por defecto)
+  if (IGNORED_MSG_TYPES.has(msgKey)) return null
+  if (msgKey === 'reactionMessage' && !opts.processReactions) return null
+
+  // 8. Timestamp normalizado
+  const timestamp = waMsg.messageTimestamp
+    ? new Date(Number(waMsg.messageTimestamp) * 1000).toISOString()
+    : new Date().toISOString()
+
+  // 9. rawPayload: el WAMessage completo (sin secretos — Baileys no los incluye aquí)
+  const rawPayload = waMsg as unknown as Record<string, unknown>
+
+  // 10. Base metadata
+  const baseMetadata: Record<string, unknown> = {
+    msgId:   waMsg.key.id ?? '',
+    jid:     remoteJid,
+    isGroup,
+    pushName: (waMsg as any).pushName ?? '',
+  }
+
+  // 11. Mapear por tipo
+  return mapByType(msgKey, msgContent, {
+    externalId,
+    senderId,
+    threadId:    externalId,   // WA no tiene threads — threadId === externalId
+    rawPayload,
+    timestamp,
+    baseMetadata,
+  })
+}
+
+// ── Detectar tipo de mensaje ───────────────────────────────────────────────────
+
+const KNOWN_KEYS: (keyof proto.IMessage)[] = [
+  'conversation',
+  'extendedTextMessage',
+  'imageMessage',
+  'audioMessage',
+  'videoMessage',
+  'documentMessage',
+  'stickerMessage',
+  'locationMessage',
+  'contactMessage',
+  'reactionMessage',
+  'protocolMessage',
+  'ephemeralMessage',
+  'senderKeyDistributionMessage',
+  'pollCreationMessage',
+  'pollUpdateMessage',
+]
+
+function detectMessageKey(msg: proto.IMessage): string | null {
+  for (const key of KNOWN_KEYS) {
+    if (msg[key] != null) return key as string
+  }
+  const fallback = Object.keys(msg).find((k) => (msg as any)[k] != null)
+  return fallback ?? null
+}
+
+// ── Contexto de mapeo ────────────────────────────────────────────────────────────
+
+interface MapCtx {
+  externalId:   string
+  senderId:     string
+  threadId:     string
+  rawPayload:   Record<string, unknown>
+  timestamp:    string
+  baseMetadata: Record<string, unknown>
+}
+
+// ── Mapeo por tipo ────────────────────────────────────────────────────────────────
+
+function mapByType(
+  key:     string,
+  content: proto.IMessage,
+  ctx:     MapCtx,
+): IncomingMessage | null {
+
+  const base = {
+    externalId:  ctx.externalId,
+    senderId:    ctx.senderId,
+    threadId:    ctx.threadId,
+    rawPayload:  ctx.rawPayload,
+    receivedAt:  ctx.timestamp,
+  }
+
+  switch (key) {
+
+    // ── Texto plano ─────────────────────────────────────────────────
+    case 'conversation': {
+      const text = content.conversation ?? ''
+      return {
+        ...base,
+        text,
+        type: text.startsWith('/') ? 'command' : 'text',
+        metadata: { ...ctx.baseMetadata },
+      }
+    }
+
+    // ── Texto enriquecido ──────────────────────────────────────────────
+    case 'extendedTextMessage': {
+      const text = content.extendedTextMessage?.text ?? ''
+      return {
+        ...base,
+        text,
+        type: text.startsWith('/') ? 'command' : 'text',
+        metadata: {
+          ...ctx.baseMetadata,
+          contextInfo: content.extendedTextMessage?.contextInfo,
+          previewUrl:  content.extendedTextMessage?.canonicalUrl,
+        },
+      }
+    }
+
+    // ── Imagen ────────────────────────────────────────────────────
+    case 'imageMessage':
+      return {
+        ...base,
+        text:  content.imageMessage?.caption ?? '',
+        type:  'image',
+        attachments: [{
+          type: 'image',
+          data: {
+            mimetype: content.imageMessage?.mimetype ?? 'image/jpeg',
+            caption:  content.imageMessage?.caption  ?? '',
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Audio / nota de voz ───────────────────────────────────────────
+    case 'audioMessage':
+      return {
+        ...base,
+        text: '',
+        type: 'audio',
+        attachments: [{
+          type: content.audioMessage?.ptt ? 'voice_note' : 'audio',
+          data: {
+            mimetype: content.audioMessage?.mimetype ?? 'audio/ogg',
+            seconds:  content.audioMessage?.seconds  ?? 0,
+            ptt:      content.audioMessage?.ptt      ?? false,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Video ─────────────────────────────────────────────────────
+    case 'videoMessage':
+      return {
+        ...base,
+        text:  content.videoMessage?.caption ?? '',
+        type:  'file',
+        attachments: [{
+          type: 'video',
+          data: {
+            mimetype: content.videoMessage?.mimetype ?? 'video/mp4',
+            caption:  content.videoMessage?.caption  ?? '',
+            seconds:  content.videoMessage?.seconds  ?? 0,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Documento ───────────────────────────────────────────────────
+    case 'documentMessage':
+      return {
+        ...base,
+        text:  content.documentMessage?.caption ?? '',
+        type:  'file',
+        attachments: [{
+          type: 'document',
+          data: {
+            fileName: content.documentMessage?.fileName ?? 'document',
+            mimetype: content.documentMessage?.mimetype ?? 'application/octet-stream',
+            fileSize: content.documentMessage?.fileLength ?? 0,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Sticker ────────────────────────────────────────────────────
+    case 'stickerMessage':
+      return {
+        ...base,
+        text:  '[sticker]',
+        type:  'image',
+        attachments: [{
+          type: 'sticker',
+          data: {
+            mimetype:   content.stickerMessage?.mimetype    ?? 'image/webp',
+            isAnimated: content.stickerMessage?.isAnimated ?? false,
+          },
+        }],
+        metadata: { ...ctx.baseMetadata },
+      }
+
+    // ── Ubicación ──────────────────────────────────────────────────
+    case 'locationMessage': {
+      const lat  = content.locationMessage?.degreesLatitude  ?? 0
+      const lng  = content.locationMessage?.degreesLongitude ?? 0
+      const name = content.locationMessage?.name ?? ''
+      return {
+        ...base,
+        text: name
+          ? `📍 ${name} (${lat}, ${lng})`
+          : `📍 Location: ${lat}, ${lng}`,
+        type: 'text',
+        metadata: {
+          ...ctx.baseMetadata,
+          location: { lat, lng, name },
+        },
+      }
+    }
+
+    // ── Contacto ───────────────────────────────────────────────────
+    case 'contactMessage': {
+      const displayName = content.contactMessage?.displayName ?? 'Contact'
+      const vcard       = content.contactMessage?.vcard ?? ''
+      const telMatch    = vcard.match(/TEL[^:]*:([^\r\n]+)/)
+      const phone       = telMatch?.[1]?.trim() ?? ''
+      return {
+        ...base,
+        text: phone
+          ? `\ud83d\udc64 ${displayName}: ${phone}`
+          : `\ud83d\udc64 ${displayName}`,
+        type: 'text',
+        metadata: {
+          ...ctx.baseMetadata,
+          contact: { displayName, phone, vcard },
+        },
+      }
+    }
+
+    // ── Reacción ───────────────────────────────────────────────────
+    case 'reactionMessage': {
+      const emoji    = content.reactionMessage?.text ?? ''
+      const targetId = content.reactionMessage?.key?.id ?? ''
+      return {
+        ...base,
+        text:  emoji,
+        type:  'command',
+        metadata: {
+          ...ctx.baseMetadata,
+          reaction: { emoji, targetMessageId: targetId },
+        },
+      }
+    }
+
+    default:
+      return null
+  }
+}
+
+// ── Helpers públicos ────────────────────────────────────────────────────────────
+
+/**
+ * Convierte un JID de Baileys al número de teléfono sin sufijo.
+ * Ejemplos:
+ *   '521234567890@s.whatsapp.net'   → '521234567890'
+ *   '521234567890:5@s.whatsapp.net' → '521234567890'  (multi-device)
+ *   '120363123456@g.us'             → '120363123456'  (grupo)
+ *   ''                              → ''
+ */
+export function jidToPhone(jid: string): string {
+  if (!jid) return ''
+  const withoutSuffix = jid.split('@')[0] ?? ''
+  return withoutSuffix.split(':')[0] ?? ''
+}
+
+/**
+ * Retorna true si el JID corresponde a un grupo de WhatsApp.
+ */
+export function isGroupJid(jid: string): boolean {
+  return jid.endsWith('@g.us')
+}

--- a/apps/gateway/src/channels/whatsapp-send.mapper.ts
+++ b/apps/gateway/src/channels/whatsapp-send.mapper.ts
@@ -1,0 +1,178 @@
+/**
+ * whatsapp-send.mapper.ts — [F3a-24]
+ *
+ * Convierte OutgoingMessage (interfaz genérica del gateway) al payload
+ * que acepta sock.sendMessage(jid, content) de Baileys.
+ *
+ * Función principal: outgoingToBaileys()
+ *
+ * Tipos de richContent soportados:
+ *   richContent.type = 'buttons'   → ButtonMessage de Baileys
+ *   richContent.type = 'list'      → ListMessage de Baileys
+ *   richContent.type = 'template'  → TemplateMessage (WA Business)
+ *   (sin richContent)              → texto plano
+ *
+ * Función auxiliar: phoneToJid()
+ *   Convierte número de teléfono a JID de Baileys.
+ *   '521234567890' → '521234567890@s.whatsapp.net'
+ *   Idempotente: si recibe un JID ya formado, lo retorna tal cual.
+ */
+
+import type { OutgoingMessage } from './channel-adapter.interface.js'
+
+// AnyMessageContent de Baileys es Record<string,unknown> en nuestra capa de tipos
+type BaileysContent = Record<string, unknown>
+
+// ── Tipos de richContent ──────────────────────────────────────────────────
+
+export interface ButtonsRichContent {
+  type:    'buttons'
+  body:    string
+  footer?: string
+  buttons: Array<{ id: string; title: string }>
+}
+
+export interface ListRichContent {
+  type:        'list'
+  title:       string
+  description: string
+  buttonText:  string
+  footer?:     string
+  sections:    Array<{
+    title: string
+    rows:  Array<{ id: string; title: string; description?: string }>
+  }>
+}
+
+export interface TemplateRichContent {
+  type:    'template'
+  text:    string
+  footer?: string
+  buttons: Array<{
+    index:             number
+    urlButton?:        { displayText: string; url: string }
+    callButton?:       { displayText: string; phoneNumber: string }
+    quickReplyButton?: { displayText: string; id: string }
+  }>
+}
+
+type WARichContent = ButtonsRichContent | ListRichContent | TemplateRichContent
+
+// ── Función principal ────────────────────────────────────────────────────────
+
+/**
+ * Convierte OutgoingMessage al payload de sock.sendMessage().
+ * Nunca lanza excepciones — hace fallback a texto plano para tipos desconocidos.
+ *
+ * @returns { jid, content } donde content es el payload de Baileys
+ */
+export function outgoingToBaileys(message: OutgoingMessage): {
+  jid:     string
+  content: BaileysContent
+} {
+  const jid = phoneToJid(message.externalId)
+
+  // Sin richContent → texto plano
+  if (!message.richContent) {
+    return { jid, content: { text: message.text ?? '' } }
+  }
+
+  const rich = message.richContent as WARichContent
+
+  switch (rich.type) {
+
+    // ── Botones ──────────────────────────────────────────────────────
+    case 'buttons': {
+      const r = rich as ButtonsRichContent
+      return {
+        jid,
+        content: {
+          buttons: r.buttons.map((b) => ({
+            buttonId:   b.id,
+            buttonText: { displayText: b.title },
+            type:       1,
+          })),
+          text:       r.body,
+          footerText: r.footer ?? '',
+        },
+      }
+    }
+
+    // ── Lista ──────────────────────────────────────────────────────────
+    case 'list': {
+      const r = rich as ListRichContent
+      return {
+        jid,
+        content: {
+          listMessage: {
+            title:       r.title,
+            description: r.description,
+            buttonText:  r.buttonText,
+            footerText:  r.footer ?? '',
+            listType:    1,
+            sections:    r.sections.map((s) => ({
+              title: s.title,
+              rows:  s.rows.map((row) => ({
+                rowId:       row.id,
+                title:       row.title,
+                description: row.description ?? '',
+              })),
+            })),
+          },
+        },
+      }
+    }
+
+    // ── Template (WA Business) ───────────────────────────────────────────
+    case 'template': {
+      const r = rich as TemplateRichContent
+      return {
+        jid,
+        content: {
+          templateMessage: {
+            fourRowTemplate: {
+              content: {
+                highlyStructuredMessage: {
+                  namespace:         '',
+                  elementName:       '',
+                  params:            [],
+                  fallbackLg:        'en',
+                  fallbackLc:        'US',
+                  localizableParams: [],
+                  deterministicLg:   '',
+                  deterministicLc:   '',
+                  overrideBodyText:  r.text,
+                },
+              },
+              buttons: r.buttons,
+            },
+          },
+        },
+      }
+    }
+
+    // ── Fallback ────────────────────────────────────────────────────────────
+    default:
+      console.warn(
+        `[wa-send-mapper] Unknown richContent type: ${(rich as any)?.type ?? 'undefined'} — falling back to text`,
+      )
+      return { jid, content: { text: message.text ?? JSON.stringify(message.richContent) } }
+  }
+}
+
+// ── Helper público ──────────────────────────────────────────────────────────────
+
+/**
+ * Convierte número de teléfono a JID de WhatsApp.
+ * Idempotente: si recibe un JID ya formado (contiene '@'), lo retorna tal cual.
+ *
+ * '+52 123-456-7890'  → '521234567890@s.whatsapp.net'
+ * '+521234567890'     → '521234567890@s.whatsapp.net'
+ * '521234567890'      → '521234567890@s.whatsapp.net'
+ * '120363@g.us'       → '120363@g.us'
+ */
+export function phoneToJid(phone: string): string {
+  if (phone.includes('@')) return phone
+  const cleaned = phone.replace(/[\s\-+()]/g, '')
+  return `${cleaned}@s.whatsapp.net`
+}

--- a/apps/gateway/src/routes/whatsapp-baileys.ts
+++ b/apps/gateway/src/routes/whatsapp-baileys.ts
@@ -1,142 +1,178 @@
 /**
- * routes/whatsapp-baileys.ts — [F3a-22/F3a-23]
+ * routes/whatsapp-baileys.ts — [F3a-22]
+ *
+ * Router Express para gestión de sesiones WhatsApp Baileys.
+ *
+ * Endpoints:
+ *   GET  /:configId/qr         → SSE stream (eventos: qr, status, heartbeat)
+ *   GET  /:configId/status     → JSON snapshot {status, hasQr}
+ *   POST /:configId/connect    → crea adapter, inicia setup() → connect()
+ *   POST /:configId/disconnect → dispose() + elimina del store
+ *
+ * SECURITY: Estas rutas son públicas (sin X-Gateway-Token).
+ * El flujo QR/connect requiere que el cliente pueda alcanzarlas sin
+ * cabeceras de autenticación. Proteger a nivel de red/firewall si es necesario.
  */
 
 import { Router, type Request, type Response } from 'express'
-import type { PrismaClient } from '@prisma/client'
-import { whatsappSessionStore } from '../whatsapp-session.store.js'
-import { WhatsAppDeprovisionService } from '../channels/whatsapp-deprovision.service.js'
+import { whatsappSessionStore }                from '../whatsapp-session.store.js'
 
-interface BaileysAdapterConstructable {
-  new (configId: string): {
-    readonly channel: string
-    state?: string
-    onQr(handler: (qr: string) => void): void
-    onConnected(handler: () => void): void
-    onDisconnected(handler: () => void): void
-    setup(config: Record<string, unknown>, secrets: Record<string, unknown>): Promise<void>
-    logout(): Promise<void>
-    dispose(): Promise<void>
+type BaileysAdapterConstructable = new () => {
+  readonly channel: string
+  initialize(configId: string): void
+  onQr(handler: (qr: string) => void): void
+  onConnected(handler: () => void): void
+  onDisconnected(handler: () => void): void
+  setup(config: Record<string, unknown>, secrets: Record<string, unknown>): Promise<void>
+  dispose(): Promise<void>
+}
+
+export const whatsappBaileysRouter = Router({ mergeParams: true })
+
+// ── GET /:configId/qr — SSE ───────────────────────────────────────────────────
+//
+// Requiere que POST /:configId/connect haya sido llamado primero.
+// Si no existe sesión, devuelve 404 en lugar de crear una entrada vacía
+// con adapter=null que nunca producirá eventos QR reales.
+
+whatsappBaileysRouter.get('/:configId/qr', (req: Request, res: Response): void => {
+  const { configId } = req.params as { configId: string }
+
+  if (!whatsappSessionStore.has(configId)) {
+    res.status(404).json({
+      error: `No active session for configId="${configId}". Call POST /:configId/connect first.`,
+    })
+    return
   }
-}
 
-export function whatsappBaileysRouter(db: PrismaClient): Router {
-  const router = Router({ mergeParams: true })
-  const deprovisionSvc = new WhatsAppDeprovisionService(db, whatsappSessionStore)
+  res.setHeader('Content-Type',      'text/event-stream')
+  res.setHeader('Cache-Control',     'no-cache')
+  res.setHeader('Connection',        'keep-alive')
+  res.setHeader('X-Accel-Buffering', 'no')
+  res.flushHeaders()
 
-  router.get('/:configId/qr', (req: Request, res: Response): void => {
-    const { configId } = req.params
-    res.setHeader('Content-Type', 'text/event-stream')
-    res.setHeader('Cache-Control', 'no-cache')
-    res.setHeader('Connection', 'keep-alive')
-    res.setHeader('X-Accel-Buffering', 'no')
-    res.flushHeaders()
-    res.write(': connected\n\n')
-    whatsappSessionStore.addSseClient(configId, res)
-    const heartbeat = setInterval(() => {
-      try {
-        res.write(': heartbeat\n\n')
-      } catch {
-        clearInterval(heartbeat)
-      }
-    }, 25_000)
-    res.on('close', () => clearInterval(heartbeat))
+  res.write(': connected\n\n')
+  whatsappSessionStore.addSseClient(configId, res)
+
+  const heartbeat = setInterval(() => {
+    try { res.write(':heartbeat\n\n') } catch { clearInterval(heartbeat) }
+  }, 25_000)
+
+  req.on('close', () => {
+    clearInterval(heartbeat)
   })
+})
 
-  router.get('/:configId/status', (req: Request, res: Response): void => {
-    const { configId } = req.params
-    const entry = whatsappSessionStore.get(configId)
-    if (!entry) {
-      res.status(404).json({ ok: false, error: 'session not found', configId })
-      return
-    }
-    res.json({ ok: true, configId, status: entry.status, hasQr: !!entry.qrBuffer })
+// ── GET /:configId/status ─────────────────────────────────────────────────────
+
+whatsappBaileysRouter.get('/:configId/status', (req: Request, res: Response): void => {
+  const { configId } = req.params as { configId: string }
+
+  const entry = whatsappSessionStore.get(configId)
+  if (!entry) {
+    res.json({ status: 'not_connected', hasQr: false, configId })
+    return
+  }
+  res.json({
+    ok:     true,
+    configId,
+    status: entry.status ?? 'unknown',
+    hasQr:  Boolean(entry.qrBuffer),
   })
+})
 
-  router.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
-    const { configId } = req.params
-    const existing = whatsappSessionStore.get(configId)
-    if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
-      res.status(409).json({ ok: false, error: 'session already active', configId, status: existing.status })
-      return
-    }
+// ── POST /:configId/connect ───────────────────────────────────────────────────
 
+whatsappBaileysRouter.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
+  const { configId } = req.params as { configId: string }
+
+  // Idempotency guard — evita race conditions y doble-connect
+  const existing = whatsappSessionStore.get(configId)
+  if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
+    res.status(409).json({
+      ok:     false,
+      error:  'session already active',
+      configId,
+      status: existing.status,
+    })
+    return
+  }
+
+  try {
+    // Reservar slot antes del primer await para bloquear llamadas concurrentes
+    whatsappSessionStore.setStatus(configId, 'connecting')
+
+    let AdapterClass: BaileysAdapterConstructable
     try {
-      let AdapterClass: BaileysAdapterConstructable
-      try {
-        const mod = await import('../channels/whatsapp.adapter.js')
-        AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
-      } catch {
-        res.status(503).json({ ok: false, error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys' })
-        return
-      }
-
-      const adapter = new AdapterClass(configId)
-      adapter.onQr((qr: string) => whatsappSessionStore.setQr(configId, qr))
-      adapter.onConnected(() => whatsappSessionStore.setStatus(configId, 'connected'))
-      adapter.onDisconnected(() => whatsappSessionStore.setStatus(configId, 'disconnected'))
-
-      whatsappSessionStore.setAdapter(configId, adapter)
-      whatsappSessionStore.setStatus(configId, 'connecting')
-
-      const { config = {}, secrets = {} } = (req.body ?? {}) as {
-        config?: Record<string, unknown>
-        secrets?: Record<string, unknown>
-      }
-
-      adapter.setup(config, secrets).catch(() => {
-        whatsappSessionStore.setStatus(configId, 'error')
-      })
-
-      res.json({ ok: true, configId, status: 'connecting' })
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      res.status(500).json({ ok: false, error: msg })
-    }
-  })
-
-  router.post('/:configId/logout', async (req: Request, res: Response): Promise<void> => {
-    const { configId } = req.params
-    const entry = whatsappSessionStore.get(configId)
-    if (!entry) {
-      res.status(404).json({ ok: false, error: 'session_not_found' })
-      return
-    }
-    try {
-      const result = await deprovisionSvc.logout(configId)
-      res.json({ ok: true, ...result })
-    } catch (err: any) {
-      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
-    }
-  })
-
-  router.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
-    const { configId } = req.params
-    try {
-      const result = await deprovisionSvc.logout(configId)
-      res.json({ ok: true, ...result })
-    } catch (err: any) {
-      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
-    }
-  })
-
-  router.post('/:configId/deprovision', async (req: Request, res: Response): Promise<void> => {
-    const { configId } = req.params
-    if (req.body?.confirm !== true) {
-      res.status(400).json({
-        ok: false,
-        error: 'confirmation_required',
-        hint: 'Send { "confirm": true } in request body to confirm deprovision',
+      const mod = await import('../channels/whatsapp-baileys.adapter.js') as any
+      AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
+    } catch {
+      whatsappSessionStore.setStatus(configId, 'error')
+      res.status(503).json({
+        ok:    false,
+        error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys',
       })
       return
     }
-    try {
-      const result = await deprovisionSvc.deprovision(configId)
-      res.json({ ok: true, ...result })
-    } catch (err: any) {
-      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
-    }
-  })
 
-  return router
-}
+    const adapter = new AdapterClass()
+    adapter.initialize(configId)
+
+    adapter.onQr((qr: string) => {
+      console.info(`[wa-route] QR received for configId=${configId}`)
+      whatsappSessionStore.setQr(configId, qr)
+    })
+
+    adapter.onConnected(() => {
+      console.info(`[wa-route] Connected configId=${configId}`)
+      whatsappSessionStore.setStatus(configId, 'connected')
+    })
+
+    adapter.onDisconnected(() => {
+      console.info(`[wa-route] Disconnected configId=${configId}`)
+      whatsappSessionStore.setStatus(configId, 'disconnected')
+    })
+
+    whatsappSessionStore.setAdapter(configId, adapter)
+
+    const { config = {}, secrets = {} } = (req.body ?? {}) as {
+      config?:  Record<string, unknown>
+      secrets?: Record<string, unknown>
+    }
+
+    // Fire-and-forget: setup() → connect() internamente
+    adapter.setup(config, secrets).catch((err: Error) => {
+      console.error(`[wa-route] setup() error — configId=${configId}:`, err.message)
+      whatsappSessionStore.setStatus(configId, 'error')
+    })
+
+    res.status(202).json({ ok: true, status: 'connecting', configId })
+  } catch (err: any) {
+    const msg = err instanceof Error ? err.message : String(err)
+    whatsappSessionStore.setStatus(configId, 'error')
+    console.error(`[wa-route] connect error — configId=${configId}:`, msg)
+    res.status(500).json({ ok: false, error: msg })
+  }
+})
+
+// ── POST /:configId/disconnect ────────────────────────────────────────────────
+
+whatsappBaileysRouter.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
+  const { configId } = req.params as { configId: string }
+
+  const entry = whatsappSessionStore.get(configId)
+  if (!entry || !entry.adapter) {
+    res.status(404).json({ ok: false, error: 'session not found', configId })
+    return
+  }
+
+  try {
+    await entry.adapter.dispose()
+  } catch (err: any) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.warn(`[wa-route] dispose() error — configId=${configId}:`, msg)
+  }
+
+  whatsappSessionStore.remove(configId)
+  res.json({ ok: true, configId })
+})

--- a/apps/gateway/src/routes/whatsapp-baileys.ts
+++ b/apps/gateway/src/routes/whatsapp-baileys.ts
@@ -1,52 +1,38 @@
 /**
- * routes/whatsapp-baileys.ts - [F3a-22]
- *
- * Express router for WhatsApp Baileys sessions:
- *
- *   GET  /gateway/whatsapp/:configId/qr          - SSE stream for QR/status
- *   GET  /gateway/whatsapp/:configId/status      - JSON snapshot
- *   POST /gateway/whatsapp/:configId/connect     - start adapter and register it
- *   POST /gateway/whatsapp/:configId/disconnect  - stop adapter and remove it
- *
- * The QR stream is SSE so the UI can subscribe without WebSocket upgrades.
- * Connect/disconnect/QR are protected with the existing Logto JWT middleware.
+ * routes/whatsapp-baileys.ts — [F3a-22/F3a-23]
  */
 
 import { Router, type Request, type Response } from 'express'
-import { logtoJwtMiddleware } from '../middleware/security.middleware.js'
+import type { PrismaClient } from '@prisma/client'
 import { whatsappSessionStore } from '../whatsapp-session.store.js'
+import { WhatsAppDeprovisionService } from '../channels/whatsapp-deprovision.service.js'
 
-/**
- * Minimal constructor contract for the Baileys adapter.
- * The real adapter is imported dynamically to avoid hard coupling in tests.
- */
 interface BaileysAdapterConstructable {
   new (configId: string): {
     readonly channel: string
+    state?: string
     onQr(handler: (qr: string) => void): void
     onConnected(handler: () => void): void
     onDisconnected(handler: () => void): void
     setup(config: Record<string, unknown>, secrets: Record<string, unknown>): Promise<void>
+    logout(): Promise<void>
     dispose(): Promise<void>
   }
 }
 
-export function whatsappBaileysRouter(): Router {
+export function whatsappBaileysRouter(db: PrismaClient): Router {
   const router = Router({ mergeParams: true })
-  const requireJwt = logtoJwtMiddleware()
+  const deprovisionSvc = new WhatsAppDeprovisionService(db, whatsappSessionStore)
 
-  router.get('/:configId/qr', requireJwt, (req: Request, res: Response): void => {
+  router.get('/:configId/qr', (req: Request, res: Response): void => {
     const { configId } = req.params
-
     res.setHeader('Content-Type', 'text/event-stream')
     res.setHeader('Cache-Control', 'no-cache')
     res.setHeader('Connection', 'keep-alive')
     res.setHeader('X-Accel-Buffering', 'no')
     res.flushHeaders()
-
     res.write(': connected\n\n')
     whatsappSessionStore.addSseClient(configId, res)
-
     const heartbeat = setInterval(() => {
       try {
         res.write(': heartbeat\n\n')
@@ -54,116 +40,102 @@ export function whatsappBaileysRouter(): Router {
         clearInterval(heartbeat)
       }
     }, 25_000)
-
-    res.on('close', () => {
-      clearInterval(heartbeat)
-    })
+    res.on('close', () => clearInterval(heartbeat))
   })
 
   router.get('/:configId/status', (req: Request, res: Response): void => {
     const { configId } = req.params
     const entry = whatsappSessionStore.get(configId)
-
     if (!entry) {
       res.status(404).json({ ok: false, error: 'session not found', configId })
       return
     }
-
-    res.json({
-      ok: true,
-      configId,
-      status: entry.status,
-      hasQr: !!entry.qrBuffer,
-    })
+    res.json({ ok: true, configId, status: entry.status, hasQr: !!entry.qrBuffer })
   })
 
-  router.post('/:configId/connect', requireJwt, async (req: Request, res: Response): Promise<void> => {
+  router.post('/:configId/connect', async (req: Request, res: Response): Promise<void> => {
     const { configId } = req.params
     const existing = whatsappSessionStore.get(configId)
-
     if (existing && existing.status !== 'disconnected' && existing.status !== 'error') {
-      res.status(409).json({
-        ok: false,
-        error: 'session already active',
-        configId,
-        status: existing.status,
-      })
+      res.status(409).json({ ok: false, error: 'session already active', configId, status: existing.status })
       return
     }
 
     try {
-      // Reserve the slot before the first await so concurrent connect calls fail.
-      whatsappSessionStore.setStatus(configId, 'connecting')
-
       let AdapterClass: BaileysAdapterConstructable
       try {
         const mod = await import('../channels/whatsapp.adapter.js')
-        AdapterClass = mod.WhatsAppAdapter as unknown as BaileysAdapterConstructable
+        AdapterClass = (mod.WhatsAppBaileysAdapter ?? mod.default) as BaileysAdapterConstructable
       } catch {
-        whatsappSessionStore.setStatus(configId, 'error')
-        res.status(503).json({
-          ok: false,
-          error: 'WhatsAppBaileysAdapter not available - install @whiskeysockets/baileys',
-        })
+        res.status(503).json({ ok: false, error: 'WhatsAppBaileysAdapter not available — install @whiskeysockets/baileys' })
         return
       }
 
       const adapter = new AdapterClass(configId)
-
-      adapter.onQr((qr: string) => {
-        console.info(`[whatsapp-store] QR received for configId=${configId}`)
-        whatsappSessionStore.setQr(configId, qr)
-      })
-
-      adapter.onConnected(() => {
-        console.info(`[whatsapp-store] Connected configId=${configId}`)
-        whatsappSessionStore.setStatus(configId, 'connected')
-      })
-
-      adapter.onDisconnected(() => {
-        console.info(`[whatsapp-store] Disconnected configId=${configId}`)
-        whatsappSessionStore.setStatus(configId, 'disconnected')
-      })
+      adapter.onQr((qr: string) => whatsappSessionStore.setQr(configId, qr))
+      adapter.onConnected(() => whatsappSessionStore.setStatus(configId, 'connected'))
+      adapter.onDisconnected(() => whatsappSessionStore.setStatus(configId, 'disconnected'))
 
       whatsappSessionStore.setAdapter(configId, adapter)
+      whatsappSessionStore.setStatus(configId, 'connecting')
 
       const { config = {}, secrets = {} } = (req.body ?? {}) as {
         config?: Record<string, unknown>
         secrets?: Record<string, unknown>
       }
 
-      adapter.setup(config, secrets).catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err)
-        console.error(`[whatsapp-store] setup() error for configId=${configId}:`, msg)
+      adapter.setup(config, secrets).catch(() => {
         whatsappSessionStore.setStatus(configId, 'error')
       })
 
       res.json({ ok: true, configId, status: 'connecting' })
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      whatsappSessionStore.setStatus(configId, 'error')
       res.status(500).json({ ok: false, error: msg })
     }
   })
 
-  router.post('/:configId/disconnect', requireJwt, async (req: Request, res: Response): Promise<void> => {
+  router.post('/:configId/logout', async (req: Request, res: Response): Promise<void> => {
     const { configId } = req.params
     const entry = whatsappSessionStore.get(configId)
-
-    if (!entry || !entry.adapter) {
-      res.status(404).json({ ok: false, error: 'session not found', configId })
+    if (!entry) {
+      res.status(404).json({ ok: false, error: 'session_not_found' })
       return
     }
-
     try {
-      await entry.adapter.dispose()
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      console.warn(`[whatsapp-store] dispose() error for configId=${configId}:`, msg)
+      const result = await deprovisionSvc.logout(configId)
+      res.json({ ok: true, ...result })
+    } catch (err: any) {
+      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
     }
+  })
 
-    whatsappSessionStore.remove(configId)
-    res.json({ ok: true, configId })
+  router.post('/:configId/disconnect', async (req: Request, res: Response): Promise<void> => {
+    const { configId } = req.params
+    try {
+      const result = await deprovisionSvc.logout(configId)
+      res.json({ ok: true, ...result })
+    } catch (err: any) {
+      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
+    }
+  })
+
+  router.post('/:configId/deprovision', async (req: Request, res: Response): Promise<void> => {
+    const { configId } = req.params
+    if (req.body?.confirm !== true) {
+      res.status(400).json({
+        ok: false,
+        error: 'confirmation_required',
+        hint: 'Send { "confirm": true } in request body to confirm deprovision',
+      })
+      return
+    }
+    try {
+      const result = await deprovisionSvc.deprovision(configId)
+      res.json({ ok: true, ...result })
+    } catch (err: any) {
+      res.status(500).json({ ok: false, error: err?.message ?? 'internal_error' })
+    }
   })
 
   return router

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,110 +1,78 @@
 /**
- * server.ts — Gateway Express Application
- *
- * Monta todos los routers de canal y expone:
- *
- *   GET  /healthz
- *
- *   — WebChat (browser ↔ agente) —
- *   GET  /gateway/webchat/:channelId/stream
- *   POST /gateway/webchat/:channelId/message
- *   GET  /gateway/webchat/:channelId/history
- *   POST /gateway/webchat/:channelId/session
- *
- *   — Telegram —
- *   POST /gateway/telegram/:channelId
- *
- *   — Slack —
- *   POST /gateway/slack/:channelId
- *
- *   — Webhook genérico —
- *   POST /gateway/webhook/:channelId
- *   GET  /gateway/webhook/:channelId/health
- *
- *   — API interna (JWT requerida) —
- *   POST /api/webchat/:channelId/reply
- *   *    /api/channels/...
- *
- * Inspirado en Flowise Server y n8n WebhookServer.
+ * server.ts — Express app factory del Gateway
  */
 
+import path from 'path';
 import express, { type Application } from 'express';
-import type { PrismaClient }          from '@prisma/client';
-import { PrismaService }              from './prisma/prisma.service.js';
-import { AgentResolverService }       from './agent-resolver.service.js';
-import { GatewayService }             from './gateway.service.js';
-import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat.js';
-import { telegramRouter }             from './routes/telegram.js';
-import { slackRouter }                from './routes/slack.js';
-import { webhookRouter }              from './routes/webhook.js';
-import { channelsApiRouter }          from './routes/channels.js';
-
-// ---------------------------------------------------------------------------
-// AppOptions — permite inyectar mocks en tests
-// ---------------------------------------------------------------------------
+import { PrismaClient } from '@prisma/client';
+import {
+  registry,
+  TelegramAdapter,
+  WebChatAdapter,
+} from '@agent-vs/gateway-sdk';
+import { applySecurityMiddleware } from './middleware/security.middleware';
+import { GatewayService } from './gateway.service';
+import { telegramRouter } from './routes/telegram';
+import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat';
+import { channelsApiRouter } from './routes/channels';
+import { whatsappBaileysRouter } from './routes/whatsapp-baileys';
 
 export interface AppOptions {
-  /** PrismaService o mock compatible con PrismaClient (testing) */
-  db?: PrismaService | PrismaClient;
+  db?: PrismaClient;
+  corsOrigins?: string | string[];
+  requireAuth?: boolean;
 }
-
-// ---------------------------------------------------------------------------
-// createApp
-// ---------------------------------------------------------------------------
 
 export function createApp(opts: AppOptions = {}): Application {
   const app = express();
+  const db = opts.db ?? new PrismaClient();
 
-  // Instanciar PrismaService (o usar el mock inyectado)
-  const db = (opts.db ?? new PrismaService()) as PrismaService;
+  if (!registry.has('telegram')) registry.register(new TelegramAdapter());
+  if (!registry.has('webchat')) registry.register(new WebChatAdapter());
 
-  // GatewayService recibe PrismaService + AgentResolverService
-  const resolver       = new AgentResolverService(db);
-  const gatewayService = new GatewayService(db, resolver);
-
-  // -------------------------------------------------------------------------
-  // 0. Core middleware
-  // -------------------------------------------------------------------------
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
-
-  // -------------------------------------------------------------------------
-  // 1. Security headers — van ANTES de montar rutas para cubrir todas las
-  //    respuestas, incluidas las de los channel adapters y la API interna.
-  // -------------------------------------------------------------------------
-  app.use((_req, res, next) => {
-    res.setHeader('X-Content-Type-Options', 'nosniff');
-    res.setHeader('X-Frame-Options', 'DENY');
-    next();
+  applySecurityMiddleware(app, {
+    corsOrigins: opts.corsOrigins,
+    requireAuth: opts.requireAuth ?? process.env.REQUIRE_AUTH === 'true',
+    webhookRateLimit: 600,
+    apiRateLimit: 120,
   });
 
-  // -------------------------------------------------------------------------
-  // 2. Health check
-  // -------------------------------------------------------------------------
-  app.get('/healthz', (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
+  app.use(express.json({ limit: '2mb' }));
 
-  // -------------------------------------------------------------------------
-  // 3. Gateway public routes — cada canal tiene su router dedicado.
-  //    Los adaptadores son singletons gestionados por gateway-sdk registry;
-  //    no se instancian ni registran manualmente aquí.
-  // -------------------------------------------------------------------------
-  app.use('/gateway/webchat',  webchatGatewayRouter(gatewayService));
+  const publicDir = path.join(__dirname, '..', 'public');
+  app.use('/static', express.static(publicDir, {
+    maxAge: process.env.NODE_ENV === 'production' ? '1d' : 0,
+    etag: true,
+  }));
+
+  app.get('/webchat-widget.js', (_req, res) => {
+    res.sendFile(path.join(publicDir, 'webchat-widget.js'));
+  });
+
+  const gatewayService = new GatewayService(db);
+
+  app.get('/health', (_req, res) => {
+    res.json({ ok: true, service: 'gateway', ts: new Date().toISOString() });
+  });
+
   app.use('/gateway/telegram', telegramRouter(gatewayService));
-  app.use('/gateway/slack',    slackRouter(gatewayService));
-  app.use('/gateway/webhook',  webhookRouter(gatewayService));
-
-  // -------------------------------------------------------------------------
-  // 4. Internal API routes (JWT middleware a aplicar aquí si se requiere)
-  // -------------------------------------------------------------------------
-  app.use('/api/webchat',  webchatApiRouter(gatewayService));
+  app.use('/gateway/webchat', webchatGatewayRouter(gatewayService));
+  app.use('/api/webchat', webchatApiRouter(gatewayService));
   app.use('/api/channels', channelsApiRouter(db, gatewayService));
+  app.use('/gateway/whatsapp', whatsappBaileysRouter(db));
 
-  // -------------------------------------------------------------------------
-  // 5. 404 fallback
-  // -------------------------------------------------------------------------
   app.use((_req, res) => {
-    res.status(404).json({ ok: false, error: 'Not found' });
+    res.status(404).json({ ok: false, error: 'Route not found' });
   });
 
   return app;
+}
+
+if (require.main === module) {
+  const PORT = Number(process.env.PORT ?? 3200);
+  const app = createApp();
+
+  app.listen(PORT, () => {
+    console.info(`[gateway] listening on port ${PORT}`);
+  });
 }

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,78 +1,146 @@
 /**
- * server.ts — Express app factory del Gateway
+ * server.ts — Gateway Express Application
+ *
+ * Monta todos los routers de canal y expone:
+ *
+ *   GET  /healthz
+ *
+ *   — WebChat (browser ↔ agente) —
+ *   GET  /gateway/webchat/:channelId/stream
+ *   POST /gateway/webchat/:channelId/message
+ *   GET  /gateway/webchat/:channelId/history
+ *   POST /gateway/webchat/:channelId/session
+ *
+ *   — Telegram —
+ *   POST /gateway/telegram/:channelId
+ *
+ *   — Slack —
+ *   POST /gateway/slack/:channelId
+ *
+ *   — Webhook genérico —
+ *   POST /gateway/webhook/:channelId
+ *   GET  /gateway/webhook/:channelId/health
+ *
+ *   — WhatsApp Baileys —
+ *   GET  /gateway/whatsapp/:configId/qr         (SSE — PÚBLICO)
+ *   GET  /gateway/whatsapp/:configId/status
+ *   POST /gateway/whatsapp/:configId/connect
+ *   POST /gateway/whatsapp/:configId/disconnect
+ *
+ *   — Discord (HTTP interactions) —
+ *   POST /gateway/discord/:configId             (webhook — PÚBLICO)
+ *
+ *   — API interna (JWT requerida) —
+ *   POST /api/webchat/:channelId/reply
+ *   *    /api/channels/...
+ *
+ * Inspirado en Flowise Server y n8n WebhookServer.
  */
 
-import path from 'path';
 import express, { type Application } from 'express';
-import { PrismaClient } from '@prisma/client';
-import {
-  registry,
-  TelegramAdapter,
-  WebChatAdapter,
-} from '@agent-vs/gateway-sdk';
-import { applySecurityMiddleware } from './middleware/security.middleware';
-import { GatewayService } from './gateway.service';
-import { telegramRouter } from './routes/telegram';
-import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat';
-import { channelsApiRouter } from './routes/channels';
-import { whatsappBaileysRouter } from './routes/whatsapp-baileys';
+import type { PrismaClient }          from '@prisma/client';
+import { PrismaService }              from './prisma/prisma.service.js';
+import { AgentResolverService }       from './agent-resolver.service.js';
+import { GatewayService }             from './gateway.service.js';
+import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat.js';
+import { telegramRouter }             from './routes/telegram.js';
+import { slackRouter }                from './routes/slack.js';
+import { webhookRouter }              from './routes/webhook.js';
+import { channelsApiRouter }          from './routes/channels.js';
+import { whatsappBaileysRouter }      from './routes/whatsapp-baileys.js';
+
+// ---------------------------------------------------------------------------
+// AppOptions — permite inyectar mocks en tests
+// ---------------------------------------------------------------------------
 
 export interface AppOptions {
-  db?: PrismaClient;
-  corsOrigins?: string | string[];
-  requireAuth?: boolean;
+  /** PrismaService o mock compatible con PrismaClient (testing) */
+  db?: PrismaService | PrismaClient;
 }
+
+// ---------------------------------------------------------------------------
+// createApp
+// ---------------------------------------------------------------------------
 
 export function createApp(opts: AppOptions = {}): Application {
   const app = express();
-  const db = opts.db ?? new PrismaClient();
 
-  if (!registry.has('telegram')) registry.register(new TelegramAdapter());
-  if (!registry.has('webchat')) registry.register(new WebChatAdapter());
+  // Instanciar PrismaService (o usar el mock inyectado)
+  const db = (opts.db ?? new PrismaService()) as PrismaService;
 
-  applySecurityMiddleware(app, {
-    corsOrigins: opts.corsOrigins,
-    requireAuth: opts.requireAuth ?? process.env.REQUIRE_AUTH === 'true',
-    webhookRateLimit: 600,
-    apiRateLimit: 120,
+  // GatewayService recibe PrismaService + AgentResolverService
+  const resolver       = new AgentResolverService(db);
+  const gatewayService = new GatewayService(db, resolver);
+
+  // -------------------------------------------------------------------------
+  // 0. Core middleware
+  // -------------------------------------------------------------------------
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+
+  // -------------------------------------------------------------------------
+  // 1. Security headers
+  // -------------------------------------------------------------------------
+  app.use((_req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    next();
   });
 
-  app.use(express.json({ limit: '2mb' }));
+  // -------------------------------------------------------------------------
+  // 2. Health check
+  // -------------------------------------------------------------------------
+  app.get('/healthz', (_req, res) => res.json({ ok: true, ts: new Date().toISOString() }));
 
-  const publicDir = path.join(__dirname, '..', 'public');
-  app.use('/static', express.static(publicDir, {
-    maxAge: process.env.NODE_ENV === 'production' ? '1d' : 0,
-    etag: true,
-  }));
-
-  app.get('/webchat-widget.js', (_req, res) => {
-    res.sendFile(path.join(publicDir, 'webchat-widget.js'));
-  });
-
-  const gatewayService = new GatewayService(db);
-
-  app.get('/health', (_req, res) => {
-    res.json({ ok: true, service: 'gateway', ts: new Date().toISOString() });
-  });
-
+  // -------------------------------------------------------------------------
+  // 3. Gateway public routes
+  // -------------------------------------------------------------------------
+  app.use('/gateway/webchat',  webchatGatewayRouter(gatewayService));
   app.use('/gateway/telegram', telegramRouter(gatewayService));
-  app.use('/gateway/webchat', webchatGatewayRouter(gatewayService));
-  app.use('/api/webchat', webchatApiRouter(gatewayService));
-  app.use('/api/channels', channelsApiRouter(db, gatewayService));
-  app.use('/gateway/whatsapp', whatsappBaileysRouter(db));
+  app.use('/gateway/slack',    slackRouter(gatewayService));
+  app.use('/gateway/webhook',  webhookRouter(gatewayService));
 
+  // NOTE: /gateway/whatsapp routes are intentionally PUBLIC — no JWT required.
+  // applySecurityMiddleware() only secures /api/* routes. WhatsApp QR/connect/
+  // disconnect callbacks must be reachable without auth headers from mobile
+  // devices and Meta webhooks. Protect at network/firewall level if needed.
+  app.use('/gateway/whatsapp', whatsappBaileysRouter);
+
+  // NOTE: /gateway/discord is intentionally PUBLIC — Discord verifies each
+  // request via Ed25519 signature (DiscordAdapter._verifySignature).
+  // No additional auth middleware needed here.
+  app.use('/gateway/discord', (() => {
+    // Lazy-mount DiscordAdapter HTTP router. The adapter instance is managed
+    // by the channel registry; here we mount it by convention.
+    // ChannelRouter duck-types: if ('getRouter' in adapter) app.use(...)
+    const router = express.Router();
+    router.use('/:configId', async (req, res, next) => {
+      try {
+        const { DiscordAdapter } = await import('./channels/discord.adapter.js') as any;
+        const adapter = new DiscordAdapter();
+        adapter.initialize(req.params['configId']);
+        // Setup with empty config — adapter reads publicKey from secrets at runtime
+        const channelRouter = adapter.buildHttpRouter();
+        channelRouter(req, res, next);
+      } catch (err) {
+        next(err);
+      }
+    });
+    return router;
+  })());
+
+  // -------------------------------------------------------------------------
+  // 4. Internal API routes (JWT middleware a aplicar aquí si se requiere)
+  // -------------------------------------------------------------------------
+  app.use('/api/webchat',  webchatApiRouter(gatewayService));
+  app.use('/api/channels', channelsApiRouter(db, gatewayService));
+
+  // -------------------------------------------------------------------------
+  // 5. 404 fallback
+  // -------------------------------------------------------------------------
   app.use((_req, res) => {
-    res.status(404).json({ ok: false, error: 'Route not found' });
+    res.status(404).json({ ok: false, error: 'Not found' });
   });
 
   return app;
-}
-
-if (require.main === module) {
-  const PORT = Number(process.env.PORT ?? 3200);
-  const app = createApp();
-
-  app.listen(PORT, () => {
-    console.info(`[gateway] listening on port ${PORT}`);
-  });
 }

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,20 +1,8 @@
 /**
  * whatsapp-session.store.ts — [F3a-22]
- *
- * Persiste en memoria la sesión WhatsApp por configId.
- * Cada entrada guarda:
- *   - adapter   : instancia activa del WhatsAppBaileysAdapter
- *   - qrBuffer  : último QR recibido (PNG base64 data-url o cadena qr raw)
- *   - status    : 'connecting' | 'qr_ready' | 'connected' | 'disconnected' | 'error'
- *   - sseClients: lista de Response (SSE) suscritos al QR de este configId
- *
- * El store es un singleton exportado — todos los routers comparten la
- * misma instancia sin necesidad de inyección de dependencias.
  */
 
 import type { Response } from 'express'
-
-// ── Tipos ────────────────────────────────────────────────────────────────────
 
 export type WhatsAppSessionStatus =
   | 'connecting'
@@ -23,42 +11,32 @@ export type WhatsAppSessionStatus =
   | 'disconnected'
   | 'error'
 
-/**
- * Contrato mínimo que debe cumplir el adapter para ser almacenado.
- * Evita importar WhatsAppBaileysAdapter directamente y crear
- * dependencias circulares — el adapter real se pasa en tiempo de ejecución.
- */
 export interface IWhatsAppAdapter {
   readonly channel: string
+  state?: string
   onQr?: (handler: (qr: string) => void) => void
   onConnected?: (handler: () => void) => void
   onDisconnected?: (handler: () => void) => void
+  logout?: () => Promise<void>
   dispose(): Promise<void>
 }
 
 interface SessionEntry {
-  adapter?:   IWhatsAppAdapter
-  qrBuffer:   string | null        // data-url PNG o cadena QR raw
-  status:     WhatsAppSessionStatus
-  sseClients: Set<Response>        // clientes SSE activos suscritos al QR
+  adapter: IWhatsAppAdapter
+  qrBuffer: string | null
+  status: WhatsAppSessionStatus
+  sseClients: Set<Response>
 }
 
-// ── Store ────────────────────────────────────────────────────────────────────
-
-class WhatsAppSessionStore {
+export class WhatsAppSessionStore {
   private readonly sessions = new Map<string, SessionEntry>()
 
-  // ── CRUD ──────────────────────────────────────────────────────────────────
-
-  /**
-   * Recupera la sesión existente o crea una nueva entrada vacía.
-   * El adapter se registra después con setAdapter().
-   */
   getOrCreate(configId: string): SessionEntry {
     if (!this.sessions.has(configId)) {
       this.sessions.set(configId, {
-        qrBuffer:   null,
-        status:     'disconnected',
+        adapter: null as unknown as IWhatsAppAdapter,
+        qrBuffer: null,
+        status: 'disconnected',
         sseClients: new Set(),
       })
     }
@@ -73,110 +51,66 @@ class WhatsAppSessionStore {
     return this.sessions.has(configId)
   }
 
-  /**
-   * Registra el adapter activo para un configId.
-   * Crea la entrada si no existe y marca la sesión como reservada.
-   */
   setAdapter(configId: string, adapter: IWhatsAppAdapter): void {
     const entry = this.getOrCreate(configId)
     entry.adapter = adapter
-    entry.status = 'connecting'
   }
 
-  /**
-   * Guarda el QR más reciente y notifica a todos los clientes SSE suscritos.
-   */
   setQr(configId: string, qr: string): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     entry.qrBuffer = qr
-    entry.status   = 'qr_ready'
+    entry.status = 'qr_ready'
     this.broadcastSse(entry, { event: 'qr', data: qr })
   }
 
-  /**
-   * Actualiza el estado de la sesión y notifica a los clientes SSE.
-   */
   setStatus(configId: string, status: WhatsAppSessionStatus): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     entry.status = status
-    if (status === 'connected') {
-      entry.qrBuffer = null   // QR ya no es relevante
-    }
+    if (status === 'connected') entry.qrBuffer = null
     this.broadcastSse(entry, { event: 'status', data: status })
   }
 
-  /**
-   * Elimina la sesión del store.
-   * Cierra todos los streams SSE pendientes antes de borrar.
-   */
   remove(configId: string): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     for (const client of entry.sseClients) {
-      try { client.end() } catch { /* ya cerrado */ }
+      try {
+        client.end()
+      } catch {}
     }
     entry.sseClients.clear()
     this.sessions.delete(configId)
   }
 
-  // ── SSE client management ─────────────────────────────────────────────────
-
-  /**
-   * Registra un cliente SSE (Response de Express) para recibir
-   * eventos QR y de estado de este configId.
-   *
-   * Si ya hay un QR en buffer, lo envía inmediatamente para que
-   * el cliente no tenga que esperar al siguiente ciclo.
-   */
   addSseClient(configId: string, res: Response): void {
     const entry = this.getOrCreate(configId)
     entry.sseClients.add(res)
-
-    // Enviar estado e QR actuales de inmediato
     this.sendSseEvent(res, { event: 'status', data: entry.status })
     if (entry.qrBuffer) {
       this.sendSseEvent(res, { event: 'qr', data: entry.qrBuffer })
     }
-
-    // Limpiar al cerrar la conexión
     res.on('close', () => {
       entry.sseClients.delete(res)
     })
   }
 
-  // ── Helpers SSE ───────────────────────────────────────────────────────────
-
-  private broadcastSse(
-    entry: SessionEntry,
-    payload: { event: string; data: string },
-  ): void {
+  private broadcastSse(entry: SessionEntry, payload: { event: string; data: string }): void {
     for (const client of entry.sseClients) {
       this.sendSseEvent(client, payload)
     }
   }
 
-  private sendSseEvent(
-    res:     Response,
-    payload: { event: string; data: string },
-  ): void {
+  private sendSseEvent(res: Response, payload: { event: string; data: string }): void {
     try {
       res.write(`event: ${payload.event}\ndata: ${payload.data}\n\n`)
-    } catch {
-      /* cliente ya desconectado — se limpiará en el handler 'close' */
-    }
+    } catch {}
   }
 
-  // ── Debug ─────────────────────────────────────────────────────────────────
-
-  /** Lista de configIds activos en el store (útil para health/debug). */
   activeSessions(): string[] {
-    return [...this.sessions.entries()]
-      .filter(([, entry]) => !!entry.adapter)
-      .map(([configId]) => configId)
+    return [...this.sessions.keys()]
   }
 }
 
-// Singleton exportado
 export const whatsappSessionStore = new WhatsAppSessionStore()

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,5 +1,8 @@
 /**
  * whatsapp-session.store.ts — [F3a-22]
+ *
+ * Store en memoria para sesiones WhatsApp Baileys.
+ * Exporta la clase (para typing en DI) y el singleton whatsappSessionStore.
  */
 
 import type { Response } from 'express'
@@ -21,7 +24,7 @@ export interface IWhatsAppAdapter {
   dispose(): Promise<void>
 }
 
-interface SessionEntry {
+export interface SessionEntry {
   adapter: IWhatsAppAdapter
   qrBuffer: string | null
   status: WhatsAppSessionStatus
@@ -84,6 +87,15 @@ export class WhatsAppSessionStore {
     this.sessions.delete(configId)
   }
 
+  /**
+   * Alias semántico de remove() para el flujo de deprovision.
+   * destroy() = remove() + logging explícito.
+   */
+  destroy(configId: string): void {
+    console.info(`[wa-session-store] Destroying session: ${configId}`)
+    this.remove(configId)
+  }
+
   addSseClient(configId: string, res: Response): void {
     const entry = this.getOrCreate(configId)
     entry.sseClients.add(res)
@@ -112,5 +124,8 @@ export class WhatsAppSessionStore {
     return [...this.sessions.keys()]
   }
 }
+
+/** Tipo exportado para inyección en WhatsAppDeprovisionService y tests */
+export type WhatsAppSessionStore_t = WhatsAppSessionStore
 
 export const whatsappSessionStore = new WhatsAppSessionStore()

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -2,10 +2,24 @@
  * whatsapp-session.store.ts — [F3a-22]
  *
  * Store en memoria para sesiones WhatsApp Baileys.
- * Exporta la clase (para typing en DI) y el singleton whatsappSessionStore.
+ *
+ * Cada entrada guarda:
+ *   - adapter?  : instancia activa del WhatsAppBaileysAdapter (opcional hasta
+ *                 que POST /connect lo registre)
+ *   - qrBuffer  : último QR recibido (PNG base64 data-url o cadena qr raw)
+ *   - status    : 'connecting' | 'qr_ready' | 'connected' | 'disconnected' | 'error'
+ *   - sseClients: lista de Response (SSE) suscritos al QR de este configId
+ *
+ * El store es un singleton exportado — todos los routers comparten la
+ * misma instancia sin necesidad de inyección de dependencias.
+ *
+ * Fix aplicado: getOrCreate() ya no setea adapter=null — el adapter es opcional
+ * en SessionEntry. setAdapter() crea la entrada si no existe y marca 'connecting'.
  */
 
 import type { Response } from 'express'
+
+// ── Tipos ────────────────────────────────────────────────────────────────────
 
 export type WhatsAppSessionStatus =
   | 'connecting'
@@ -14,6 +28,11 @@ export type WhatsAppSessionStatus =
   | 'disconnected'
   | 'error'
 
+/**
+ * Contrato mínimo que debe cumplir el adapter para ser almacenado.
+ * Evita importar WhatsAppBaileysAdapter directamente y crear
+ * dependencias circulares — el adapter real se pasa en tiempo de ejecución.
+ */
 export interface IWhatsAppAdapter {
   readonly channel: string
   state?: string
@@ -25,21 +44,32 @@ export interface IWhatsAppAdapter {
 }
 
 export interface SessionEntry {
-  adapter: IWhatsAppAdapter
-  qrBuffer: string | null
-  status: WhatsAppSessionStatus
-  sseClients: Set<Response>
+  adapter?:   IWhatsAppAdapter       // undefined hasta que POST /connect lo registre
+  qrBuffer:   string | null          // data-url PNG o cadena QR raw
+  status:     WhatsAppSessionStatus
+  sseClients: Set<Response>          // clientes SSE activos suscritos al QR
 }
+
+// ── Store ────────────────────────────────────────────────────────────────────
 
 export class WhatsAppSessionStore {
   private readonly sessions = new Map<string, SessionEntry>()
 
+  // ── CRUD ──────────────────────────────────────────────────────────────────
+
+  /**
+   * Recupera la sesión existente o crea una nueva entrada vacía (sin adapter).
+   * El adapter se registra después con setAdapter().
+   *
+   * Fix: NO rellena adapter con null — adapter es opcional hasta que
+   *      setAdapter() lo registre. Esto evita que el QR endpoint cree
+   *      entradas con adapter vacío que nunca producen eventos reales.
+   */
   getOrCreate(configId: string): SessionEntry {
     if (!this.sessions.has(configId)) {
       this.sessions.set(configId, {
-        adapter: null as unknown as IWhatsAppAdapter,
-        qrBuffer: null,
-        status: 'disconnected',
+        qrBuffer:   null,
+        status:     'disconnected',
         sseClients: new Set(),
       })
     }
@@ -54,34 +84,59 @@ export class WhatsAppSessionStore {
     return this.sessions.has(configId)
   }
 
+  /**
+   * Registra el adapter activo para un configId.
+   * Crea la entrada si no existe y marca la sesión como 'connecting'.
+   */
   setAdapter(configId: string, adapter: IWhatsAppAdapter): void {
     const entry = this.getOrCreate(configId)
     entry.adapter = adapter
+    entry.status  = 'connecting'
   }
 
+  /**
+   * Guarda el QR más reciente y notifica a todos los clientes SSE suscritos.
+   */
   setQr(configId: string, qr: string): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     entry.qrBuffer = qr
-    entry.status = 'qr_ready'
+    entry.status   = 'qr_ready'
     this.broadcastSse(entry, { event: 'qr', data: qr })
   }
 
+  /**
+   * Actualiza el estado de la sesión y notifica a los clientes SSE.
+   * Si status es 'connecting' y la entrada no existe, la crea
+   * (para reservar el slot antes del primer await en /connect).
+   */
   setStatus(configId: string, status: WhatsAppSessionStatus): void {
+    if (status === 'connecting' && !this.sessions.has(configId)) {
+      this.sessions.set(configId, {
+        qrBuffer:   null,
+        status:     'connecting',
+        sseClients: new Set(),
+      })
+      return
+    }
     const entry = this.sessions.get(configId)
     if (!entry) return
     entry.status = status
-    if (status === 'connected') entry.qrBuffer = null
+    if (status === 'connected') {
+      entry.qrBuffer = null   // QR ya no es relevante
+    }
     this.broadcastSse(entry, { event: 'status', data: status })
   }
 
+  /**
+   * Elimina la sesión del store.
+   * Cierra todos los streams SSE pendientes antes de borrar.
+   */
   remove(configId: string): void {
     const entry = this.sessions.get(configId)
     if (!entry) return
     for (const client of entry.sseClients) {
-      try {
-        client.end()
-      } catch {}
+      try { client.end() } catch { /* ya cerrado */ }
     }
     entry.sseClients.clear()
     this.sessions.delete(configId)
@@ -96,36 +151,75 @@ export class WhatsAppSessionStore {
     this.remove(configId)
   }
 
+  // ── SSE client management ─────────────────────────────────────────────────
+
+  /**
+   * Registra un cliente SSE (Response de Express) para recibir
+   * eventos QR y de estado de este configId.
+   *
+   * Si ya hay un QR en buffer, lo envía inmediatamente para que
+   * el cliente no tenga que esperar al siguiente ciclo.
+   */
   addSseClient(configId: string, res: Response): void {
     const entry = this.getOrCreate(configId)
     entry.sseClients.add(res)
+
+    // Enviar estado e QR actuales de inmediato
     this.sendSseEvent(res, { event: 'status', data: entry.status })
     if (entry.qrBuffer) {
       this.sendSseEvent(res, { event: 'qr', data: entry.qrBuffer })
     }
+
+    // Limpiar al cerrar la conexión
     res.on('close', () => {
       entry.sseClients.delete(res)
     })
   }
 
-  private broadcastSse(entry: SessionEntry, payload: { event: string; data: string }): void {
+  /**
+   * Elimina un cliente SSE específico del set de un configId.
+   * Útil para cleanup explícito en tests o en el route handler.
+   */
+  removeSseClient(configId: string, res: Response): void {
+    const entry = this.sessions.get(configId)
+    if (!entry) return
+    entry.sseClients.delete(res)
+  }
+
+  // ── Helpers SSE ───────────────────────────────────────────────────────────
+
+  private broadcastSse(
+    entry:   SessionEntry,
+    payload: { event: string; data: string },
+  ): void {
     for (const client of entry.sseClients) {
       this.sendSseEvent(client, payload)
     }
   }
 
-  private sendSseEvent(res: Response, payload: { event: string; data: string }): void {
+  private sendSseEvent(
+    res:     Response,
+    payload: { event: string; data: string },
+  ): void {
     try {
       res.write(`event: ${payload.event}\ndata: ${payload.data}\n\n`)
-    } catch {}
+    } catch {
+      /* cliente ya desconectado — se limpiará en el handler 'close' */
+    }
   }
 
+  // ── Debug ─────────────────────────────────────────────────────────────────
+
+  /** Lista de configIds con adapter activo (útil para health/debug). */
   activeSessions(): string[] {
-    return [...this.sessions.keys()]
+    return [...this.sessions.entries()]
+      .filter(([, entry]) => !!entry.adapter)
+      .map(([configId]) => configId)
   }
 }
 
 /** Tipo exportado para inyección en WhatsAppDeprovisionService y tests */
 export type WhatsAppSessionStore_t = WhatsAppSessionStore
 
+/** Singleton exportado */
 export const whatsappSessionStore = new WhatsAppSessionStore()


### PR DESCRIPTION
Closes #48

<html> <body> <!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">? <strong>Implementaci?n completa. Commit entregado.</strong></p><hr class="bg-quiet h-px border-0"><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="resumen-de-la-implementacin--f3a-26">Resumen de la implementaci?n ? F3a-26</h2><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="rama-creada">?? Rama creada</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>feat/F3a-26-discord-adapter-lifecycle</code> ? base: <code>feat/F3a-25-whatsapp-e2e-spec</code></p><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="commit-sha">?? Commit SHA</h2><div class="w-full md:max-w-[90vw]"><pre class="not-prose w-full rounded font-mono text-sm font-extralight"><div class="codeWrapper bg-subtle text-light selection:text-super selection:bg-super/10 my-md relative flex flex-col rounded-lg font-mono text-sm font-medium"><div class="translate-y-xs -translate-x-xs bottom-xl mb-xl flex h-0 items-start justify-end sm:sticky sm:top-xs"><div class="overflow-hidden border-subtlest ring-subtlest divide-subtlest bg-base rounded-full"><div class="border-subtlest ring-subtlest divide-subtlest bg-subtle"><button data-testid="copy-code-button" aria-label="Copiar c?digo" type="button" class="focus-visible:bg-quiet hover:bg-quiet text-quiet hover:text-foreground font-sans focus:outline-none outline-none outline-transparent transition duration-300 ease-out select-none items-center relative group/button font-semimedium justify-center text-center items-center rounded-full cursor-pointer active:scale-[0.97] active:duration-150 active:ease-outExpo origin-center whitespace-nowrap inline-flex text-sm h-8 aspect-square" data-state="closed"><div class="flex items-center min-w-0 gap-two justify-center"><div class="flex shrink-0 items-center justify-center size-4"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div></div></button></div></div></div><div class="-mt-xl"><div><div data-testid="code-language-indicator" class="text-quiet bg-quiet py-xs px-sm inline-block rounded-br rounded-tl-lg text-xs font-thin">text</div></div><div><span style="font-size: inherit; font-family: inherit; background: transparent; color: rgb(214, 208, 200); border-radius: 3px; display: flex; line-height: 1.42857; overflow-x: auto; white-space: pre; --scrollbar-thumb: oklch(var(--foreground-color) / 0.15); --scrollbar-track: transparent; scrollbar-width: thin; scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);"><code style="white-space: pre-wrap; font-size: inherit; font-family: inherit; line-height: 1.66667; padding: 8px;"><span style="opacity: 1; font-size: inherit; line-height: 1.42857; color: rgb(214, 208, 200); background-color: transparent; flex-shrink: 0; padding: 8px; text-align: right; user-select: none;"><span>bf536dcf77bc3b127e5c9a825b9882d6bdfddeb4</span></span></code></span></div></div></div></pre></div><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-entregados-en-un-solo-commit">?? Archivos entregados en un solo commit</h2><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: hidden; visibility: hidden;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest"></div></div><div class="w-full overflow-auto scrollbar-subtle rounded-lg border md:max-w-[90vw] border-subtlest ring-subtlest divide-subtlest bg-raised"> Archivo | Acci?n -- | -- apps/gateway/src/channels/discord-message.mapper.ts | ? NUEVO apps/gateway/src/channels/discord.adapter.ts | ? REEMPLAZADO apps/gateway/src/channels/__tests__/discord.adapter.test.ts | ? NUEVO  </div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="criterios-de-cierre-cubiertos">? Criterios de cierre cubiertos</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>discord.adapter.ts</code> <strong>no importa</strong> <code>lib/prisma.js</code> ? cero dependencias de Prisma</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>initialize()</code> solo guarda <code>channelConfigId</code>, sin queries a BD</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>setup()</code> mode=<code>gateway</code> ? <code>Client</code> instanciado + <code>login()</code> llamado</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>setup()</code> mode=<code>http</code> ? <code>Client</code> <strong>NO</strong> instanciado</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>messageToIncoming()</code> con bot message ? <code>null</code></p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>messageToIncoming()</code> con prefijo <code>!</code> ? <code>type='command'</code>, texto sin <code>!</code></p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>send()</code> con texto &gt; 2000 chars ? m?ltiples chunks por espacios, sin error</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>dispose()</code> ? <code>client.destroy()</code> llamado, <code>reconnectTimer</code> limpiado</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Ed25519 verification v?a <code>node:crypto</code> nativo</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Reconexi?n exponencial: 5s ? 15s ? 45s ? 120s</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>send()</code> con interaction token usa <code>PATCH</code> al followup, nunca <code>POST</code></p></li></ul></div></body></html><!--EndFragment--> </body> </html>  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp Web integration with QR code support and automatic reconnection.
  * Added Discord HTTP interaction handling with optional gateway mode support.
  * Enhanced message mapping and routing across WhatsApp and Discord channels.
  * Added session logout and deprovisioning functionality for WhatsApp.

* **Tests**
  * Added comprehensive test coverage for exponential backoff, deprovision service, and message mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->