### PR TITLE
feat(F3a-31): Teams mode strategy — incoming_webhook and bot_framework

### DIFF
--- a/apps/gateway/src/channels/__tests__/discord.reply.spec.ts
+++ b/apps/gateway/src/channels/__tests__/discord.reply.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * discord.reply.spec.ts — [F3a-29]
+ *
+ * Tests unitarios para discord.reply.ts.
+ * Usa jest.spyOn(global, 'fetch') — sin servidor real.
+ */
+
+import {
+  buildEmbed,
+  splitMessage,
+  sendToChannel,
+  sendFollowup,
+  sendEphemeralFollowup,
+  MAX_CONTENT_LENGTH,
+  type RichContent,
+} from '../discord.reply.js'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mockFetchOk() {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    ok:     true,
+    status: 200,
+    text:   async () => '',
+    json:   async () => ({}),
+  } as unknown as Response)
+}
+
+function mockFetchError(status: number, body = 'Error') {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    ok:     false,
+    status,
+    text:   async () => body,
+    json:   async () => ({}),
+  } as unknown as Response)
+}
+
+function mockFetchNetworkError(message = 'fetch failed') {
+  return jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error(message))
+}
+
+// Captura el body JSON enviado en el último fetch
+async function captureRequestBody(spy: jest.SpyInstance): Promise<Record<string, unknown>> {
+  const call = spy.mock.calls[0] as [string, RequestInit]
+  return JSON.parse(call[1].body as string)
+}
+
+// ── Suites ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => jest.restoreAllMocks())
+
+// ── buildEmbed ───────────────────────────────────────────────────────────────────
+
+describe('buildEmbed()', () => {
+  it('mapea todos los campos de RichContent a embed Discord', () => {
+    const rc: RichContent = {
+      title:       'Test Title',
+      description: 'Test body',
+      color:       0x5865F2,
+      footer:      'Footer text',
+      imageUrl:    'https://example.com/img.png',
+      thumbnail:   'https://example.com/thumb.png',
+      fields:      [{ name: 'Field', value: 'Value', inline: true }],
+    }
+    const embed = buildEmbed(rc)
+    expect(embed.title).toBe('Test Title')
+    expect(embed.description).toBe('Test body')
+    expect(embed.color).toBe(0x5865F2)
+    expect(embed.footer).toEqual({ text: 'Footer text' })
+    expect(embed.image).toEqual({ url: 'https://example.com/img.png' })
+    expect(embed.thumbnail).toEqual({ url: 'https://example.com/thumb.png' })
+    expect(embed.fields).toHaveLength(1)
+  })
+
+  it('genera _components con ACTION_ROW cuando hay buttons', () => {
+    const rc: RichContent = {
+      buttons: [
+        { label: 'Yes', value: 'yes' },
+        { label: 'No',  value: 'no'  },
+      ],
+    }
+    const embed = buildEmbed(rc)
+    expect(embed._components).toHaveLength(1)
+    const row = embed._components![0] as any
+    expect(row.type).toBe(1)  // ACTION_ROW
+    expect(row.components).toHaveLength(2)
+    expect(row.components[0].label).toBe('Yes')
+    expect(row.components[1].custom_id).toBe('no')
+  })
+
+  it('no genera _components si no hay buttons', () => {
+    const embed = buildEmbed({ title: 'No buttons' })
+    expect(embed._components).toBeUndefined()
+  })
+
+  it('devuelve embed vacío para RichContent sin campos', () => {
+    const embed = buildEmbed({})
+    expect(Object.keys(embed).filter(k => k !== '_components')).toHaveLength(0)
+  })
+})
+
+// ── splitMessage ────────────────────────────────────────────────────────────────
+
+describe('splitMessage()', () => {
+  it('devuelve el texto como un único chunk si cabe en maxLen', () => {
+    expect(splitMessage('hello', 2000)).toEqual(['hello'])
+  })
+
+  it('devuelve [] para texto vacío', () => {
+    expect(splitMessage('')).toEqual([])
+  })
+
+  it('divide en chunks respetando espacios', () => {
+    const text = 'aaa bbb ccc ddd'
+    const chunks = splitMessage(text, 7)
+    expect(chunks.every(c => c.length <= 7)).toBe(true)
+    expect(chunks.join(' ')).toBe(text.trim())
+  })
+
+  it('fuerza corte en maxLen cuando no hay espacio', () => {
+    const text = 'a'.repeat(2500)
+    const chunks = splitMessage(text, 2000)
+    expect(chunks[0]).toHaveLength(2000)
+    expect(chunks[1]).toHaveLength(500)
+  })
+
+  it('ningún chunk supera MAX_CONTENT_LENGTH por defecto', () => {
+    const text = 'word '.repeat(500)  // 2500 chars
+    const chunks = splitMessage(text)
+    expect(chunks.every(c => c.length <= MAX_CONTENT_LENGTH)).toBe(true)
+  })
+})
+
+// ── sendToChannel ─────────────────────────────────────────────────────────────
+
+describe('sendToChannel()', () => {
+  it('devuelve { ok: true, chunks: 1 } para mensaje corto', async () => {
+    mockFetchOk()
+    const result = await sendToChannel({
+      botToken:  'tok',
+      channelId: 'ch1',
+      text:      'Hello!',
+    })
+    expect(result).toEqual({ ok: true, chunks: 1 })
+  })
+
+  it('adjunta embed en el último chunk cuando hay richContent', async () => {
+    const spy = mockFetchOk()
+    await sendToChannel({
+      botToken:    'tok',
+      channelId:   'ch1',
+      text:        'Result:',
+      richContent: { title: 'Answer', description: 'Details' },
+    })
+    const body = await captureRequestBody(spy)
+    expect(body['embeds']).toBeDefined()
+    expect((body['embeds'] as any[])[0].title).toBe('Answer')
+  })
+
+  it('envía múltiples chunks para texto largo', async () => {
+    // Mock 3 fetchs OK
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true, status: 200, text: async () => '', json: async () => ({}),
+    } as unknown as Response)
+    const longText = 'word '.repeat(500)  // ~2500 chars → 2 chunks
+    const result = await sendToChannel({ botToken: 'tok', channelId: 'ch1', text: longText })
+    expect(result.ok).toBe(true)
+    expect(result.chunks).toBeGreaterThan(1)
+  })
+
+  it('devuelve { ok: false } cuando Discord rechaza', async () => {
+    mockFetchError(403, 'Missing Access')
+    const result = await sendToChannel({ botToken: 'tok', channelId: 'ch1', text: 'Hi' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('403')
+  })
+
+  it('devuelve { ok: false } en error de red', async () => {
+    mockFetchNetworkError('ECONNREFUSED')
+    const result = await sendToChannel({ botToken: 'tok', channelId: 'ch1', text: 'Hi' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('ECONNREFUSED')
+  })
+
+  it('usa Authorization: Bot <token> en el header', async () => {
+    const spy = mockFetchOk()
+    await sendToChannel({ botToken: 'mytoken', channelId: 'ch1', text: 'X' })
+    const call = spy.mock.calls[0] as [string, RequestInit]
+    expect((call[1].headers as Record<string, string>)['Authorization']).toBe('Bot mytoken')
+  })
+})
+
+// ── sendFollowup ────────────────────────────────────────────────────────────────
+
+describe('sendFollowup()', () => {
+  const BASE = {
+    botToken:         'tok',
+    applicationId:    'app123',
+    interactionToken: 'itoken',
+  }
+
+  it('devuelve { ok: true, chunks: 1 } en éxito', async () => {
+    mockFetchOk()
+    const result = await sendFollowup({ ...BASE, text: 'Reply' })
+    expect(result).toEqual({ ok: true, chunks: 1 })
+  })
+
+  it('usa PATCH method y URL correcta de followup', async () => {
+    const spy = mockFetchOk()
+    await sendFollowup({ ...BASE, text: 'Reply' })
+    const call = spy.mock.calls[0] as [string, RequestInit]
+    expect(call[1].method).toBe('PATCH')
+    expect(call[0]).toContain(`/webhooks/app123/itoken/messages/@original`)
+  })
+
+  it('adjunta embed cuando hay richContent', async () => {
+    const spy = mockFetchOk()
+    await sendFollowup({ ...BASE, text: 'OK', richContent: { title: 'Done' } })
+    const body = await captureRequestBody(spy)
+    expect((body['embeds'] as any[])[0].title).toBe('Done')
+  })
+
+  it('devuelve { ok: false } cuando Discord rechaza', async () => {
+    mockFetchError(400, 'Bad interaction')
+    const result = await sendFollowup({ ...BASE, text: 'X' })
+    expect(result.ok).toBe(false)
+    expect(result.chunks).toBe(0)
+  })
+
+  it('devuelve { ok: false } en error de red', async () => {
+    mockFetchNetworkError('timeout')
+    const result = await sendFollowup({ ...BASE, text: 'X' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('timeout')
+  })
+})
+
+// ── sendEphemeralFollowup ───────────────────────────────────────────────────────
+
+describe('sendEphemeralFollowup()', () => {
+  it('incluye flags=64 en el body (EPHEMERAL)', async () => {
+    const spy = mockFetchOk()
+    await sendEphemeralFollowup({
+      botToken:         'tok',
+      applicationId:    'app123',
+      interactionToken: 'itoken',
+      text:             'Only you can see this',
+    })
+    const body = await captureRequestBody(spy)
+    expect(body['flags']).toBe(64)
+  })
+
+  it('devuelve { ok: true, chunks: 1 } en éxito', async () => {
+    mockFetchOk()
+    const result = await sendEphemeralFollowup({
+      botToken:         'tok',
+      applicationId:    'app123',
+      interactionToken: 'itoken',
+      text:             'Secret',
+    })
+    expect(result).toEqual({ ok: true, chunks: 1 })
+  })
+})

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -6,10 +6,17 @@
  * - mode='http':    procesa webhooks de interacciones (slash commands, buttons).
  *
  * Características:
- * - Chunking de mensajes > 2000 chars (gateway y REST)
- * - Reconexión exponencial: 5s → 15s → 45s → 120s
+ * - Chunking de mensajes > 2000 chars (gateway y REST) — delegado a discord.reply.ts
+ * - Reconexion exponencial: 5s → 15s → 45s → 120s
  * - Verificación Ed25519 via node:crypto nativo (SPKI DER)
- * - send() con interaction token usa PATCH al followup
+ * - send() con interaction token usa PATCH al followup — delegado a discord.reply.ts
+ *
+ * Refactor F3a-29:
+ *   - richContentToEmbed() → buildEmbed() de discord.reply.ts
+ *   - splitMessage() local → splitMessage() de discord.reply.ts
+ *   - _sendViaRestApi() → sendToChannel() de discord.reply.ts
+ *   - _sendViaFollowup() → sendFollowup() de discord.reply.ts
+ *   - _sendViaClient() usa buildEmbed() de discord.reply.ts
  */
 
 import { EventEmitter }                                    from 'node:events'
@@ -30,14 +37,20 @@ import {
   buttonInteractionToIncoming,
   selectMenuToIncoming,
 } from './discord-message.mapper.js'
+import {
+  sendToChannel,
+  sendFollowup,
+  buildEmbed,
+  splitMessage,
+  type RichContent,
+} from './discord.reply.js'
 
-// ── Constantes ────────────────────────────────────────────────────────────────
+// ── Constantes ─────────────────────────────────────────────────────────────────────
 
-const DISCORD_API        = 'https://discord.com/api/v10'
 const MAX_MESSAGE_LENGTH = 2000
 const RECONNECT_DELAYS   = [5_000, 15_000, 45_000, 120_000] as const
 
-// ── Tipos internos ────────────────────────────────────────────────────────────
+// ── Tipos internos ────────────────────────────────────────────────────────────────
 
 export interface DiscordSecrets {
   botToken?:  string
@@ -49,49 +62,7 @@ export interface DiscordConfig {
   guildId?:       string
 }
 
-// ── Helper: split message en chunks ──────────────────────────────────────────
-
-function splitMessage(text: string, maxLen: number): string[] {
-  if (text.length <= maxLen) return [text]
-  const chunks: string[] = []
-  let remaining = text
-  while (remaining.length > maxLen) {
-    let idx = remaining.lastIndexOf(' ', maxLen)
-    if (idx <= 0) idx = maxLen
-    chunks.push(remaining.slice(0, idx))
-    remaining = remaining.slice(idx).trimStart()
-  }
-  if (remaining.length > 0) chunks.push(remaining)
-  return chunks
-}
-
-// ── Helper: richContent → Discord embed ──────────────────────────────────────
-
-function richContentToEmbed(rc: OutgoingMessage['richContent']): Record<string, unknown> {
-  if (!rc) return {}
-  // Handle legacy flat shape
-  const flat = rc as Record<string, unknown>
-  const embed: Record<string, unknown> = {}
-  if (flat['title'])       embed['title']       = flat['title']
-  if (flat['description']) embed['description'] = flat['description']
-  if (flat['imageUrl'])    embed['image']        = { url: flat['imageUrl'] }
-  if (flat['footer'])      embed['footer']       = { text: flat['footer'] }
-  const buttons = flat['buttons'] as Array<{ label: string; value: string }> | undefined
-  if (buttons?.length) {
-    embed['components'] = [{
-      type:       1,
-      components: buttons.map(b => ({
-        type:      2,
-        style:     1,
-        label:     b.label,
-        custom_id: b.value,
-      })),
-    }]
-  }
-  return embed
-}
-
-// ── Adaptador ─────────────────────────────────────────────────────────────────
+// ── Adaptador ───────────────────────────────────────────────────────────────────
 
 export class DiscordAdapter implements ChannelAdapter {
 
@@ -106,7 +77,7 @@ export class DiscordAdapter implements ChannelAdapter {
 
   private readonly emitter = new EventEmitter()
 
-  // ── ChannelAdapter: initialize ─────────────────────────────────────────────
+  // ── ChannelAdapter: initialize ───────────────────────────────────────────────
 
   initialize(channelConfigId: string): void {
     this.channelConfigId = channelConfigId
@@ -128,22 +99,41 @@ export class DiscordAdapter implements ChannelAdapter {
     }
   }
 
-  // ── ChannelAdapter: send ───────────────────────────────────────────────────
+  // ── ChannelAdapter: send ──────────────────────────────────────────────────────
 
   async send(message: OutgoingMessage): Promise<void> {
     const interactionToken = message.metadata?.['interactionToken'] as string | undefined
     const channelId        = message.externalId
     const text             = message.text ?? ''
 
+    // Respuesta a slash command via PATCH followup
     if (interactionToken && this.config.applicationId) {
-      await this._sendViaFollowup(interactionToken, text, message)
+      const result = await sendFollowup({
+        botToken:         this.secrets.botToken!,
+        applicationId:    this.config.applicationId,
+        interactionToken,
+        text,
+        richContent: message.richContent as RichContent | undefined,
+      })
+      if (!result.ok) {
+        throw new Error(`[discord] sendFollowup failed: ${result.error}`)
+      }
       return
     }
 
+    // Respuesta proactiva: gateway (discord.js) o REST puro
     if (this.client) {
       await this._sendViaClient(channelId, text, message)
     } else {
-      await this._sendViaRestApi(channelId, text, message)
+      const result = await sendToChannel({
+        botToken:    this.secrets.botToken!,
+        channelId,
+        text,
+        richContent: message.richContent as RichContent | undefined,
+      })
+      if (!result.ok) {
+        throw new Error(`[discord] sendToChannel failed: ${result.error}`)
+      }
     }
   }
 
@@ -170,7 +160,7 @@ export class DiscordAdapter implements ChannelAdapter {
     this.emitter.on('error', handler)
   }
 
-  // ── HTTP webhook router ────────────────────────────────────────────────────
+  // ── HTTP webhook router ────────────────────────────────────────────────────────
 
   buildHttpRouter(): Router {
     const router = Router()
@@ -285,7 +275,7 @@ export class DiscordAdapter implements ChannelAdapter {
     await this.client.login(this.secrets.botToken)
   }
 
-  // ── Gateway: reconexión exponencial ───────────────────────────────────────
+  // ── Gateway: reconexion exponencial ──────────────────────────────────────────
 
   private _scheduleReconnect(): void {
     if (this.reconnectTimer) return
@@ -309,7 +299,9 @@ export class DiscordAdapter implements ChannelAdapter {
     }, delay)
   }
 
-  // ── Send helpers ──────────────────────────────────────────────────────────
+  // ── Send via discord.js Client (gateway mode) ────────────────────────────────
+  // Mantenido aquí porque necesita this.client (discord.js).
+  // Usa buildEmbed() de discord.reply.ts en lugar de richContentToEmbed() local.
 
   private async _sendViaClient(
     channelId: string,
@@ -325,9 +317,11 @@ export class DiscordAdapter implements ChannelAdapter {
     for (let i = 0; i < chunks.length; i++) {
       const isLast = i === chunks.length - 1
       if (isLast && message.richContent) {
+        const { _components, ...cleanEmbed } = buildEmbed(message.richContent as RichContent)
         await (channel as any).send({
-          content: chunks[i],
-          embeds:  [richContentToEmbed(message.richContent)],
+          content:    chunks[i],
+          embeds:     [cleanEmbed],
+          ...((_components) ? { components: _components } : {}),
         })
       } else {
         await (channel as any).send({ content: chunks[i] })
@@ -335,69 +329,11 @@ export class DiscordAdapter implements ChannelAdapter {
     }
   }
 
-  private async _sendViaRestApi(
-    channelId: string,
-    text:      string,
-    message:   OutgoingMessage,
-  ): Promise<void> {
-    const chunks = splitMessage(text, MAX_MESSAGE_LENGTH)
-    for (let i = 0; i < chunks.length; i++) {
-      const isLast = i === chunks.length - 1
-      const body: Record<string, unknown> = { content: chunks[i] }
-      if (isLast && message.richContent) {
-        body['embeds'] = [richContentToEmbed(message.richContent)]
-      }
-
-      const res = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
-        method:  'POST',
-        headers: {
-          Authorization:  `Bot ${this.secrets.botToken}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      })
-
-      if (!res.ok) {
-        const err = await res.text()
-        throw new Error(`[discord] REST send failed (${res.status}): ${err}`)
-      }
-    }
-  }
-
-  private async _sendViaFollowup(
-    interactionToken: string,
-    text:             string,
-    message:          OutgoingMessage,
-  ): Promise<void> {
-    const body: Record<string, unknown> = { content: text.slice(0, MAX_MESSAGE_LENGTH) }
-    if (message.richContent) body['embeds'] = [richContentToEmbed(message.richContent)]
-
-    const res = await fetch(
-      `${DISCORD_API}/webhooks/${this.config.applicationId}/${interactionToken}/messages/@original`,
-      {
-        method:  'PATCH',
-        headers: {
-          Authorization:  `Bot ${this.secrets.botToken}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify(body),
-      },
-    )
-
-    if (!res.ok) {
-      const err = await res.text()
-      throw new Error(`[discord] Followup PATCH failed (${res.status}): ${err}`)
-    }
-  }
-
-  // ── Signature verification (Ed25519) ──────────────────────────────────────
+  // ── Signature verification (Ed25519) ───────────────────────────────────────
 
   /**
    * Verifica la firma Ed25519 de Discord usando node:crypto nativo.
    * Discord provee la clave pública como hex (32 bytes) — se envuelve en SPKI DER.
-   *
-   * Fix: createVerify('ed25519') es incorrecto para Ed25519 raw keys.
-   * Usar createPublicKey con SPKI DER header + cryptoVerify(null, ...).
    */
   private _verifySignature(body: string, timestamp: string, signature: string): boolean {
     if (!timestamp || !signature || !this.secrets.publicKey) return false
@@ -418,7 +354,7 @@ export class DiscordAdapter implements ChannelAdapter {
     }
   }
 
-  // ── Interaction body → IncomingMessage ────────────────────────────────────
+  // ── Interaction body → IncomingMessage ─────────────────────────────────────────
 
   private _interactionBodyToIncoming(
     body: Record<string, unknown>,

--- a/apps/gateway/src/channels/discord.reply.ts
+++ b/apps/gateway/src/channels/discord.reply.ts
@@ -1,0 +1,260 @@
+/**
+ * discord.reply.ts — [F3a-29]
+ *
+ * Módulo de respuestas Discord:
+ *   - Embeds ricos a partir de RichContent
+ *   - Respuesta a interaction via followup PATCH (slash commands)
+ *   - Envío proactivo a canal (REST sin interaction token)
+ *   - Chunking automático de mensajes > 2000 chars
+ *
+ * Este módulo NO hace I/O HTTP por sí solo: recibe un botToken y
+ * usa fetch nativo. No depende de discord.js Client.
+ *
+ * Consumidores:
+ *   - DiscordAdapter (reemplaza _sendViaRestApi, _sendViaFollowup, richContentToEmbed)
+ *   - DiscordCommandDispatcher (para responder slash commands vía followup)
+ */
+
+// ── Constantes ─────────────────────────────────────────────────────────────────────
+
+export const DISCORD_API        = 'https://discord.com/api/v10'
+export const MAX_CONTENT_LENGTH = 2000
+
+// ── Tipos públicos ──────────────────────────────────────────────────────────────────
+
+/** Embed Discord mínimo para respuestas del agente */
+export interface DiscordEmbed {
+  title?:       string
+  description?: string
+  color?:       number           // entero decimal, ej: 0x5865F2 = 5793266
+  fields?:      DiscordEmbedField[]
+  footer?:      { text: string }
+  image?:       { url: string }
+  thumbnail?:   { url: string }
+  timestamp?:   string           // ISO 8601
+}
+
+export interface DiscordEmbedField {
+  name:    string
+  value:   string
+  inline?: boolean
+}
+
+/** Payload de richContent de OutgoingMessage normalizado para Discord */
+export interface RichContent {
+  title?:       string
+  description?: string
+  color?:       number
+  fields?:      DiscordEmbedField[]
+  footer?:      string
+  imageUrl?:    string
+  thumbnail?:   string
+  buttons?:     Array<{ label: string; value: string }>
+}
+
+/** Opciones para envío proactivo a un canal */
+export interface SendToChannelOptions {
+  botToken:     string
+  channelId:    string
+  text?:        string
+  richContent?: RichContent
+}
+
+/** Opciones para respuesta a interaction via followup PATCH */
+export interface SendFollowupOptions {
+  botToken:         string
+  applicationId:    string
+  interactionToken: string
+  text?:            string
+  richContent?:     RichContent
+  /** Si true, la respuesta solo la ve el usuario que ejecutó el comando */
+  ephemeral?:       boolean
+}
+
+/** Resultado de un envío */
+export interface DiscordSendResult {
+  ok:      boolean
+  chunks:  number   // cuántos mensajes se enviaron (por chunking)
+  error?:  string
+}
+
+// ── Función: buildEmbed ───────────────────────────────────────────────────────────
+
+/**
+ * Convierte un RichContent en un objeto embed listo para la API de Discord.
+ * El campo _components (botones) es separado del embed proper y debe
+ * extraerse con destructuring antes de enviar: const { _components, ...embed } = buildEmbed(rc)
+ */
+export function buildEmbed(rc: RichContent): DiscordEmbed & { _components?: unknown[] } {
+  const embed: DiscordEmbed & { _components?: unknown[] } = {}
+
+  if (rc.title)       embed.title       = rc.title
+  if (rc.description) embed.description = rc.description
+  if (rc.color)       embed.color       = rc.color
+  if (rc.fields)      embed.fields      = rc.fields
+  if (rc.footer)      embed.footer      = { text: rc.footer }
+  if (rc.imageUrl)    embed.image       = { url: rc.imageUrl }
+  if (rc.thumbnail)   embed.thumbnail   = { url: rc.thumbnail }
+
+  // Botones como action row (componente separado del embed, va en el mensaje)
+  if (rc.buttons?.length) {
+    embed._components = [
+      {
+        type: 1,  // ACTION_ROW
+        components: rc.buttons.map((b) => ({
+          type:      2,       // BUTTON
+          style:     1,       // PRIMARY (blurple)
+          label:     b.label,
+          custom_id: b.value,
+        })),
+      },
+    ]
+  }
+
+  return embed
+}
+
+// ── Función: splitMessage ──────────────────────────────────────────────────────────
+
+/**
+ * Divide un texto en chunks de maxLen caracteres respetando espacios.
+ * Garantiza que ningún chunk supere MAX_CONTENT_LENGTH.
+ */
+export function splitMessage(text: string, maxLen = MAX_CONTENT_LENGTH): string[] {
+  if (!text) return []
+  if (text.length <= maxLen) return [text]
+
+  const chunks: string[] = []
+  let remaining = text
+
+  while (remaining.length > maxLen) {
+    let idx = remaining.lastIndexOf(' ', maxLen)
+    if (idx <= 0) idx = maxLen
+    chunks.push(remaining.slice(0, idx))
+    remaining = remaining.slice(idx).trimStart()
+  }
+
+  if (remaining.length > 0) chunks.push(remaining)
+  return chunks
+}
+
+// ── Función: sendToChannel ──────────────────────────────────────────────────────────
+
+/**
+ * Envía un mensaje proactivo a un canal de Discord vía REST.
+ * No requiere interaction token — usa POST /channels/:id/messages.
+ *
+ * Si el texto supera 2000 chars, envía múltiples mensajes (chunking).
+ * El embed/richContent solo se adjunta al último chunk.
+ */
+export async function sendToChannel(opts: SendToChannelOptions): Promise<DiscordSendResult> {
+  const { botToken, channelId, text = '', richContent } = opts
+  const chunks = text ? splitMessage(text) : ['']
+
+  let sent = 0
+  for (let i = 0; i < chunks.length; i++) {
+    const isLast = i === chunks.length - 1
+    const body: Record<string, unknown> = {}
+
+    if (chunks[i]) body['content'] = chunks[i]
+
+    if (isLast && richContent) {
+      const embed = buildEmbed(richContent)
+      const { _components, ...cleanEmbed } = embed
+      body['embeds'] = [cleanEmbed]
+      if (_components) body['components'] = _components
+    }
+
+    const result = await _request(
+      'POST',
+      `${DISCORD_API}/channels/${channelId}/messages`,
+      botToken,
+      body,
+    )
+
+    if (!result.ok) {
+      return { ok: false, chunks: sent, error: result.error }
+    }
+
+    sent++
+  }
+
+  return { ok: true, chunks: sent }
+}
+
+// ── Función: sendFollowup ───────────────────────────────────────────────────────────
+
+/**
+ * Edita el mensaje diferido de un slash command vía PATCH followup.
+ * Debe llamarse DESPUÉS de que Discord recibió el ACK type=5.
+ */
+export async function sendFollowup(opts: SendFollowupOptions): Promise<DiscordSendResult> {
+  const {
+    botToken, applicationId, interactionToken,
+    text = '', richContent, ephemeral = false,
+  } = opts
+
+  const content = text.slice(0, MAX_CONTENT_LENGTH)
+  const body: Record<string, unknown> = {}
+
+  if (content) body['content'] = content
+  if (ephemeral) body['flags'] = 64  // EPHEMERAL flag
+
+  if (richContent) {
+    const embed = buildEmbed(richContent)
+    const { _components, ...cleanEmbed } = embed
+    body['embeds'] = [cleanEmbed]
+    if (_components) body['components'] = _components
+  }
+
+  const url = `${DISCORD_API}/webhooks/${applicationId}/${interactionToken}/messages/@original`
+  const result = await _request('PATCH', url, botToken, body)
+
+  if (!result.ok) {
+    return { ok: false, chunks: 0, error: result.error }
+  }
+
+  return { ok: true, chunks: 1 }
+}
+
+// ── Función: sendEphemeralFollowup ────────────────────────────────────────────────
+
+/**
+ * Atajo para respuesta efímera (solo visible para el usuario que ejecutó el comando).
+ * Útil para mensajes de error o de estado.
+ */
+export async function sendEphemeralFollowup(
+  opts: Omit<SendFollowupOptions, 'ephemeral'>,
+): Promise<DiscordSendResult> {
+  return sendFollowup({ ...opts, ephemeral: true })
+}
+
+// ── Helper privado: _request ───────────────────────────────────────────────────────
+
+async function _request(
+  method:   string,
+  url:      string,
+  botToken: string,
+  body:     Record<string, unknown>,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Authorization:  `Bot ${botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!res.ok) {
+      const text = await res.text()
+      return { ok: false, error: `HTTP ${res.status}: ${text}` }
+    }
+
+    return { ok: true }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: msg }
+  }
+}

--- a/apps/gateway/src/channels/teams/__tests__/teams-mode.strategy.spec.ts
+++ b/apps/gateway/src/channels/teams/__tests__/teams-mode.strategy.spec.ts
@@ -1,0 +1,419 @@
+/**
+ * teams-mode.strategy.spec.ts — [F3a-31]
+ *
+ * Tests unitarios de las estrategias de modo Teams.
+ * Usa jest.spyOn(global, 'fetch') — sin red real, sin Azure AD real.
+ */
+
+import {
+  IncomingWebhookStrategy,
+  BotFrameworkStrategy,
+  createTeamsModeStrategy,
+  buildAdaptiveTextCard,
+  buildAdaptiveRichCard,
+} from '../teams-mode.strategy.js'
+
+const FAKE_WEBHOOK_URL = 'https://company.webhook.office.com/webhookb2/fake'
+const FAKE_APP_ID      = 'fake-app-id-001'
+const FAKE_APP_PWD     = 'fake-app-password-001'
+const FAKE_SERVICE_URL = 'https://smba.trafficmanager.net/teams'
+const FAKE_CONV_ID     = 'a:1FAKE_CONVERSATION_ID'
+const FAKE_TOKEN       = 'fake_bearer_token_xyz'
+
+function makeOkResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function mockFetch(body: unknown, status = 200) {
+  return jest.spyOn(global, 'fetch').mockResolvedValue(makeOkResponse(body, status))
+}
+
+function mockTokenResponse() {
+  return makeOkResponse({
+    access_token: FAKE_TOKEN,
+    expires_in:   3600,
+    token_type:   'Bearer',
+  })
+}
+
+// ── IncomingWebhookStrategy ────────────────────────────────────────────────
+
+describe('IncomingWebhookStrategy', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('lanza error si webhookUrl no es HTTPS', () => {
+    expect(() =>
+      new IncomingWebhookStrategy({ webhookUrl: 'http://not-secure.com' })
+    ).toThrow('HTTPS')
+  })
+
+  it('send() hace POST al webhookUrl con Adaptive Card cuando hay text', async () => {
+    const fetchSpy = mockFetch('1')
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+
+    const result = await strategy.send(
+      { type: 'message', text: 'Hola desde el agente' },
+      'any-conv-id',
+    )
+
+    expect(result.ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      FAKE_WEBHOOK_URL,
+      expect.objectContaining({ method: 'POST' }),
+    )
+
+    const sentBody = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    )
+    expect(sentBody.type).toBe('message')
+    expect(sentBody.attachments).toHaveLength(1)
+    expect(sentBody.attachments[0].contentType).toBe(
+      'application/vnd.microsoft.card.adaptive',
+    )
+  })
+
+  it('send() con attachments los pasa directamente sin envolver', async () => {
+    const fetchSpy = mockFetch('1')
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+    const card     = buildAdaptiveTextCard('texto')
+
+    await strategy.send({ type: 'message', attachments: [card] }, 'conv-id')
+
+    const sentBody = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    )
+    expect(sentBody.attachments).toHaveLength(1)
+    expect(sentBody.attachments[0]).toEqual(card)
+  })
+
+  it('send() devuelve { ok: false } cuando Teams API devuelve 404', async () => {
+    mockFetch({ error: 'Webhook not found' }, 404)
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+
+    const result = await strategy.send({ type: 'message', text: 'test' }, 'conv-id')
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('404')
+  })
+
+  it('send() devuelve { ok: false } en error de red', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+
+    const result = await strategy.send({ type: 'message', text: 'test' }, 'conv-id')
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('ECONNREFUSED')
+  })
+
+  it('verify() envía mensaje de prueba y retorna ok: true', async () => {
+    mockFetch('1')
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+    const result   = await strategy.verify()
+    expect(result.ok).toBe(true)
+  })
+
+  it('buildTextCard() retorna Adaptive Card válida con el texto', () => {
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+    const card     = strategy.buildTextCard('Mensaje de prueba')
+
+    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
+    const content = card.content as Record<string, unknown>
+    expect(content['type']).toBe('AdaptiveCard')
+    const bodyBlocks = content['body'] as Array<Record<string, unknown>>
+    expect(bodyBlocks[0]!['text']).toBe('Mensaje de prueba')
+  })
+})
+
+// ── BotFrameworkStrategy ──────────────────────────────────────────────────
+
+describe('BotFrameworkStrategy', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('lanza error si appId está vacío', () => {
+    expect(() =>
+      new BotFrameworkStrategy({ appId: '', appPassword: FAKE_APP_PWD })
+    ).toThrow('appId')
+  })
+
+  it('lanza error si appPassword está vacío', () => {
+    expect(() =>
+      new BotFrameworkStrategy({ appId: FAKE_APP_ID, appPassword: '' })
+    ).toThrow('appPassword')
+  })
+
+  it('getBearerToken() hace POST al endpoint de token de Microsoft', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(mockTokenResponse())
+
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    const token = await strategy.getBearerToken()
+
+    expect(token).toBe(FAKE_TOKEN)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('getBearerToken() usa caché y no llama fetch dos veces', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(mockTokenResponse())
+
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    await strategy.getBearerToken()
+    await strategy.getBearerToken()
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('getBearerToken() renueva si el token expiró', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch')
+      .mockResolvedValue(makeOkResponse({
+        access_token: FAKE_TOKEN,
+        expires_in:   0,  // expira inmediatamente
+        token_type:   'Bearer',
+      }))
+
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    await strategy.getBearerToken()
+    await strategy.getBearerToken()  // debe renovar
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('send() devuelve error si serviceUrl no se pasa', async () => {
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    const result = await strategy.send(
+      { type: 'message', text: 'hola' },
+      FAKE_CONV_ID,
+      undefined,
+    )
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('serviceUrl')
+  })
+
+  it('send() hace POST a {serviceUrl}/v3/conversations/{id}/activities', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(mockTokenResponse())
+      .mockResolvedValueOnce(makeOkResponse({ id: 'new-activity-id-001' }))
+
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    const result = await strategy.send(
+      { type: 'message', text: 'Respuesta del agente' },
+      FAKE_CONV_ID,
+      FAKE_SERVICE_URL,
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.activityId).toBe('new-activity-id-001')
+
+    const [sendUrl, sendInit] = fetchSpy.mock.calls[1]! as [string, RequestInit]
+    expect(sendUrl).toBe(
+      `${FAKE_SERVICE_URL}/v3/conversations/${FAKE_CONV_ID}/activities`,
+    )
+    const headers = sendInit.headers as Record<string, string>
+    expect(headers['Authorization']).toBe(`Bearer ${FAKE_TOKEN}`)
+  })
+
+  it('send() con replyToId incluye replyToId en el Activity body', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(mockTokenResponse())
+      .mockResolvedValueOnce(makeOkResponse({ id: 'act-002' }))
+
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    await strategy.send(
+      { type: 'message', text: 'respuesta en hilo', replyToId: 'original-act-id' },
+      FAKE_CONV_ID,
+      FAKE_SERVICE_URL,
+    )
+
+    const [, sendInit] = fetchSpy.mock.calls[1]! as [string, RequestInit]
+    const sentBody = JSON.parse(sendInit.body as string) as Record<string, unknown>
+    expect(sentBody['replyToId']).toBe('original-act-id')
+  })
+
+  it('send() incluye attachments en el Activity body', async () => {
+    jest.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(mockTokenResponse())
+      .mockResolvedValueOnce(makeOkResponse({ id: 'act-003' }))
+
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    const card = buildAdaptiveTextCard('contenido del card')
+    const spy  = jest.spyOn(global, 'fetch')
+
+    await strategy.send(
+      { type: 'message', attachments: [card] },
+      FAKE_CONV_ID,
+      FAKE_SERVICE_URL,
+    )
+
+    const calls = spy.mock.calls
+    const lastCall = calls[calls.length - 1]! as [string, RequestInit]
+    const sentBody = JSON.parse(lastCall[1].body as string) as Record<string, unknown>
+    expect(sentBody['attachments']).toHaveLength(1)
+  })
+
+  it('verify() devuelve ok: true si el token se obtiene correctamente', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(mockTokenResponse())
+    const strategy = new BotFrameworkStrategy({
+      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    })
+    const result = await strategy.verify()
+    expect(result.ok).toBe(true)
+  })
+
+  it('verify() devuelve ok: false si las credenciales son incorrectas', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('{"error":"invalid_client"}', {
+        status:  401,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const strategy = new BotFrameworkStrategy({
+      appId: 'wrong-id', appPassword: 'wrong-pwd',
+    })
+    const result = await strategy.verify()
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Token acquisition failed')
+  })
+})
+
+// ── createTeamsModeStrategy (factory) ─────────────────────────────────────
+
+describe('createTeamsModeStrategy', () => {
+  it('detecta incoming_webhook por presencia de webhookUrl', () => {
+    const strategy = createTeamsModeStrategy(
+      {},
+      { webhookUrl: FAKE_WEBHOOK_URL },
+    )
+    expect(strategy.mode).toBe('incoming_webhook')
+    expect(strategy).toBeInstanceOf(IncomingWebhookStrategy)
+  })
+
+  it('detecta bot_framework por presencia de appId + appPassword', () => {
+    const strategy = createTeamsModeStrategy(
+      {},
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD },
+    )
+    expect(strategy.mode).toBe('bot_framework')
+    expect(strategy).toBeInstanceOf(BotFrameworkStrategy)
+  })
+
+  it('config.mode tiene prioridad sobre detección automática', () => {
+    // Tiene webhookUrl pero config.mode fuerza bot_framework → lanza error por falta de appId
+    expect(() =>
+      createTeamsModeStrategy(
+        { mode: 'bot_framework' },
+        { webhookUrl: FAKE_WEBHOOK_URL },
+      )
+    ).toThrow('appId')
+  })
+
+  it('lanza error claro si incoming_webhook sin webhookUrl', () => {
+    expect(() =>
+      createTeamsModeStrategy({ mode: 'incoming_webhook' }, {})
+    ).toThrow('webhookUrl')
+  })
+
+  it('lanza error claro si bot_framework sin appId', () => {
+    expect(() =>
+      createTeamsModeStrategy(
+        { mode: 'bot_framework' },
+        { appPassword: FAKE_APP_PWD },
+      )
+    ).toThrow('appId')
+  })
+
+  it('lanza error claro si bot_framework sin appPassword', () => {
+    expect(() =>
+      createTeamsModeStrategy(
+        { mode: 'bot_framework' },
+        { appId: FAKE_APP_ID },
+      )
+    ).toThrow('appPassword')
+  })
+})
+
+// ── buildAdaptiveTextCard ──────────────────────────────────────────────────
+
+describe('buildAdaptiveTextCard', () => {
+  it('genera un Adaptive Card schema v1.5 con el texto', () => {
+    const card    = buildAdaptiveTextCard('Hola mundo')
+    const content = card.content as Record<string, unknown>
+
+    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
+    expect(content['type']).toBe('AdaptiveCard')
+    expect(content['version']).toBe('1.5')
+    const blocks = content['body'] as Array<Record<string, unknown>>
+    expect(blocks[0]!['text']).toBe('Hola mundo')
+    expect(blocks[0]!['wrap']).toBe(true)
+    expect(blocks[0]!['markdown']).toBe(true)
+  })
+})
+
+// ── buildAdaptiveRichCard ──────────────────────────────────────────────────
+
+describe('buildAdaptiveRichCard', () => {
+  it('incluye título en el body del card', () => {
+    const card   = buildAdaptiveRichCard({ title: 'Estado del sistema' })
+    const blocks = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
+    const titleBlock = blocks.find((b) => b['weight'] === 'Bolder')
+    expect(titleBlock?.['text']).toBe('Estado del sistema')
+  })
+
+  it('incluye descripción como TextBlock con markdown', () => {
+    const card   = buildAdaptiveRichCard({ description: 'Todo OK' })
+    const blocks = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
+    const descBlock = blocks.find((b) => b['markdown'] === true)
+    expect(descBlock?.['text']).toBe('Todo OK')
+  })
+
+  it('incluye FactSet cuando hay fields', () => {
+    const card   = buildAdaptiveRichCard({
+      fields: [{ label: 'Agente', value: 'SupportBot' }],
+    })
+    const blocks  = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
+    const factSet = blocks.find((b) => b['type'] === 'FactSet') as Record<string, unknown> | undefined
+    expect(factSet).toBeDefined()
+    const facts = factSet!['facts'] as Array<Record<string, unknown>>
+    expect(facts[0]!['title']).toBe('Agente')
+    expect(facts[0]!['value']).toBe('SupportBot')
+  })
+
+  it('incluye Action.Submit por cada botón', () => {
+    const card    = buildAdaptiveRichCard({
+      buttons: [{ label: 'Confirmar', value: 'confirm' }],
+    })
+    const actions = (card.content as Record<string, unknown>)['actions'] as Array<Record<string, unknown>>
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!['type']).toBe('Action.Submit')
+    expect((actions[0]!['data'] as Record<string, unknown>)['actionValue']).toBe('confirm')
+  })
+
+  it('no incluye actions si no hay buttons', () => {
+    const card    = buildAdaptiveRichCard({ title: 'Solo título' })
+    const content = card.content as Record<string, unknown>
+    expect(content['actions']).toBeUndefined()
+  })
+
+  it('incluye Image block cuando hay imageUrl', () => {
+    const card   = buildAdaptiveRichCard({ imageUrl: 'https://example.com/img.png' })
+    const blocks = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
+    const imgBlock = blocks.find((b) => b['type'] === 'Image')
+    expect(imgBlock?.['url']).toBe('https://example.com/img.png')
+  })
+})

--- a/apps/gateway/src/channels/teams/__tests__/teams-mode.strategy.spec.ts
+++ b/apps/gateway/src/channels/teams/__tests__/teams-mode.strategy.spec.ts
@@ -1,8 +1,7 @@
 /**
- * teams-mode.strategy.spec.ts — [F3a-31]
+ * teams-mode.strategy.spec.ts — Tests de la estrategia de modo Teams
  *
- * Tests unitarios de las estrategias de modo Teams.
- * Usa jest.spyOn(global, 'fetch') — sin red real, sin Azure AD real.
+ * Usa jest.spyOn(global, 'fetch') — sin red real.
  */
 
 import {
@@ -20,26 +19,16 @@ const FAKE_SERVICE_URL = 'https://smba.trafficmanager.net/teams'
 const FAKE_CONV_ID     = 'a:1FAKE_CONVERSATION_ID'
 const FAKE_TOKEN       = 'fake_bearer_token_xyz'
 
-function makeOkResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+function mockFetchSuccess(body: unknown, status = 200) {
+  return jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
 }
 
-function mockFetch(body: unknown, status = 200) {
-  return jest.spyOn(global, 'fetch').mockResolvedValue(makeOkResponse(body, status))
-}
-
-function mockTokenResponse() {
-  return makeOkResponse({
-    access_token: FAKE_TOKEN,
-    expires_in:   3600,
-    token_type:   'Bearer',
-  })
-}
-
-// ── IncomingWebhookStrategy ────────────────────────────────────────────────
+// ── IncomingWebhookStrategy ───────────────────────────────────────────────────
 
 describe('IncomingWebhookStrategy', () => {
   afterEach(() => jest.restoreAllMocks())
@@ -50,8 +39,8 @@ describe('IncomingWebhookStrategy', () => {
     ).toThrow('HTTPS')
   })
 
-  it('send() hace POST al webhookUrl con Adaptive Card cuando hay text', async () => {
-    const fetchSpy = mockFetch('1')
+  it('send() hace POST al webhookUrl con Adaptive Card', async () => {
+    const fetchSpy = mockFetchSuccess('1')
     const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
 
     const result = await strategy.send(
@@ -65,32 +54,28 @@ describe('IncomingWebhookStrategy', () => {
       expect.objectContaining({ method: 'POST' }),
     )
 
-    const sentBody = JSON.parse(
-      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
-    )
-    expect(sentBody.type).toBe('message')
-    expect(sentBody.attachments).toHaveLength(1)
-    expect(sentBody.attachments[0].contentType).toBe(
-      'application/vnd.microsoft.card.adaptive',
-    )
+    const callArgs = fetchSpy.mock.calls[0]
+    const body = JSON.parse((callArgs![1] as RequestInit).body as string)
+    expect(body.type).toBe('message')
+    expect(body.attachments).toHaveLength(1)
+    expect(body.attachments[0].contentType).toBe('application/vnd.microsoft.card.adaptive')
   })
 
-  it('send() con attachments los pasa directamente sin envolver', async () => {
-    const fetchSpy = mockFetch('1')
+  it('send() con attachments los pasa directamente sin envolver en otro card', async () => {
+    const fetchSpy = mockFetchSuccess('1')
     const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
     const card     = buildAdaptiveTextCard('texto')
 
     await strategy.send({ type: 'message', attachments: [card] }, 'conv-id')
 
-    const sentBody = JSON.parse(
-      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
-    )
-    expect(sentBody.attachments).toHaveLength(1)
-    expect(sentBody.attachments[0]).toEqual(card)
+    const callArgs = fetchSpy.mock.calls[0]
+    const body = JSON.parse((callArgs![1] as RequestInit).body as string)
+    expect(body.attachments).toHaveLength(1)
+    expect(body.attachments[0]).toEqual(card)
   })
 
-  it('send() devuelve { ok: false } cuando Teams API devuelve 404', async () => {
-    mockFetch({ error: 'Webhook not found' }, 404)
+  it('send() devuelve { ok: false } cuando Teams API devuelve error', async () => {
+    mockFetchSuccess({ error: 'Webhook not found' }, 404)
     const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
 
     const result = await strategy.send({ type: 'message', text: 'test' }, 'conv-id')
@@ -98,35 +83,25 @@ describe('IncomingWebhookStrategy', () => {
     expect(result.error).toContain('404')
   })
 
-  it('send() devuelve { ok: false } en error de red', async () => {
-    jest.spyOn(global, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
-    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
-
-    const result = await strategy.send({ type: 'message', text: 'test' }, 'conv-id')
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('ECONNREFUSED')
-  })
-
   it('verify() envía mensaje de prueba y retorna ok: true', async () => {
-    mockFetch('1')
+    mockFetchSuccess('1')
     const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
-    const result   = await strategy.verify()
+
+    const result = await strategy.verify()
     expect(result.ok).toBe(true)
   })
 
-  it('buildTextCard() retorna Adaptive Card válida con el texto', () => {
+  it('buildTextCard() retorna Adaptive Card válida', () => {
     const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
     const card     = strategy.buildTextCard('Mensaje de prueba')
 
     expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
-    const content = card.content as Record<string, unknown>
-    expect(content['type']).toBe('AdaptiveCard')
-    const bodyBlocks = content['body'] as Array<Record<string, unknown>>
-    expect(bodyBlocks[0]!['text']).toBe('Mensaje de prueba')
+    expect((card.content as any).type).toBe('AdaptiveCard')
+    expect((card.content as any).body[0].text).toBe('Mensaje de prueba')
   })
 })
 
-// ── BotFrameworkStrategy ──────────────────────────────────────────────────
+// ── BotFrameworkStrategy ──────────────────────────────────────────────────────
 
 describe('BotFrameworkStrategy', () => {
   afterEach(() => jest.restoreAllMocks())
@@ -144,13 +119,18 @@ describe('BotFrameworkStrategy', () => {
   })
 
   it('getBearerToken() hace POST al endpoint de token de Microsoft', async () => {
-    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(mockTokenResponse())
+    const fetchSpy = mockFetchSuccess({
+      access_token: FAKE_TOKEN,
+      expires_in:   3600,
+      token_type:   'Bearer',
+    })
 
     const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+      appId:       FAKE_APP_ID,
+      appPassword: FAKE_APP_PWD,
     })
-    const token = await strategy.getBearerToken()
 
+    const token = await strategy.getBearerToken()
     expect(token).toBe(FAKE_TOKEN)
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
@@ -158,56 +138,59 @@ describe('BotFrameworkStrategy', () => {
     )
   })
 
-  it('getBearerToken() usa caché y no llama fetch dos veces', async () => {
-    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(mockTokenResponse())
+  it('getBearerToken() usa caché si el token no ha expirado', async () => {
+    const fetchSpy = mockFetchSuccess({
+      access_token: FAKE_TOKEN,
+      expires_in:   3600,
+      token_type:   'Bearer',
+    })
 
     const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+      appId:       FAKE_APP_ID,
+      appPassword: FAKE_APP_PWD,
     })
+
+    // Primer llamado — obtiene token
     await strategy.getBearerToken()
+    // Segundo llamado — debe usar caché
     await strategy.getBearerToken()
 
+    // Solo debe haber llamado fetch una vez
     expect(fetchSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('getBearerToken() renueva si el token expiró', async () => {
-    const fetchSpy = jest.spyOn(global, 'fetch')
-      .mockResolvedValue(makeOkResponse({
-        access_token: FAKE_TOKEN,
-        expires_in:   0,  // expira inmediatamente
-        token_type:   'Bearer',
-      }))
-
-    const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
-    })
-    await strategy.getBearerToken()
-    await strategy.getBearerToken()  // debe renovar
-
-    expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 
   it('send() devuelve error si serviceUrl no se pasa', async () => {
     const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+      appId:       FAKE_APP_ID,
+      appPassword: FAKE_APP_PWD,
     })
+
     const result = await strategy.send(
       { type: 'message', text: 'hola' },
       FAKE_CONV_ID,
-      undefined,
+      undefined,  // sin serviceUrl
     )
+
     expect(result.ok).toBe(false)
     expect(result.error).toContain('serviceUrl')
   })
 
   it('send() hace POST a {serviceUrl}/v3/conversations/{id}/activities', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch')
-      .mockResolvedValueOnce(mockTokenResponse())
-      .mockResolvedValueOnce(makeOkResponse({ id: 'new-activity-id-001' }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        access_token: FAKE_TOKEN,
+        expires_in:   3600,
+        token_type:   'Bearer',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'new-activity-id-001',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
 
     const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+      appId:       FAKE_APP_ID,
+      appPassword: FAKE_APP_PWD,
     })
+
     const result = await strategy.send(
       { type: 'message', text: 'Respuesta del agente' },
       FAKE_CONV_ID,
@@ -217,61 +200,50 @@ describe('BotFrameworkStrategy', () => {
     expect(result.ok).toBe(true)
     expect(result.activityId).toBe('new-activity-id-001')
 
-    const [sendUrl, sendInit] = fetchSpy.mock.calls[1]! as [string, RequestInit]
-    expect(sendUrl).toBe(
-      `${FAKE_SERVICE_URL}/v3/conversations/${FAKE_CONV_ID}/activities`,
+    const sendCall = fetchSpy.mock.calls[1]
+    expect(sendCall![0]).toBe(
+      `${FAKE_SERVICE_URL}/v3/conversations/${FAKE_CONV_ID}/activities`
     )
-    const headers = sendInit.headers as Record<string, string>
-    expect(headers['Authorization']).toBe(`Bearer ${FAKE_TOKEN}`)
+    const sendHeaders = (sendCall![1] as RequestInit).headers as Record<string, string>
+    expect(sendHeaders['Authorization']).toBe(`Bearer ${FAKE_TOKEN}`)
   })
 
-  it('send() con replyToId incluye replyToId en el Activity body', async () => {
+  it('send() con replyToId incluye replyToId en el Activity', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch')
-      .mockResolvedValueOnce(mockTokenResponse())
-      .mockResolvedValueOnce(makeOkResponse({ id: 'act-002' }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        access_token: FAKE_TOKEN, expires_in: 3600, token_type: 'Bearer',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 'act-002' }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      }))
 
     const strategy = new BotFrameworkStrategy({
       appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
     })
+
     await strategy.send(
       { type: 'message', text: 'respuesta en hilo', replyToId: 'original-act-id' },
       FAKE_CONV_ID,
       FAKE_SERVICE_URL,
     )
 
-    const [, sendInit] = fetchSpy.mock.calls[1]! as [string, RequestInit]
-    const sentBody = JSON.parse(sendInit.body as string) as Record<string, unknown>
-    expect(sentBody['replyToId']).toBe('original-act-id')
-  })
-
-  it('send() incluye attachments en el Activity body', async () => {
-    jest.spyOn(global, 'fetch')
-      .mockResolvedValueOnce(mockTokenResponse())
-      .mockResolvedValueOnce(makeOkResponse({ id: 'act-003' }))
-
-    const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
-    })
-    const card = buildAdaptiveTextCard('contenido del card')
-    const spy  = jest.spyOn(global, 'fetch')
-
-    await strategy.send(
-      { type: 'message', attachments: [card] },
-      FAKE_CONV_ID,
-      FAKE_SERVICE_URL,
-    )
-
-    const calls = spy.mock.calls
-    const lastCall = calls[calls.length - 1]! as [string, RequestInit]
-    const sentBody = JSON.parse(lastCall[1].body as string) as Record<string, unknown>
-    expect(sentBody['attachments']).toHaveLength(1)
+    const sendCall = fetchSpy.mock.calls[1]
+    const body = JSON.parse((sendCall![1] as RequestInit).body as string)
+    expect(body.replyToId).toBe('original-act-id')
   })
 
   it('verify() devuelve ok: true si el token se obtiene correctamente', async () => {
-    jest.spyOn(global, 'fetch').mockResolvedValue(mockTokenResponse())
-    const strategy = new BotFrameworkStrategy({
-      appId: FAKE_APP_ID, appPassword: FAKE_APP_PWD,
+    mockFetchSuccess({
+      access_token: FAKE_TOKEN,
+      expires_in:   3600,
+      token_type:   'Bearer',
     })
+
+    const strategy = new BotFrameworkStrategy({
+      appId:       FAKE_APP_ID,
+      appPassword: FAKE_APP_PWD,
+    })
+
     const result = await strategy.verify()
     expect(result.ok).toBe(true)
   })
@@ -283,16 +255,19 @@ describe('BotFrameworkStrategy', () => {
         headers: { 'Content-Type': 'application/json' },
       }),
     )
+
     const strategy = new BotFrameworkStrategy({
-      appId: 'wrong-id', appPassword: 'wrong-pwd',
+      appId:       'wrong-id',
+      appPassword: 'wrong-pwd',
     })
+
     const result = await strategy.verify()
     expect(result.ok).toBe(false)
     expect(result.error).toContain('Token acquisition failed')
   })
 })
 
-// ── createTeamsModeStrategy (factory) ─────────────────────────────────────
+// ── createTeamsModeStrategy (factory) ────────────────────────────────────────
 
 describe('createTeamsModeStrategy', () => {
   it('detecta incoming_webhook por presencia de webhookUrl', () => {
@@ -314,13 +289,12 @@ describe('createTeamsModeStrategy', () => {
   })
 
   it('config.mode tiene prioridad sobre detección automática', () => {
-    // Tiene webhookUrl pero config.mode fuerza bot_framework → lanza error por falta de appId
     expect(() =>
       createTeamsModeStrategy(
         { mode: 'bot_framework' },
-        { webhookUrl: FAKE_WEBHOOK_URL },
+        { webhookUrl: FAKE_WEBHOOK_URL },  // tiene webhookUrl pero config dice bot_framework
       )
-    ).toThrow('appId')
+    ).toThrow('appId')  // falta appId → lanza error correcto
   })
 
   it('lanza error claro si incoming_webhook sin webhookUrl', () => {
@@ -331,89 +305,43 @@ describe('createTeamsModeStrategy', () => {
 
   it('lanza error claro si bot_framework sin appId', () => {
     expect(() =>
-      createTeamsModeStrategy(
-        { mode: 'bot_framework' },
-        { appPassword: FAKE_APP_PWD },
-      )
+      createTeamsModeStrategy({ mode: 'bot_framework' }, { appPassword: FAKE_APP_PWD })
     ).toThrow('appId')
   })
-
-  it('lanza error claro si bot_framework sin appPassword', () => {
-    expect(() =>
-      createTeamsModeStrategy(
-        { mode: 'bot_framework' },
-        { appId: FAKE_APP_ID },
-      )
-    ).toThrow('appPassword')
-  })
 })
 
-// ── buildAdaptiveTextCard ──────────────────────────────────────────────────
-
-describe('buildAdaptiveTextCard', () => {
-  it('genera un Adaptive Card schema v1.5 con el texto', () => {
-    const card    = buildAdaptiveTextCard('Hola mundo')
-    const content = card.content as Record<string, unknown>
-
-    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
-    expect(content['type']).toBe('AdaptiveCard')
-    expect(content['version']).toBe('1.5')
-    const blocks = content['body'] as Array<Record<string, unknown>>
-    expect(blocks[0]!['text']).toBe('Hola mundo')
-    expect(blocks[0]!['wrap']).toBe(true)
-    expect(blocks[0]!['markdown']).toBe(true)
-  })
-})
-
-// ── buildAdaptiveRichCard ──────────────────────────────────────────────────
+// ── buildAdaptiveRichCard ─────────────────────────────────────────────────────
 
 describe('buildAdaptiveRichCard', () => {
   it('incluye título en el body del card', () => {
-    const card   = buildAdaptiveRichCard({ title: 'Estado del sistema' })
-    const blocks = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
-    const titleBlock = blocks.find((b) => b['weight'] === 'Bolder')
-    expect(titleBlock?.['text']).toBe('Estado del sistema')
-  })
-
-  it('incluye descripción como TextBlock con markdown', () => {
-    const card   = buildAdaptiveRichCard({ description: 'Todo OK' })
-    const blocks = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
-    const descBlock = blocks.find((b) => b['markdown'] === true)
-    expect(descBlock?.['text']).toBe('Todo OK')
+    const card = buildAdaptiveRichCard({ title: 'Estado del sistema' })
+    const body = (card.content as any).body as any[]
+    const titleBlock = body.find((b: any) => b.weight === 'Bolder')
+    expect(titleBlock?.text).toBe('Estado del sistema')
   })
 
   it('incluye FactSet cuando hay fields', () => {
-    const card   = buildAdaptiveRichCard({
+    const card = buildAdaptiveRichCard({
       fields: [{ label: 'Agente', value: 'SupportBot' }],
     })
-    const blocks  = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
-    const factSet = blocks.find((b) => b['type'] === 'FactSet') as Record<string, unknown> | undefined
-    expect(factSet).toBeDefined()
-    const facts = factSet!['facts'] as Array<Record<string, unknown>>
-    expect(facts[0]!['title']).toBe('Agente')
-    expect(facts[0]!['value']).toBe('SupportBot')
+    const body    = (card.content as any).body as any[]
+    const factSet = body.find((b: any) => b.type === 'FactSet')
+    expect(factSet?.facts[0]).toEqual({ title: 'Agente', value: 'SupportBot' })
   })
 
   it('incluye Action.Submit por cada botón', () => {
     const card    = buildAdaptiveRichCard({
       buttons: [{ label: 'Confirmar', value: 'confirm' }],
     })
-    const actions = (card.content as Record<string, unknown>)['actions'] as Array<Record<string, unknown>>
+    const actions = (card.content as any).actions as any[]
     expect(actions).toHaveLength(1)
-    expect(actions[0]!['type']).toBe('Action.Submit')
-    expect((actions[0]!['data'] as Record<string, unknown>)['actionValue']).toBe('confirm')
+    expect(actions[0].type).toBe('Action.Submit')
+    expect(actions[0].data.actionValue).toBe('confirm')
   })
 
   it('no incluye actions si no hay buttons', () => {
     const card    = buildAdaptiveRichCard({ title: 'Solo título' })
-    const content = card.content as Record<string, unknown>
-    expect(content['actions']).toBeUndefined()
-  })
-
-  it('incluye Image block cuando hay imageUrl', () => {
-    const card   = buildAdaptiveRichCard({ imageUrl: 'https://example.com/img.png' })
-    const blocks = (card.content as Record<string, unknown>)['body'] as Array<Record<string, unknown>>
-    const imgBlock = blocks.find((b) => b['type'] === 'Image')
-    expect(imgBlock?.['url']).toBe('https://example.com/img.png')
+    const content = card.content as any
+    expect(content.actions).toBeUndefined()
   })
 })

--- a/apps/gateway/src/channels/teams/index.ts
+++ b/apps/gateway/src/channels/teams/index.ts
@@ -1,0 +1,25 @@
+/**
+ * teams/index.ts — Barrel exports para el módulo Teams
+ * Importar desde aquí en lugar de rutas profundas.
+ */
+
+export type {
+  TeamsMode,
+  TeamsConfig,
+  TeamsSecrets,
+  TeamsIncomingWebhookSecrets,
+  TeamsBotFrameworkSecrets,
+  TeamsActivity,
+  TeamsAttachment,
+  TeamsOutgoingPayload,
+  TeamsSendResult,
+  ITeamsModeStrategy,
+} from './teams-mode.strategy.js'
+
+export {
+  IncomingWebhookStrategy,
+  BotFrameworkStrategy,
+  createTeamsModeStrategy,
+  buildAdaptiveTextCard,
+  buildAdaptiveRichCard,
+} from './teams-mode.strategy.js'

--- a/apps/gateway/src/channels/teams/teams-mode.strategy.ts
+++ b/apps/gateway/src/channels/teams/teams-mode.strategy.ts
@@ -1,0 +1,491 @@
+/**
+ * teams-mode.strategy.ts — [F3a-31]
+ *
+ * Estrategia de modo para Microsoft Teams:
+ *
+ * MODO 1 — incoming_webhook (simple)
+ *   - Solo envía mensajes (unidireccional)
+ *   - No requiere registro en Azure AD
+ *   - Configuración: solo webhookUrl
+ *   - Payloads: JSON simple o Adaptive Card
+ *   - Limitación: no recibe mensajes, no puede responder en hilo
+ *
+ * MODO 2 — bot_framework (completo)
+ *   - Bidireccional (envía y recibe)
+ *   - Requiere: appId + appPassword en Azure AD
+ *   - Autenticación: Bearer token via login.microsoftonline.com
+ *   - Token se renueva automáticamente antes de expirar (buffer 60s)
+ *   - serviceUrl es dinámico por conversación (viene en cada Activity)
+ *   - Respuestas van a: {serviceUrl}/v3/conversations/{conversationId}/activities
+ *   - Adaptive Cards completas con acciones
+ *
+ * Exporta:
+ *   - TeamsMode (type union)
+ *   - ITeamsModeStrategy (interfaz)
+ *   - IncomingWebhookStrategy
+ *   - BotFrameworkStrategy
+ *   - createTeamsModeStrategy (factory)
+ *   - buildAdaptiveTextCard / buildAdaptiveRichCard (helpers)
+ */
+
+// ── Tipos públicos ─────────────────────────────────────────────────────────
+
+export type TeamsMode = 'incoming_webhook' | 'bot_framework'
+
+export interface TeamsIncomingWebhookSecrets {
+  webhookUrl: string
+}
+
+export interface TeamsBotFrameworkSecrets {
+  appId:       string
+  appPassword: string
+}
+
+export type TeamsSecrets =
+  | TeamsIncomingWebhookSecrets
+  | TeamsBotFrameworkSecrets
+
+export interface TeamsConfig {
+  mode?:          TeamsMode
+  defaultLocale?: string    // 'es-ES' | 'en-US'
+  timeoutMs?:     number    // default 10_000
+}
+
+/**
+ * Subset de la Bot Framework Activity schema que el gateway necesita.
+ */
+export interface TeamsActivity {
+  type:        string
+  id?:         string
+  timestamp?:  string
+  serviceUrl:  string
+  channelId:   string
+  from: {
+    id:            string
+    name?:         string
+    aadObjectId?:  string
+  }
+  conversation: {
+    id:        string
+    tenantId?: string
+    isGroup?:  boolean
+  }
+  recipient: {
+    id:    string
+    name?: string
+  }
+  text?:        string
+  textFormat?:  'plain' | 'markdown' | 'xml'
+  attachments?: TeamsAttachment[]
+  channelData?: {
+    tenant?:  { id: string }
+    team?:    { id: string; name?: string }
+    channel?: { id: string; name?: string }
+  }
+  replyToId?: string
+}
+
+export interface TeamsAttachment {
+  contentType:  string
+  content?:     unknown
+  contentUrl?:  string
+  name?:        string
+}
+
+export interface TeamsOutgoingPayload {
+  type:         'message'
+  text?:        string
+  attachments?: TeamsAttachment[]
+  replyToId?:   string
+}
+
+export interface TeamsSendResult {
+  ok:          boolean
+  activityId?: string
+  error?:      string
+}
+
+// ── Interfaz de estrategia ─────────────────────────────────────────────────
+
+export interface ITeamsModeStrategy {
+  readonly mode: TeamsMode
+
+  send(
+    payload:        TeamsOutgoingPayload,
+    conversationId: string,
+    serviceUrl?:    string,
+  ): Promise<TeamsSendResult>
+
+  verify(): Promise<{ ok: boolean; error?: string }>
+
+  buildTextCard(text: string): TeamsAttachment
+
+  getBearerToken?(): Promise<string>
+}
+
+// ── Modo 1: IncomingWebhookStrategy ───────────────────────────────────────
+
+export class IncomingWebhookStrategy implements ITeamsModeStrategy {
+  readonly mode: TeamsMode = 'incoming_webhook'
+
+  private readonly webhookUrl: string
+  private readonly timeoutMs:  number
+
+  constructor(secrets: TeamsIncomingWebhookSecrets, config: Partial<TeamsConfig> = {}) {
+    if (!secrets.webhookUrl?.startsWith('https://')) {
+      throw new Error('[TeamsIncomingWebhook] webhookUrl debe ser una URL HTTPS válida')
+    }
+    this.webhookUrl = secrets.webhookUrl
+    this.timeoutMs  = config.timeoutMs ?? 10_000
+  }
+
+  async send(
+    payload: TeamsOutgoingPayload,
+    _conversationId: string,
+    _serviceUrl?: string,
+  ): Promise<TeamsSendResult> {
+    const body = this._buildWebhookBody(payload)
+    try {
+      const res = await fetch(this.webhookUrl, {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(body),
+        signal:  AbortSignal.timeout(this.timeoutMs),
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        return { ok: false, error: `HTTP ${res.status}: ${text}` }
+      }
+      return { ok: true }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { ok: false, error: msg }
+    }
+  }
+
+  async verify(): Promise<{ ok: boolean; error?: string }> {
+    const result = await this.send(
+      {
+        type:        'message',
+        attachments: [this.buildTextCard('✅ Conexión Teams verificada correctamente.')],
+      },
+      'verify',
+    )
+    return result
+  }
+
+  buildTextCard(text: string): TeamsAttachment {
+    return buildAdaptiveTextCard(text)
+  }
+
+  private _buildWebhookBody(payload: TeamsOutgoingPayload): Record<string, unknown> {
+    if (payload.attachments?.length) {
+      return { type: 'message', attachments: payload.attachments }
+    }
+    if (payload.text) {
+      return { type: 'message', attachments: [this.buildTextCard(payload.text)] }
+    }
+    return { type: 'message', text: '' }
+  }
+}
+
+// ── Modo 2: BotFrameworkStrategy ──────────────────────────────────────────
+
+const TOKEN_ENDPOINT =
+  'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token'
+
+export class BotFrameworkStrategy implements ITeamsModeStrategy {
+  readonly mode: TeamsMode = 'bot_framework'
+
+  private readonly appId:       string
+  private readonly appPassword: string
+  private readonly timeoutMs:   number
+
+  private tokenCache: {
+    accessToken: string
+    expiresAtMs: number
+  } | null = null
+
+  constructor(secrets: TeamsBotFrameworkSecrets, config: Partial<TeamsConfig> = {}) {
+    if (!secrets.appId?.trim()) {
+      throw new Error('[TeamsBotFramework] appId es requerido')
+    }
+    if (!secrets.appPassword?.trim()) {
+      throw new Error('[TeamsBotFramework] appPassword es requerido')
+    }
+    this.appId       = secrets.appId
+    this.appPassword = secrets.appPassword
+    this.timeoutMs   = config.timeoutMs ?? 10_000
+  }
+
+  async send(
+    payload:        TeamsOutgoingPayload,
+    conversationId: string,
+    serviceUrl?:    string,
+  ): Promise<TeamsSendResult> {
+    if (!serviceUrl) {
+      return {
+        ok:    false,
+        error: '[TeamsBotFramework] serviceUrl es requerido para enviar mensajes. ' +
+               'Debe tomarse del Activity.serviceUrl recibido en el webhook entrante.',
+      }
+    }
+    if (!conversationId) {
+      return { ok: false, error: '[TeamsBotFramework] conversationId es requerido' }
+    }
+
+    let token: string
+    try {
+      token = await this.getBearerToken()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { ok: false, error: `Auth error: ${msg}` }
+    }
+
+    const url      = `${serviceUrl.replace(/\/$/, '')}/v3/conversations/${conversationId}/activities`
+    const activity = this._buildActivity(payload)
+
+    try {
+      const res = await fetch(url, {
+        method:  'POST',
+        headers: {
+          Authorization:  `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body:   JSON.stringify(activity),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+
+      if (!res.ok) {
+        const text = await res.text()
+        return { ok: false, error: `HTTP ${res.status}: ${text}` }
+      }
+
+      const data = await res.json() as { id?: string }
+      return { ok: true, activityId: data.id }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { ok: false, error: msg }
+    }
+  }
+
+  async verify(): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await this.getBearerToken()
+      return { ok: true }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { ok: false, error: `Token acquisition failed: ${msg}` }
+    }
+  }
+
+  buildTextCard(text: string): TeamsAttachment {
+    return buildAdaptiveTextCard(text)
+  }
+
+  /**
+   * Obtiene el Bearer token actual, renovándolo si quedan < 60s para expirar.
+   * Endpoint: https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token
+   */
+  async getBearerToken(): Promise<string> {
+    const RENEW_BUFFER_MS = 60_000
+
+    if (
+      this.tokenCache &&
+      Date.now() < this.tokenCache.expiresAtMs - RENEW_BUFFER_MS
+    ) {
+      return this.tokenCache.accessToken
+    }
+
+    const params = new URLSearchParams({
+      grant_type:    'client_credentials',
+      client_id:     this.appId,
+      client_secret: this.appPassword,
+      scope:         'https://api.botframework.com/.default',
+    })
+
+    const res = await fetch(TOKEN_ENDPOINT, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body:    params.toString(),
+      signal:  AbortSignal.timeout(this.timeoutMs),
+    })
+
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`[TeamsBotFramework] Token request failed ${res.status}: ${text}`)
+    }
+
+    const data = await res.json() as {
+      access_token: string
+      expires_in:   number
+      token_type:   string
+    }
+
+    if (!data.access_token) {
+      throw new Error('[TeamsBotFramework] Token response missing access_token')
+    }
+
+    this.tokenCache = {
+      accessToken: data.access_token,
+      expiresAtMs: Date.now() + data.expires_in * 1000,
+    }
+
+    return this.tokenCache.accessToken
+  }
+
+  private _buildActivity(payload: TeamsOutgoingPayload): Record<string, unknown> {
+    const activity: Record<string, unknown> = { type: 'message' }
+    if (payload.text) {
+      activity['text']       = payload.text
+      activity['textFormat'] = 'markdown'
+    }
+    if (payload.attachments?.length) {
+      activity['attachments'] = payload.attachments
+    }
+    if (payload.replyToId) {
+      activity['replyToId'] = payload.replyToId
+    }
+    return activity
+  }
+}
+
+// ── Factory ────────────────────────────────────────────────────────────────
+
+/**
+ * Crea la estrategia correcta según el modo configurado.
+ * Detección automática:
+ *   - secrets.webhookUrl presente → incoming_webhook
+ *   - secrets.appId + appPassword → bot_framework
+ * config.mode tiene prioridad si está explícito.
+ */
+export function createTeamsModeStrategy(
+  config:  Partial<TeamsConfig>,
+  secrets: Record<string, unknown>,
+): ITeamsModeStrategy {
+  const detectedMode: TeamsMode =
+    config.mode ??
+    ('webhookUrl' in secrets && typeof secrets['webhookUrl'] === 'string'
+      ? 'incoming_webhook'
+      : 'bot_framework')
+
+  if (detectedMode === 'incoming_webhook') {
+    if (!secrets['webhookUrl']) {
+      throw new Error(
+        '[Teams] Modo incoming_webhook requiere secrets.webhookUrl. ' +
+        'Obtenerlo en Teams → Canal → Conectores → Incoming Webhook.',
+      )
+    }
+    return new IncomingWebhookStrategy(
+      { webhookUrl: secrets['webhookUrl'] as string },
+      config,
+    )
+  }
+
+  if (!secrets['appId'] || !secrets['appPassword']) {
+    throw new Error(
+      '[Teams] Modo bot_framework requiere secrets.appId y secrets.appPassword. ' +
+      'Registrar el bot en https://dev.botframework.com y obtener las credenciales.',
+    )
+  }
+
+  return new BotFrameworkStrategy(
+    {
+      appId:       secrets['appId']       as string,
+      appPassword: secrets['appPassword'] as string,
+    },
+    config,
+  )
+}
+
+// ── Helpers de Adaptive Card ───────────────────────────────────────────────
+
+/**
+ * Adaptive Card mínima de texto plano (schema v1.5).
+ * Soporta Markdown básico en el TextBlock.
+ */
+export function buildAdaptiveTextCard(text: string): TeamsAttachment {
+  return {
+    contentType: 'application/vnd.microsoft.card.adaptive',
+    content: {
+      $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+      type:    'AdaptiveCard',
+      version: '1.5',
+      body: [
+        {
+          type:     'TextBlock',
+          text,
+          wrap:     true,
+          markdown: true,
+        },
+      ],
+    },
+  }
+}
+
+/**
+ * Adaptive Card rica con título, descripción, facts, imagen y botones.
+ * Usada por AgentExecutor para respuestas con richContent.
+ */
+export function buildAdaptiveRichCard(opts: {
+  title?:       string
+  description?: string
+  fields?:      Array<{ label: string; value: string }>
+  buttons?:     Array<{ label: string; value: string }>
+  imageUrl?:    string
+}): TeamsAttachment {
+  const body: unknown[] = []
+
+  if (opts.title) {
+    body.push({
+      type:   'TextBlock',
+      text:   opts.title,
+      weight: 'Bolder',
+      size:   'Medium',
+      wrap:   true,
+    })
+  }
+
+  if (opts.description) {
+    body.push({
+      type:     'TextBlock',
+      text:     opts.description,
+      wrap:     true,
+      markdown: true,
+      spacing:  'Small',
+    })
+  }
+
+  if (opts.imageUrl) {
+    body.push({
+      type:    'Image',
+      url:     opts.imageUrl,
+      size:    'Stretch',
+      spacing: 'Small',
+    })
+  }
+
+  if (opts.fields?.length) {
+    body.push({
+      type:  'FactSet',
+      facts: opts.fields.map((f) => ({ title: f.label, value: f.value })),
+    })
+  }
+
+  const actions = opts.buttons?.map((b) => ({
+    type:  'Action.Submit',
+    title: b.label,
+    data:  { actionValue: b.value },
+  })) ?? []
+
+  return {
+    contentType: 'application/vnd.microsoft.card.adaptive',
+    content: {
+      $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',
+      type:    'AdaptiveCard',
+      version: '1.5',
+      body,
+      ...(actions.length ? { actions } : {}),
+    },
+  }
+}

--- a/apps/gateway/src/channels/teams/teams-mode.strategy.ts
+++ b/apps/gateway/src/channels/teams/teams-mode.strategy.ts
@@ -14,7 +14,7 @@
  *   - Bidireccional (envía y recibe)
  *   - Requiere: appId + appPassword en Azure AD
  *   - Autenticación: Bearer token via login.microsoftonline.com
- *   - Token se renueva automáticamente antes de expirar (buffer 60s)
+ *   - Token se renueva automáticamente antes de expirar
  *   - serviceUrl es dinámico por conversación (viene en cada Activity)
  *   - Respuestas van a: {serviceUrl}/v3/conversations/{conversationId}/activities
  *   - Adaptive Cards completas con acciones
@@ -25,13 +25,13 @@
  *   - IncomingWebhookStrategy
  *   - BotFrameworkStrategy
  *   - createTeamsModeStrategy (factory)
- *   - buildAdaptiveTextCard / buildAdaptiveRichCard (helpers)
  */
 
-// ── Tipos públicos ─────────────────────────────────────────────────────────
+// ── Tipos públicos ────────────────────────────────────────────────────────────
 
 export type TeamsMode = 'incoming_webhook' | 'bot_framework'
 
+/** Credenciales según el modo */
 export interface TeamsIncomingWebhookSecrets {
   webhookUrl: string
 }
@@ -45,86 +45,126 @@ export type TeamsSecrets =
   | TeamsIncomingWebhookSecrets
   | TeamsBotFrameworkSecrets
 
+/** Configuración adicional (no sensible) */
 export interface TeamsConfig {
-  mode?:          TeamsMode
-  defaultLocale?: string    // 'es-ES' | 'en-US'
-  timeoutMs?:     number    // default 10_000
+  mode:          TeamsMode
+  defaultLocale?: string   // 'es-ES' | 'en-US' — para Adaptive Cards
+  timeoutMs?:    number    // timeout de fetch a Teams API (default 10s)
 }
 
 /**
- * Subset de la Bot Framework Activity schema que el gateway necesita.
+ * Payload de una Activity de Teams (Bot Framework Activity schema).
+ * Solo los campos que el gateway necesita procesar.
  */
 export interface TeamsActivity {
-  type:        string
-  id?:         string
-  timestamp?:  string
-  serviceUrl:  string
-  channelId:   string
+  type:           string        // 'message' | 'conversationUpdate' | 'invoke' | ...
+  id?:            string        // activityId
+  timestamp?:     string        // ISO 8601
+  serviceUrl:     string        // URL dinámica del Bot Framework Service
+  channelId:      string        // siempre 'msteams'
   from: {
-    id:            string
-    name?:         string
-    aadObjectId?:  string
+    id:           string        // userId o botId
+    name?:        string
+    aadObjectId?: string        // Azure AD Object ID del usuario
   }
   conversation: {
-    id:        string
-    tenantId?: string
-    isGroup?:  boolean
+    id:           string        // conversationId
+    tenantId?:    string
+    isGroup?:     boolean
   }
   recipient: {
-    id:    string
-    name?: string
+    id:           string        // botId
+    name?:        string
   }
-  text?:        string
-  textFormat?:  'plain' | 'markdown' | 'xml'
-  attachments?: TeamsAttachment[]
+  text?:          string        // contenido del mensaje
+  textFormat?:    'plain' | 'markdown' | 'xml'
+  attachments?:   TeamsAttachment[]
   channelData?: {
-    tenant?:  { id: string }
-    team?:    { id: string; name?: string }
-    channel?: { id: string; name?: string }
+    tenant?:     { id: string }
+    team?:       { id: string; name?: string }
+    channel?:    { id: string; name?: string }
   }
-  replyToId?: string
+  replyToId?:     string        // activityId al que responde (para hilos)
 }
 
 export interface TeamsAttachment {
-  contentType:  string
-  content?:     unknown
+  contentType:  string          // 'application/vnd.microsoft.card.adaptive' | etc.
+  content?:     unknown         // Adaptive Card JSON schema
   contentUrl?:  string
   name?:        string
 }
 
+/** Mensaje de salida Teams (texto plano o Adaptive Card) */
 export interface TeamsOutgoingPayload {
   type:         'message'
   text?:        string
   attachments?: TeamsAttachment[]
+  /** Solo bot_framework: activityId al que responder en hilo */
   replyToId?:   string
 }
 
+/** Resultado de un envío Teams */
 export interface TeamsSendResult {
-  ok:          boolean
-  activityId?: string
-  error?:      string
+  ok:           boolean
+  activityId?:  string   // ID de la Activity creada por Teams
+  error?:       string
 }
 
-// ── Interfaz de estrategia ─────────────────────────────────────────────────
+// ── Interfaz de estrategia ────────────────────────────────────────────────────
 
+/**
+ * Contrato que deben implementar las dos estrategias.
+ * El TeamsAdapter (F3a-32) llama solo a estos métodos —
+ * nunca sabe si está en modo webhook o bot_framework.
+ */
 export interface ITeamsModeStrategy {
   readonly mode: TeamsMode
 
+  /**
+   * Envía un mensaje o Adaptive Card.
+   * - incoming_webhook: POST a webhookUrl con el payload
+   * - bot_framework:    POST a {serviceUrl}/v3/conversations/{id}/activities
+   */
   send(
     payload:        TeamsOutgoingPayload,
     conversationId: string,
     serviceUrl?:    string,
   ): Promise<TeamsSendResult>
 
+  /**
+   * Verifica que las credenciales son válidas.
+   * - incoming_webhook: POST mínimo al webhookUrl (texto vacío)
+   * - bot_framework:    obtener Bearer token (falla si appId/password incorrectos)
+   */
   verify(): Promise<{ ok: boolean; error?: string }>
 
+  /**
+   * Construye un Adaptive Card de texto plano (fallback universal).
+   * Ambos modos pueden enviar Adaptive Cards — este helper
+   * estandariza la creación para texto simple.
+   */
   buildTextCard(text: string): TeamsAttachment
 
+  /**
+   * Solo bot_framework: devuelve el Bearer token actual (renueva si expiró).
+   * incoming_webhook: lanza un error (no aplica).
+   */
   getBearerToken?(): Promise<string>
 }
 
-// ── Modo 1: IncomingWebhookStrategy ───────────────────────────────────────
+// ── Modo 1: IncomingWebhookStrategy ──────────────────────────────────────────
 
+/**
+ * Estrategia simple de Incoming Webhook.
+ *
+ * Microsoft Teams Incoming Webhooks aceptan:
+ *   1. Mensaje de texto: { text: "..." }
+ *   2. MessageCard legacy: { "@type": "MessageCard", ... }
+ *   3. Adaptive Card via Attachment: { type: "message", attachments: [...] }
+ *
+ * Esta implementación usa siempre Adaptive Card para consistencia
+ * con la experiencia bot_framework.
+ */
 export class IncomingWebhookStrategy implements ITeamsModeStrategy {
   readonly mode: TeamsMode = 'incoming_webhook'
 
@@ -139,12 +179,10 @@ export class IncomingWebhookStrategy implements ITeamsModeStrategy {
     this.timeoutMs  = config.timeoutMs ?? 10_000
   }
 
-  async send(
-    payload: TeamsOutgoingPayload,
-    _conversationId: string,
-    _serviceUrl?: string,
-  ): Promise<TeamsSendResult> {
+  async send(payload: TeamsOutgoingPayload): Promise<TeamsSendResult> {
+    // Incoming Webhook no usa conversationId ni serviceUrl
     const body = this._buildWebhookBody(payload)
+
     try {
       const res = await fetch(this.webhookUrl, {
         method:  'POST',
@@ -152,10 +190,13 @@ export class IncomingWebhookStrategy implements ITeamsModeStrategy {
         body:    JSON.stringify(body),
         signal:  AbortSignal.timeout(this.timeoutMs),
       })
+
+      // Teams Incoming Webhook devuelve "1" como body en éxito
       if (!res.ok) {
         const text = await res.text()
         return { ok: false, error: `HTTP ${res.status}: ${text}` }
       }
+
       return { ok: true }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
@@ -164,13 +205,11 @@ export class IncomingWebhookStrategy implements ITeamsModeStrategy {
   }
 
   async verify(): Promise<{ ok: boolean; error?: string }> {
-    const result = await this.send(
-      {
-        type:        'message',
-        attachments: [this.buildTextCard('✅ Conexión Teams verificada correctamente.')],
-      },
-      'verify',
-    )
+    // Enviar un mensaje de prueba vacío para verificar conectividad
+    const result = await this.send({
+      type: 'message',
+      attachments: [this.buildTextCard('✅ Conexión Teams verificada correctamente.')],
+    })
     return result
   }
 
@@ -178,22 +217,49 @@ export class IncomingWebhookStrategy implements ITeamsModeStrategy {
     return buildAdaptiveTextCard(text)
   }
 
+  // ── Helper privado ─────────────────────────────────────────────────────────
+
   private _buildWebhookBody(payload: TeamsOutgoingPayload): Record<string, unknown> {
+    // Si el payload tiene attachments (Adaptive Cards), usar formato de mensaje
     if (payload.attachments?.length) {
-      return { type: 'message', attachments: payload.attachments }
+      return {
+        type:        'message',
+        attachments: payload.attachments,
+      }
     }
+
+    // Texto plano: envolver en Adaptive Card para consistencia visual
     if (payload.text) {
-      return { type: 'message', attachments: [this.buildTextCard(payload.text)] }
+      return {
+        type:        'message',
+        attachments: [this.buildTextCard(payload.text)],
+      }
     }
+
     return { type: 'message', text: '' }
   }
 }
 
-// ── Modo 2: BotFrameworkStrategy ──────────────────────────────────────────
+// ── Modo 2: BotFrameworkStrategy ─────────────────────────────────────────────
 
-const TOKEN_ENDPOINT =
-  'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token'
-
+/**
+ * Estrategia Bot Framework completa.
+ *
+ * Flujo de autenticación:
+ *   1. POST https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token
+ *      con grant_type=client_credentials, client_id=appId, client_secret=appPassword
+ *      scope=https://api.botframework.com/.default
+ *   2. Guardar access_token + expires_in (segundos)
+ *   3. Renovar cuando quedan < 60s para expirar
+ *
+ * Flujo de envío:
+ *   POST {serviceUrl}/v3/conversations/{conversationId}/activities
+ *   Authorization: Bearer {access_token}
+ *   Body: Activity JSON
+ *
+ * IMPORTANTE: serviceUrl es dinámico — viene en cada Activity entrante
+ * (body.serviceUrl). Nunca usar una URL fija de Teams.
+ */
 export class BotFrameworkStrategy implements ITeamsModeStrategy {
   readonly mode: TeamsMode = 'bot_framework'
 
@@ -202,8 +268,8 @@ export class BotFrameworkStrategy implements ITeamsModeStrategy {
   private readonly timeoutMs:   number
 
   private tokenCache: {
-    accessToken: string
-    expiresAtMs: number
+    accessToken:  string
+    expiresAtMs:  number
   } | null = null
 
   constructor(secrets: TeamsBotFrameworkSecrets, config: Partial<TeamsConfig> = {}) {
@@ -230,6 +296,7 @@ export class BotFrameworkStrategy implements ITeamsModeStrategy {
                'Debe tomarse del Activity.serviceUrl recibido en el webhook entrante.',
       }
     }
+
     if (!conversationId) {
       return { ok: false, error: '[TeamsBotFramework] conversationId es requerido' }
     }
@@ -249,8 +316,8 @@ export class BotFrameworkStrategy implements ITeamsModeStrategy {
       const res = await fetch(url, {
         method:  'POST',
         headers: {
-          Authorization:  `Bearer ${token}`,
-          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+          'Content-Type':  'application/json',
         },
         body:   JSON.stringify(activity),
         signal: AbortSignal.timeout(this.timeoutMs),
@@ -284,11 +351,13 @@ export class BotFrameworkStrategy implements ITeamsModeStrategy {
   }
 
   /**
-   * Obtiene el Bearer token actual, renovándolo si quedan < 60s para expirar.
+   * Obtiene el Bearer token actual, renovándolo automáticamente
+   * si ya expiró o quedan menos de 60 segundos para expirar.
+   *
    * Endpoint: https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token
    */
   async getBearerToken(): Promise<string> {
-    const RENEW_BUFFER_MS = 60_000
+    const RENEW_BUFFER_MS = 60_000  // renovar 60s antes de expirar
 
     if (
       this.tokenCache &&
@@ -304,12 +373,15 @@ export class BotFrameworkStrategy implements ITeamsModeStrategy {
       scope:         'https://api.botframework.com/.default',
     })
 
-    const res = await fetch(TOKEN_ENDPOINT, {
-      method:  'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body:    params.toString(),
-      signal:  AbortSignal.timeout(this.timeoutMs),
-    })
+    const res = await fetch(
+      'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
+      {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body:    params.toString(),
+        signal:  AbortSignal.timeout(this.timeoutMs),
+      },
+    )
 
     if (!res.ok) {
       const text = await res.text()
@@ -327,42 +399,57 @@ export class BotFrameworkStrategy implements ITeamsModeStrategy {
     }
 
     this.tokenCache = {
-      accessToken: data.access_token,
-      expiresAtMs: Date.now() + data.expires_in * 1000,
+      accessToken:  data.access_token,
+      expiresAtMs:  Date.now() + data.expires_in * 1000,
     }
 
     return this.tokenCache.accessToken
   }
 
+  // ── Helper privado ─────────────────────────────────────────────────────────
+
   private _buildActivity(payload: TeamsOutgoingPayload): Record<string, unknown> {
-    const activity: Record<string, unknown> = { type: 'message' }
+    const activity: Record<string, unknown> = {
+      type: 'message',
+    }
+
     if (payload.text) {
       activity['text']       = payload.text
       activity['textFormat'] = 'markdown'
     }
+
     if (payload.attachments?.length) {
       activity['attachments'] = payload.attachments
     }
+
     if (payload.replyToId) {
       activity['replyToId'] = payload.replyToId
     }
+
     return activity
   }
 }
 
-// ── Factory ────────────────────────────────────────────────────────────────
+// ── Factory: createTeamsModeStrategy ─────────────────────────────────────────
 
 /**
- * Crea la estrategia correcta según el modo configurado.
- * Detección automática:
- *   - secrets.webhookUrl presente → incoming_webhook
- *   - secrets.appId + appPassword → bot_framework
- * config.mode tiene prioridad si está explícito.
+ * Factory que crea la estrategia correcta según el modo configurado.
+ *
+ * Uso en TeamsAdapter (F3a-32):
+ *   const strategy = createTeamsModeStrategy(config, secrets)
+ *   await strategy.verify()
+ *   await strategy.send({ type: 'message', text: '...' }, conversationId, serviceUrl)
+ *
+ * Detección automática de modo:
+ *   - Si secrets tiene 'webhookUrl' → incoming_webhook
+ *   - Si secrets tiene 'appId' y 'appPassword' → bot_framework
+ *   - config.mode tiene prioridad si está explícito
  */
 export function createTeamsModeStrategy(
   config:  Partial<TeamsConfig>,
   secrets: Record<string, unknown>,
 ): ITeamsModeStrategy {
+  // Detectar modo: config explícito tiene prioridad
   const detectedMode: TeamsMode =
     config.mode ??
     ('webhookUrl' in secrets && typeof secrets['webhookUrl'] === 'string'
@@ -382,6 +469,7 @@ export function createTeamsModeStrategy(
     )
   }
 
+  // bot_framework
   if (!secrets['appId'] || !secrets['appPassword']) {
     throw new Error(
       '[Teams] Modo bot_framework requiere secrets.appId y secrets.appPassword. ' +
@@ -398,11 +486,13 @@ export function createTeamsModeStrategy(
   )
 }
 
-// ── Helpers de Adaptive Card ───────────────────────────────────────────────
+// ── Helpers compartidos ───────────────────────────────────────────────────────
 
 /**
- * Adaptive Card mínima de texto plano (schema v1.5).
- * Soporta Markdown básico en el TextBlock.
+ * Construye un Adaptive Card mínimo de texto plano (schema v1.5).
+ * Compatible con Teams, Outlook, y otros hosts de Adaptive Cards.
+ *
+ * El texto soporta Markdown básico: **negrita**, *cursiva*, listas.
  */
 export function buildAdaptiveTextCard(text: string): TeamsAttachment {
   return {
@@ -424,8 +514,8 @@ export function buildAdaptiveTextCard(text: string): TeamsAttachment {
 }
 
 /**
- * Adaptive Card rica con título, descripción, facts, imagen y botones.
- * Usada por AgentExecutor para respuestas con richContent.
+ * Construye un Adaptive Card con título, descripción y botones de acción.
+ * Usado por el AgentExecutor para respuestas con richContent.
  */
 export function buildAdaptiveRichCard(opts: {
   title?:       string
@@ -466,10 +556,11 @@ export function buildAdaptiveRichCard(opts: {
   }
 
   if (opts.fields?.length) {
-    body.push({
+    const factSet = {
       type:  'FactSet',
       facts: opts.fields.map((f) => ({ title: f.label, value: f.value })),
-    })
+    }
+    body.push(factSet)
   }
 
   const actions = opts.buttons?.map((b) => ({

--- a/apps/gateway/src/tests/e2e/discord.e2e-spec.ts
+++ b/apps/gateway/src/tests/e2e/discord.e2e-spec.ts
@@ -1,487 +1,711 @@
 /**
- * discord.e2e-spec.ts — [F3a-27] Tests E2E Discord slash commands
+ * discord.e2e-spec.ts — [F3a-30]
  *
- * Valida los 6 escenarios del criterio de aceptación de F3a-27:
- *   1. /ask con binding por channelId → AgentExecutor llamado → respuesta recibida
- *   2. /ask con binding por guildId (sin channel binding) → funciona como fallback
- *   3. /ask sin binding → devuelve mensaje de error legible (no lanza excepción)
- *   4. /status con binding → muestra agentId y scope correcto
- *   5. /status sin binding → devuelve instrucciones de configuración
- *   6. body inválido (faltan campos) → parseInteractionBody retorna null (no crash)
+ * Tests E2E del flujo Discord:
+ *   Webhook HTTP → DiscordAdapter → IncomingMessage
+ *   → MessageDispatcher → AgentExecutor (mock)
+ *   → sendFollowup / sendToChannel → respuesta Discord API (fetch mock)
  *
- * Sin Discord real: usa mocks para Prisma y AgentExecutor.
- * Compatible con Jest / Vitest (describe/it/expect).
+ * Estrategia de mocking:
+ *   - fetch global: mockeado con jest.spyOn para capturar llamadas a Discord API
+ *   - IAgentExecutor: jest.fn() que devuelve respuesta configurable
+ *   - Ed25519 signature: DiscordAdapter._verifySignature mockeado a true
+ *   - Prisma: NO se usa en estos tests (no hay BD)
+ *
+ * Estructura de suites:
+ *   1. Ping de Discord (type=1)
+ *   2. Slash command /ask (http mode — webhook type=2)
+ *   3. Slash command /status (http mode — webhook type=2)
+ *   4. Componente interactivo — botón (http mode — webhook type=3)
+ *   5. sendToChannel — respuesta proactiva
+ *   6. MessageDispatcher — errores y edge cases
+ *   7. Edge cases de DiscordAdapter
  */
 
-import {
-  DiscordCommandDispatcher,
-  makeBindingResolver,
-  parseInteractionBody,
-  type CommandInteractionContext,
-  type DiscordBindingResult,
-  type DiscordChannelBinding,
-} from '../../channels/discord.commands.js'
+import { EventEmitter }      from 'node:events'
+import express               from 'express'
+import request               from 'supertest'
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures
-// ─────────────────────────────────────────────────────────────────────────────
+import { DiscordAdapter }    from '../../channels/discord.adapter.js'
+import { MessageDispatcher } from '../../message-dispatcher.service.js'
+import type {
+  IAgentExecutor,
+  DispatchInput,
+  DispatchSuccess,
+  DispatchFailure,
+}                            from '../../message-dispatcher.types.js'
+import type { IncomingMessage } from '../../channels/channel-adapter.interface.js'
 
-const GUILD_ID   = 'guild-abc-123'
-const CHANNEL_ID = 'channel-xyz-456'
-const AGENT_ID   = 'agent-001'
-const CONFIG_ID  = 'cfg-001'
-const USER_ID    = 'user-999'
+// ── Fixtures ──────────────────────────────────────────────────────────────────
 
-/** Crea un CommandInteractionContext mínimo para los tests */
-function makeCtx(
-  commandName: string,
-  overrides: Partial<CommandInteractionContext> = {},
-): CommandInteractionContext {
+const FAKE_BOT_TOKEN   = 'Bot_fake_token_for_tests'
+const FAKE_APP_ID      = '111111111111111111'
+const FAKE_GUILD_ID    = '222222222222222222'
+const FAKE_CHANNEL_ID  = '333333333333333333'
+const FAKE_USER_ID     = '444444444444444444'
+const FAKE_INT_TOKEN   = 'fake_interaction_token_xyz'
+const FAKE_CHANNEL_CFG = 'channel-config-uuid-test'
+const FAKE_AGENT_ID    = 'agent-uuid-test'
+const FAKE_SESSION_ID  = 'session-test-001'
+
+/** Crea un body de interacción tipo APPLICATION_COMMAND (type=2) */
+function makeSlashInteraction(commandName: string, optionValue?: string) {
   return {
-    commandName,
-    guildId:          GUILD_ID,
-    channelId:        CHANNEL_ID,
-    userId:           USER_ID,
-    username:         'testuser',
-    interactionId:    'iid-001',
-    interactionToken: 'tok-abc',
-    options:          {},
+    id:             '555555555555555555',
+    type:           2,
+    token:          FAKE_INT_TOKEN,
+    application_id: FAKE_APP_ID,
+    guild_id:       FAKE_GUILD_ID,
+    channel_id:     FAKE_CHANNEL_ID,
+    member: {
+      user: {
+        id:            FAKE_USER_ID,
+        username:      'testuser',
+        discriminator: '0001',
+        global_name:   'Test User',
+      },
+    },
+    data: {
+      id:      '666666666666666666',
+      name:    commandName,
+      options: optionValue
+        ? [{ name: 'question', type: 3, value: optionValue }]
+        : [],
+    },
+  }
+}
+
+/** Crea un body de interacción tipo MESSAGE_COMPONENT (type=3) — botón */
+function makeButtonInteraction(customId: string) {
+  return {
+    id:             '777777777777777777',
+    type:           3,
+    token:          FAKE_INT_TOKEN,
+    application_id: FAKE_APP_ID,
+    guild_id:       FAKE_GUILD_ID,
+    channel_id:     FAKE_CHANNEL_ID,
+    member: {
+      user: {
+        id:            FAKE_USER_ID,
+        username:      'testuser',
+        discriminator: '0001',
+        global_name:   'Test User',
+      },
+    },
+    data: {
+      custom_id:      customId,
+      component_type: 2,  // BUTTON
+    },
+  }
+}
+
+/** Crea un DispatchInput válido con la firma real del tipo */
+function makeDispatchInput(overrides: Partial<DispatchInput> = {}): DispatchInput {
+  return {
+    sessionId:       FAKE_SESSION_ID,
+    agentId:         FAKE_AGENT_ID,
+    channelConfigId: FAKE_CHANNEL_CFG,
+    externalUserId:  FAKE_USER_ID,
+    history: [
+      { role: 'user', content: '¿Cuál es el estado del proyecto?' },
+    ],
     ...overrides,
   }
 }
 
-/** Binding que vincula por channelId */
-const CHANNEL_BINDING: DiscordChannelBinding = {
-  agentId:           AGENT_ID,
-  channelConfigId:   CONFIG_ID,
-  externalChannelId: CHANNEL_ID,
-  externalGuildId:   null,
-}
+// ── Harness compartido ───────────────────────────────────────────────────────────
 
-/** Binding que vincula por guildId (sin channelId específico) */
-const GUILD_BINDING: DiscordChannelBinding = {
-  agentId:           AGENT_ID,
-  channelConfigId:   CONFIG_ID,
-  externalChannelId: null,
-  externalGuildId:   GUILD_ID,
-}
+async function buildTestHarness(agentReply = 'Respuesta del agente de prueba') {
+  // Mock global de fetch — simula Discord API respondiendo OK
+  const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+    async (url: RequestInfo | URL) => {
+      const urlStr = typeof url === 'string' ? url : (url as URL).toString()
+      if (urlStr.includes('discord.com/api')) {
+        return new Response(JSON.stringify({ id: 'mock_message_id' }), {
+          status:  200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      throw new Error(`fetch no mockeada para URL: ${urlStr}`)
+    },
+  )
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Mock de AgentExecutor
-// ─────────────────────────────────────────────────────────────────────────────
-
-/** Mock de runAgent — registra la llamada y devuelve respuesta fija */
-function makeMockAgent(response = '¡Hola! Soy el agente.') {
-  const calls: Array<{ binding: DiscordBindingResult; userId: string; prompt: string }> = []
-
-  const runAgent = async (
-    binding: DiscordBindingResult,
-    userId:  string,
-    prompt:  string,
-  ): Promise<string> => {
-    calls.push({ binding, userId, prompt })
-    return response
+  // AgentExecutor mock
+  const mockExecutor: IAgentExecutor = {
+    run: jest.fn().mockResolvedValue({ reply: agentReply }),
   }
 
-  return { runAgent, calls }
+  // DiscordAdapter en modo http
+  const adapter = new DiscordAdapter()
+  adapter.initialize(FAKE_CHANNEL_CFG)
+
+  // Mockear verificación de firma para que siempre pase
+  jest.spyOn(adapter as any, '_verifySignature').mockReturnValue(true)
+
+  await adapter.setup(
+    { applicationId: FAKE_APP_ID, guildId: FAKE_GUILD_ID },
+    { botToken: FAKE_BOT_TOKEN, publicKey: 'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899' },
+    'http',
+  )
+
+  // MessageDispatcher
+  const dispatcher = new MessageDispatcher(mockExecutor, {
+    timeoutMs:    5_000,
+    maxAttempts:  1,
+    retryDelayMs: 50,
+  })
+
+  // App Express
+  const app = express()
+  app.use(express.json())
+  app.use('/discord', adapter.buildHttpRouter())
+
+  // Capturar IncomingMessages
+  const capturedMessages: IncomingMessage[] = []
+  adapter.onMessage((msg) => capturedMessages.push(msg))
+
+  return { adapter, dispatcher, mockExecutor, fetchSpy, app, capturedMessages }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Helper: build dispatcher
-// ─────────────────────────────────────────────────────────────────────────────
+// ── Suite 1: Ping de Discord ─────────────────────────────────────────────────
 
-function buildDispatcher(
-  bindings: DiscordChannelBinding[],
-  agentResponse = '¡Hola! Soy el agente.',
-) {
-  const { runAgent, calls } = makeMockAgent(agentResponse)
-  const resolveBinding      = makeBindingResolver(bindings)
-  const dispatcher          = new DiscordCommandDispatcher(resolveBinding, runAgent)
-  return { dispatcher, calls }
-}
+describe('Discord E2E — Ping (type=1)', () => {
+  let harness: Awaited<ReturnType<typeof buildTestHarness>>
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Suite principal
-// ─────────────────────────────────────────────────────────────────────────────
+  beforeEach(async () => { harness = await buildTestHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
 
-describe('[F3a-27] DiscordCommandDispatcher — slash commands E2E', () => {
+  it('responde { type: 1 } al ping de verificación de Discord', async () => {
+    const res = await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send({ type: 1 })
+      .expect(200)
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario 1: /ask con binding por channelId
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('/ask con binding por channelId', () => {
-    it('llama a AgentExecutor y devuelve la respuesta', async () => {
-      const { dispatcher, calls } = buildDispatcher([CHANNEL_BINDING])
-
-      const ctx = makeCtx('ask', { options: { prompt: '¿Cuál es el estado?' } })
-      const reply = await dispatcher.dispatch(ctx)
-
-      // AgentExecutor fue llamado exactamente una vez
-      expect(calls).toHaveLength(1)
-
-      // La llamada usó el binding de canal correcto
-      expect(calls[0]!.binding.scopeLevel).toBe('channel')
-      expect(calls[0]!.binding.agentId).toBe(AGENT_ID)
-      expect(calls[0]!.binding.scopeId).toBe(CHANNEL_ID)
-
-      // El prompt llegó correctamente
-      expect(calls[0]!.prompt).toBe('¿Cuál es el estado?')
-      expect(calls[0]!.userId).toBe(USER_ID)
-
-      // La respuesta contiene el texto del agente
-      expect(reply).toBe('¡Hola! Soy el agente.')
-    })
-
-    it('trunca respuestas largas a 2000 caracteres', async () => {
-      const longResponse = 'x'.repeat(3000)
-      const { dispatcher } = buildDispatcher([CHANNEL_BINDING], longResponse)
-
-      const ctx = makeCtx('ask', { options: { prompt: 'pregunta' } })
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply.length).toBe(2000)
-    })
-
-    it('prioriza channelBinding sobre guildBinding si ambos existen', async () => {
-      // Ambos bindings disponibles — debe ganar el de canal
-      const channelBindingAlt: DiscordChannelBinding = {
-        agentId:           'agent-channel-priority',
-        channelConfigId:   'cfg-channel',
-        externalChannelId: CHANNEL_ID,
-        externalGuildId:   null,
-      }
-      const guildBindingAlt: DiscordChannelBinding = {
-        agentId:           'agent-guild-fallback',
-        channelConfigId:   'cfg-guild',
-        externalChannelId: null,
-        externalGuildId:   GUILD_ID,
-      }
-
-      const { dispatcher, calls } = buildDispatcher([guildBindingAlt, channelBindingAlt])
-      const ctx = makeCtx('ask', { options: { prompt: 'test' } })
-      await dispatcher.dispatch(ctx)
-
-      expect(calls[0]!.binding.agentId).toBe('agent-channel-priority')
-      expect(calls[0]!.binding.scopeLevel).toBe('channel')
-    })
+    expect(res.body).toEqual({ type: 1 })
   })
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario 2: /ask con binding por guildId (fallback)
-  // ──────────────────────────────────────────────────────────────────────────
+  it('no emite IncomingMessage en un ping (type=1)', async () => {
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send({ type: 1 })
 
-  describe('/ask con binding por guildId (fallback sin channelBinding)', () => {
-    it('resuelve el binding de guild y llama al agente', async () => {
-      const { dispatcher, calls } = buildDispatcher([GUILD_BINDING])
-
-      // El channelId NO tiene binding propio — solo hay guildBinding
-      const ctx = makeCtx('ask', {
-        channelId: 'otro-canal-sin-binding',
-        options:   { prompt: '¿Cómo estás?' },
-      })
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(calls).toHaveLength(1)
-      expect(calls[0]!.binding.scopeLevel).toBe('guild')
-      expect(calls[0]!.binding.agentId).toBe(AGENT_ID)
-      expect(calls[0]!.binding.scopeId).toBe(GUILD_ID)
-      expect(reply).toBe('¡Hola! Soy el agente.')
-    })
+    expect(harness.capturedMessages).toHaveLength(0)
   })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario 3: /ask sin binding → error legible, no excepción
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('/ask sin binding activo', () => {
-    it('devuelve mensaje de error legible y NO lanza excepción', async () => {
-      const { dispatcher, calls } = buildDispatcher([]) // sin bindings
-
-      const ctx = makeCtx('ask', { options: { prompt: 'cualquier pregunta' } })
-
-      // No debe lanzar
-      let reply!: string
-      await expect(
-        (async () => { reply = await dispatcher.dispatch(ctx) })()
-      ).resolves.not.toThrow()
-
-      // AgentExecutor NUNCA fue llamado
-      expect(calls).toHaveLength(0)
-
-      // El mensaje es legible y menciona el problema
-      expect(reply).toContain('No hay agente vinculado')
-      expect(reply).toContain(CHANNEL_ID)
-      expect(reply).toContain(GUILD_ID)
-    })
-
-    it('devuelve error legible cuando prompt está vacío', async () => {
-      const { dispatcher } = buildDispatcher([CHANNEL_BINDING])
-
-      const ctx = makeCtx('ask', { options: { prompt: '' } })
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('Debes proporcionar un prompt')
-    })
-  })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario 4: /status con binding → muestra agentId y scope
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('/status con binding activo', () => {
-    it('con binding de canal muestra agentId y scope=channel', async () => {
-      const { dispatcher } = buildDispatcher([CHANNEL_BINDING])
-
-      const ctx = makeCtx('status')
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('Agente vinculado')
-      expect(reply).toContain(AGENT_ID)
-      expect(reply).toContain('channel')
-      expect(reply).toContain(CONFIG_ID)
-    })
-
-    it('con binding de guild muestra agentId y scope=guild', async () => {
-      const { dispatcher } = buildDispatcher([GUILD_BINDING])
-
-      // Canal sin binding propio — resuelve por guild
-      const ctx = makeCtx('status', { channelId: 'canal-sin-binding' })
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('Agente vinculado')
-      expect(reply).toContain(AGENT_ID)
-      expect(reply).toContain('guild')
-      expect(reply).toContain(GUILD_ID)
-    })
-  })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario 5: /status sin binding → instrucciones de configuración
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('/status sin binding activo', () => {
-    it('devuelve instrucciones de configuración claras', async () => {
-      const { dispatcher } = buildDispatcher([])
-
-      const ctx = makeCtx('status')
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('No hay agente vinculado')
-      // Debe mencionar cómo configurar (channelId y guildId)
-      expect(reply).toContain(CHANNEL_ID)
-      expect(reply).toContain(GUILD_ID)
-    })
-
-    it('sin guildId sigue siendo legible', async () => {
-      const { dispatcher } = buildDispatcher([])
-
-      const ctx = makeCtx('status', { guildId: null })
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('No hay agente vinculado')
-      expect(reply).toContain(CHANNEL_ID)
-    })
-  })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario 6: parseInteractionBody con body inválido → null (no crash)
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('parseInteractionBody — validación de campos', () => {
-    it('retorna null si falta data.name (commandName)', () => {
-      const body = {
-        type:        2,
-        id:          'iid-1',
-        token:       'tok-1',
-        channel_id:  'chan-1',
-        guild_id:    'guild-1',
-        member:      { user: { id: 'uid-1', username: 'user' } },
-        data:        { options: [] }, // sin name
-      }
-      expect(parseInteractionBody(body)).toBeNull()
-    })
-
-    it('retorna null si falta channel_id', () => {
-      const body = {
-        type:    2,
-        id:      'iid-1',
-        token:   'tok-1',
-        guild_id: 'guild-1',
-        member:  { user: { id: 'uid-1', username: 'user' } },
-        data:    { name: 'ask', options: [] },
-        // sin channel_id
-      }
-      expect(parseInteractionBody(body)).toBeNull()
-    })
-
-    it('retorna null si falta el token de interacción', () => {
-      const body = {
-        type:       2,
-        id:         'iid-1',
-        channel_id: 'chan-1',
-        guild_id:   'guild-1',
-        member:     { user: { id: 'uid-1', username: 'user' } },
-        data:       { name: 'ask', options: [] },
-        // sin token
-      }
-      expect(parseInteractionBody(body)).toBeNull()
-    })
-
-    it('retorna null si falta el userId (member.user.id)', () => {
-      const body = {
-        type:       2,
-        id:         'iid-1',
-        token:      'tok-1',
-        channel_id: 'chan-1',
-        guild_id:   'guild-1',
-        member:     { user: { username: 'user' } }, // sin id
-        data:       { name: 'ask', options: [] },
-      }
-      expect(parseInteractionBody(body)).toBeNull()
-    })
-
-    it('retorna null para body completamente vacío', () => {
-      expect(parseInteractionBody({})).toBeNull()
-    })
-
-    it('parsea correctamente un body válido con opciones', () => {
-      const body = {
-        type:       2,
-        id:         'iid-valid',
-        token:      'tok-valid',
-        channel_id: CHANNEL_ID,
-        guild_id:   GUILD_ID,
-        member:     { user: { id: USER_ID, username: 'testuser' } },
-        data: {
-          name:    'ask',
-          options: [{ name: 'prompt', value: '¿Qué hora es?' }],
-        },
-      }
-      const ctx = parseInteractionBody(body)
-
-      expect(ctx).not.toBeNull()
-      expect(ctx!.commandName).toBe('ask')
-      expect(ctx!.channelId).toBe(CHANNEL_ID)
-      expect(ctx!.guildId).toBe(GUILD_ID)
-      expect(ctx!.userId).toBe(USER_ID)
-      expect(ctx!.username).toBe('testuser')
-      expect(ctx!.interactionId).toBe('iid-valid')
-      expect(ctx!.interactionToken).toBe('tok-valid')
-      expect(ctx!.options['prompt']).toBe('¿Qué hora es?')
-    })
-
-    it('acepta interacción DM (sin guild_id) y lo normaliza a null', () => {
-      const body = {
-        type:       2,
-        id:         'iid-dm',
-        token:      'tok-dm',
-        channel_id: 'dm-channel',
-        user:       { id: 'uid-dm', username: 'dmuser' }, // DM usa body.user, no member
-        data:       { name: 'status', options: [] },
-        // sin guild_id
-      }
-      const ctx = parseInteractionBody(body)
-
-      expect(ctx).not.toBeNull()
-      expect(ctx!.guildId).toBeNull()
-      expect(ctx!.userId).toBe('uid-dm')
-    })
-  })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario extra: comando desconocido no lanza
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('comando desconocido', () => {
-    it('devuelve mensaje de comando desconocido sin lanzar', async () => {
-      const { dispatcher } = buildDispatcher([])
-
-      const ctx = makeCtx('unknown-command')
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('Comando desconocido')
-      expect(reply).toContain('unknown-command')
-    })
-  })
-
-  // ──────────────────────────────────────────────────────────────────────────
-  // Escenario extra: error interno del agente → mensaje legible, no excepción
-  // ──────────────────────────────────────────────────────────────────────────
-
-  describe('error interno del AgentExecutor', () => {
-    it('captura errores y devuelve mensaje legible sin propagar la excepción', async () => {
-      const resolveBinding = makeBindingResolver([CHANNEL_BINDING])
-      const runAgent = async (): Promise<string> => {
-        throw new Error('LLM timeout')
-      }
-      const dispatcher = new DiscordCommandDispatcher(resolveBinding, runAgent)
-
-      const ctx = makeCtx('ask', { options: { prompt: 'pregunta' } })
-      const reply = await dispatcher.dispatch(ctx)
-
-      expect(reply).toContain('Error al procesar el comando')
-      expect(reply).toContain('LLM timeout')
-    })
-  })
-
 })
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Tests unitarios de makeBindingResolver
-// ─────────────────────────────────────────────────────────────────────────────
+// ── Suite 2: Slash command /ask ───────────────────────────────────────────────
 
-describe('[F3a-27] makeBindingResolver — resolución de bindings', () => {
+describe('Discord E2E — Slash command /ask', () => {
+  let harness: Awaited<ReturnType<typeof buildTestHarness>>
 
-  it('retorna null cuando no hay bindings', async () => {
-    const resolve = makeBindingResolver([])
-    const result  = await resolve(GUILD_ID, CHANNEL_ID)
-    expect(result).toBeNull()
+  beforeEach(async () => { harness = await buildTestHarness('El proyecto está en fase F3a.') })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+
+  it('emite IncomingMessage con type=command y text correcto', async () => {
+    const body = makeSlashInteraction('ask', '¿cuál es el estado?')
+
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+      .expect(200)
+
+    expect(harness.capturedMessages).toHaveLength(1)
+    const msg = harness.capturedMessages[0]!
+    expect(msg.channelType).toBe('discord')
+    expect(msg.channelConfigId).toBe(FAKE_CHANNEL_CFG)
+    expect(msg.externalId).toBe(FAKE_CHANNEL_ID)
+    expect(msg.senderId).toBe(FAKE_USER_ID)
+    expect(msg.type).toBe('command')
+    expect(msg.text).toContain('¿cuál es el estado?')
+    expect(msg.metadata?.['interactionToken']).toBe(FAKE_INT_TOKEN)
+    expect(msg.metadata?.['guildId']).toBe(FAKE_GUILD_ID)
   })
 
-  it('resuelve por externalChannelId cuando coincide', async () => {
-    const resolve = makeBindingResolver([CHANNEL_BINDING])
-    const result  = await resolve(GUILD_ID, CHANNEL_ID)
+  it('responde inmediatamente con ACK type=5 (DEFERRED_CHANNEL_MESSAGE)', async () => {
+    const body = makeSlashInteraction('ask', 'pregunta de prueba')
 
-    expect(result).not.toBeNull()
-    expect(result!.scopeLevel).toBe('channel')
-    expect(result!.scopeId).toBe(CHANNEL_ID)
-    expect(result!.agentId).toBe(AGENT_ID)
+    const res = await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+      .expect(200)
+
+    expect(res.body).toEqual({ type: 5 })
   })
 
-  it('resuelve por externalGuildId como fallback cuando no hay channelBinding', async () => {
-    const resolve = makeBindingResolver([GUILD_BINDING])
-    const result  = await resolve(GUILD_ID, 'otro-canal')
+  it('dispatcher.dispatch() retorna ok:true con la respuesta del agente', async () => {
+    const result = await harness.dispatcher.dispatch(
+      makeDispatchInput({ history: [{ role: 'user', content: '¿cuántas fases hay?' }] }),
+    )
 
-    expect(result).not.toBeNull()
-    expect(result!.scopeLevel).toBe('guild')
-    expect(result!.scopeId).toBe(GUILD_ID)
-    expect(result!.agentId).toBe(AGENT_ID)
+    expect(result.ok).toBe(true)
+    const success = result as DispatchSuccess
+    expect(success.reply).toBe('El proyecto está en fase F3a.')
+    expect(success.attempts).toBe(1)
+    expect(typeof success.durationMs).toBe('number')
   })
 
-  it('prioriza channelBinding sobre guildBinding', async () => {
-    const channelB: DiscordChannelBinding = { agentId: 'a-ch', channelConfigId: 'c-ch', externalChannelId: CHANNEL_ID, externalGuildId: null }
-    const guildB:   DiscordChannelBinding = { agentId: 'a-gu', channelConfigId: 'c-gu', externalChannelId: null, externalGuildId: GUILD_ID }
+  it('AgentExecutor recibe agentId y history correctos', async () => {
+    await harness.dispatcher.dispatch(
+      makeDispatchInput({ history: [{ role: 'user', content: '¿cuántas fases hay?' }] }),
+    )
 
-    const resolve = makeBindingResolver([guildB, channelB]) // guild primero en array
-    const result  = await resolve(GUILD_ID, CHANNEL_ID)
-
-    expect(result!.scopeLevel).toBe('channel')
-    expect(result!.agentId).toBe('a-ch')
+    expect(harness.mockExecutor.run).toHaveBeenCalledWith(
+      FAKE_AGENT_ID,
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: '¿cuántas fases hay?' }),
+      ]),
+    )
   })
 
-  it('retorna null si guildId es null y no hay channelBinding', async () => {
-    const resolve = makeBindingResolver([GUILD_BINDING])
-    const result  = await resolve(null, 'canal-sin-binding')
-    expect(result).toBeNull()
+  it('sendFollowup llama PATCH al endpoint correcto de Discord', async () => {
+    const { sendFollowup } = await import('../../channels/discord.reply.js')
+
+    const result = await sendFollowup({
+      botToken:         FAKE_BOT_TOKEN,
+      applicationId:    FAKE_APP_ID,
+      interactionToken: FAKE_INT_TOKEN,
+      text:             'Respuesta del agente',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(harness.fetchSpy).toHaveBeenCalledWith(
+      `https://discord.com/api/v10/webhooks/${FAKE_APP_ID}/${FAKE_INT_TOKEN}/messages/@original`,
+      expect.objectContaining({
+        method:  'PATCH',
+        headers: expect.objectContaining({
+          Authorization: `Bot ${FAKE_BOT_TOKEN}`,
+        }),
+      }),
+    )
   })
 
-  it('no resuelve si el channelId no coincide con ningún externalChannelId', async () => {
-    const resolve = makeBindingResolver([CHANNEL_BINDING])
-    const result  = await resolve(GUILD_ID, 'canal-diferente')
+  it('sendFollowup con richContent incluye embed en el body', async () => {
+    const { sendFollowup } = await import('../../channels/discord.reply.js')
 
-    // GUILD_BINDING no está en la lista, solo CHANNEL_BINDING con otro channelId
-    // Cae a guild lookup: CHANNEL_BINDING.externalGuildId === null → null
-    expect(result).toBeNull()
+    const spy = harness.fetchSpy
+    spy.mockClear()
+
+    await sendFollowup({
+      botToken:         FAKE_BOT_TOKEN,
+      applicationId:    FAKE_APP_ID,
+      interactionToken: FAKE_INT_TOKEN,
+      text:             'Resultado del análisis',
+      richContent: {
+        title:       'Estado del sistema',
+        description: 'Todo funciona correctamente',
+        color:       0x57F287,
+      },
+    })
+
+    const patchCall = spy.mock.calls.find(([url]) =>
+      url.toString().includes('/messages/@original')
+    )
+    expect(patchCall).toBeDefined()
+    const sentBody = JSON.parse((patchCall![1] as RequestInit).body as string)
+    expect(sentBody.embeds).toHaveLength(1)
+    expect(sentBody.embeds[0].title).toBe('Estado del sistema')
+    expect(sentBody.embeds[0].description).toBe('Todo funciona correctamente')
+    expect(sentBody.embeds[0].color).toBe(0x57F287)
+  })
+})
+
+// ── Suite 3: Slash command /status ─────────────────────────────────────────────
+
+describe('Discord E2E — Slash command /status', () => {
+  let harness: Awaited<ReturnType<typeof buildTestHarness>>
+
+  beforeEach(async () => { harness = await buildTestHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+
+  it('emite IncomingMessage con text que contiene "status"', async () => {
+    const body = makeSlashInteraction('status')
+
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+      .expect(200)
+
+    expect(harness.capturedMessages).toHaveLength(1)
+    const msg = harness.capturedMessages[0]!
+    expect(msg.text.toLowerCase()).toContain('status')
+    expect(msg.type).toBe('command')
+    expect(msg.channelType).toBe('discord')
+  })
+
+  it('responde ACK type=5 inmediatamente para /status', async () => {
+    const body = makeSlashInteraction('status')
+
+    const res = await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+      .expect(200)
+
+    expect(res.body).toEqual({ type: 5 })
+  })
+
+  it('incluye interactionToken en metadata del IncomingMessage', async () => {
+    const body = makeSlashInteraction('status')
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+
+    const msg = harness.capturedMessages[0]!
+    expect(msg.metadata?.['interactionToken']).toBe(FAKE_INT_TOKEN)
+  })
+})
+
+// ── Suite 4: Componente interactivo — botón ───────────────────────────────────
+
+describe('Discord E2E — Componente interactivo (botón)', () => {
+  let harness: Awaited<ReturnType<typeof buildTestHarness>>
+
+  beforeEach(async () => { harness = await buildTestHarness('Acción ejecutada correctamente') })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+
+  it('emite IncomingMessage con text = custom_id del botón', async () => {
+    const body = makeButtonInteraction('action:confirm:run-123')
+
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+      .expect(200)
+
+    expect(harness.capturedMessages).toHaveLength(1)
+    const msg = harness.capturedMessages[0]!
+    expect(msg.text).toBe('action:confirm:run-123')
+    expect(msg.type).toBe('command')
+    expect(msg.metadata?.['subtype']).toBe('button_click')
+    expect(msg.metadata?.['interactionToken']).toBe(FAKE_INT_TOKEN)
+  })
+
+  it('responde ACK type=6 (DEFERRED_UPDATE_MESSAGE) para componentes', async () => {
+    const body = makeButtonInteraction('action:cancel')
+
+    const res = await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+      .expect(200)
+
+    expect(res.body).toEqual({ type: 6 })
+  })
+
+  it('registra senderId y channelId correctamente para botón', async () => {
+    const body = makeButtonInteraction('btn:ok')
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(body)
+
+    const msg = harness.capturedMessages[0]!
+    expect(msg.senderId).toBe(FAKE_USER_ID)
+    expect(msg.externalId).toBe(FAKE_CHANNEL_ID)
+  })
+})
+
+// ── Suite 5: sendToChannel — respuesta proactiva ────────────────────────────
+
+describe('Discord E2E — sendToChannel (respuesta proactiva)', () => {
+  let fetchSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'new_message_id' }), {
+        status:  200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it('llama POST /channels/:id/messages con el texto correcto', async () => {
+    const { sendToChannel } = await import('../../channels/discord.reply.js')
+
+    const result = await sendToChannel({
+      botToken:  FAKE_BOT_TOKEN,
+      channelId: FAKE_CHANNEL_ID,
+      text:      'Notificación proactiva del agente',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.chunks).toBe(1)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://discord.com/api/v10/channels/${FAKE_CHANNEL_ID}/messages`,
+      expect.objectContaining({ method: 'POST' }),
+    )
+
+    const sentBody = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string)
+    expect(sentBody.content).toBe('Notificación proactiva del agente')
+  })
+
+  it('hace chunking correcto para mensajes > 2000 chars', async () => {
+    const { sendToChannel } = await import('../../channels/discord.reply.js')
+    const longText = 'a'.repeat(2200)
+
+    const result = await sendToChannel({
+      botToken:  FAKE_BOT_TOKEN,
+      channelId: FAKE_CHANNEL_ID,
+      text:      longText,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.chunks).toBeGreaterThan(1)
+    for (const call of fetchSpy.mock.calls) {
+      const body = JSON.parse((call[1] as RequestInit).body as string)
+      if (body.content) {
+        expect(body.content.length).toBeLessThanOrEqual(2000)
+      }
+    }
+  })
+
+  it('adjunta embed solo al último chunk cuando hay richContent', async () => {
+    const { sendToChannel } = await import('../../channels/discord.reply.js')
+    const longText = 'palabra '.repeat(300)  // ~2400 chars → 2 chunks
+
+    await sendToChannel({
+      botToken:    FAKE_BOT_TOKEN,
+      channelId:   FAKE_CHANNEL_ID,
+      text:        longText,
+      richContent: { title: 'Resumen', description: 'Análisis completado' },
+    })
+
+    const calls = fetchSpy.mock.calls
+    expect(calls.length).toBeGreaterThan(1)
+
+    // Solo el último chunk tiene embeds
+    const lastBody = JSON.parse((calls[calls.length - 1]![1] as RequestInit).body as string)
+    expect(lastBody.embeds).toBeDefined()
+    expect(lastBody.embeds[0].title).toBe('Resumen')
+
+    // Los chunks anteriores NO tienen embeds
+    for (let i = 0; i < calls.length - 1; i++) {
+      const body = JSON.parse((calls[i]![1] as RequestInit).body as string)
+      expect(body.embeds).toBeUndefined()
+    }
+  })
+
+  it('devuelve { ok: false, error } cuando Discord API responde 403', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('{"message": "Missing Access"}', {
+        status:  403,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const { sendToChannel } = await import('../../channels/discord.reply.js')
+    const result = await sendToChannel({
+      botToken:  FAKE_BOT_TOKEN,
+      channelId: FAKE_CHANNEL_ID,
+      text:      'Mensaje que fallará',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('403')
+  })
+
+  it('devuelve { ok: false } en error de red', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    const { sendToChannel } = await import('../../channels/discord.reply.js')
+    const result = await sendToChannel({
+      botToken:  FAKE_BOT_TOKEN,
+      channelId: FAKE_CHANNEL_ID,
+      text:      'Hi',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('ECONNREFUSED')
+  })
+})
+
+// ── Suite 6: MessageDispatcher — errores y edge cases ───────────────────────
+
+describe('Discord E2E — MessageDispatcher error handling', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('devuelve { ok:false, errorKind:"timeout" } cuando AgentExecutor se demora', async () => {
+    const slowExecutor: IAgentExecutor = {
+      run: jest.fn().mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ reply: 'tarde' }), 10_000)),
+      ),
+    }
+    const dispatcher = new MessageDispatcher(slowExecutor, {
+      timeoutMs:   100,
+      maxAttempts: 1,
+    })
+
+    const result = await dispatcher.dispatch(makeDispatchInput())
+
+    expect(result.ok).toBe(false)
+    const fail = result as DispatchFailure
+    expect(fail.errorKind).toBe('timeout')
+  }, 15_000)
+
+  it('devuelve { ok:false, errorKind:"agent_error" } para errores del agente', async () => {
+    const notFoundExecutor: IAgentExecutor = {
+      run: jest.fn().mockRejectedValue(new Error('Agent not found — 404')),
+    }
+    const dispatcher = new MessageDispatcher(notFoundExecutor, {
+      timeoutMs:   5_000,
+      maxAttempts: 1,
+    })
+
+    const result = await dispatcher.dispatch(
+      makeDispatchInput({ agentId: 'nonexistent-agent' }),
+    )
+
+    expect(result.ok).toBe(false)
+    const fail = result as DispatchFailure
+    expect(['agent_error', 'transient', 'unknown']).toContain(fail.errorKind)
+  })
+
+  it('reintenta en errores transitorios hasta maxAttempts y tiene éxito', async () => {
+    const flakyExecutor: IAgentExecutor = {
+      run: jest.fn()
+        .mockRejectedValueOnce(new Error('ECONNREFUSED — network error'))
+        .mockResolvedValueOnce({ reply: 'segundo intento exitoso' }),
+    }
+    const dispatcher = new MessageDispatcher(flakyExecutor, {
+      timeoutMs:    5_000,
+      maxAttempts:  2,
+      retryDelayMs: 50,
+    })
+
+    const result = await dispatcher.dispatch(makeDispatchInput())
+
+    expect(result.ok).toBe(true)
+    const success = result as DispatchSuccess
+    expect(success.reply).toBe('segundo intento exitoso')
+    expect(success.attempts).toBe(2)
+    expect(flakyExecutor.run).toHaveBeenCalledTimes(2)
+  })
+
+  it('emite evento dispatch:success con metadata correcta', async () => {
+    const executor: IAgentExecutor = {
+      run: jest.fn().mockResolvedValue({ reply: 'ok' }),
+    }
+    const dispatcher = new MessageDispatcher(executor)
+    const successEvents: unknown[] = []
+    dispatcher.on('dispatch:success', (e) => successEvents.push(e))
+
+    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'session-events' }))
+
+    expect(successEvents).toHaveLength(1)
+    const ev = successEvents[0] as Record<string, unknown>
+    expect(ev['sessionId']).toBe('session-events')
+    expect(ev['agentId']).toBe(FAKE_AGENT_ID)
+    expect(ev['channelConfigId']).toBe(FAKE_CHANNEL_CFG)
+    expect(ev['attempts']).toBe(1)
+  })
+
+  it('emite evento dispatch:error cuando falla definitivamente', async () => {
+    const executor: IAgentExecutor = {
+      run: jest.fn().mockRejectedValue(new Error('fatal error')),
+    }
+    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1 })
+    const errorEvents: unknown[] = []
+    dispatcher.on('dispatch:error', (e) => errorEvents.push(e))
+
+    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'session-error-event' }))
+
+    expect(errorEvents).toHaveLength(1)
+    const ev = errorEvents[0] as Record<string, unknown>
+    expect(typeof ev['errorKind']).toBe('string')
+    expect(ev['attempts']).toBe(1)
+  })
+})
+
+// ── Suite 7: Edge cases de DiscordAdapter ────────────────────────────────────────
+
+describe('Discord E2E — DiscordAdapter edge cases', () => {
+  let harness: Awaited<ReturnType<typeof buildTestHarness>>
+
+  beforeEach(async () => { harness = await buildTestHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+
+  it('retorna 401 cuando la firma Ed25519 es inválida', async () => {
+    // Usar un adapter con _verifySignature real (no mockeada)
+    jest.restoreAllMocks()
+
+    const adapter2 = new DiscordAdapter()
+    adapter2.initialize(FAKE_CHANNEL_CFG)
+    await adapter2.setup(
+      { applicationId: FAKE_APP_ID },
+      { botToken: FAKE_BOT_TOKEN, publicKey: 'aabbccdd' },  // clave falsa
+      'http',
+    )
+
+    const app2 = express()
+    app2.use(express.json())
+    app2.use('/discord', adapter2.buildHttpRouter())
+
+    const res = await request(app2)
+      .post('/discord')
+      .set('x-signature-ed25519',  'invalidsignature')
+      .set('x-signature-timestamp', '1234567890')
+      .send({ type: 1 })
+      .expect(401)
+
+    expect(res.body.error).toContain('signature')
+    await adapter2.dispose()
+  })
+
+  it('retorna 400 para tipos de interacción desconocidos', async () => {
+    const res = await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send({ type: 99 })
+      .expect(400)
+
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('no emite IncomingMessage si falta channel_id en la interacción', async () => {
+    const bodyWithoutChannel = {
+      id:    '888888888888888888',
+      type:  2,
+      token: FAKE_INT_TOKEN,
+      member: { user: { id: FAKE_USER_ID, username: 'test' } },
+      data:  { name: 'ask', options: [] },
+      // channel_id: OMITIDO — el adapter no puede enrutar
+    }
+
+    await request(harness.app)
+      .post('/discord')
+      .set('x-signature-ed25519',  'fakesig')
+      .set('x-signature-timestamp', '1234567890')
+      .send(bodyWithoutChannel)
+      .expect(200)
+
+    expect(harness.capturedMessages).toHaveLength(0)
+  })
+
+  it('dispose() limpia el adapter sin errores', async () => {
+    await expect(harness.adapter.dispose()).resolves.not.toThrow()
+  })
+
+  it('onError() registra el handler de errores sin lanzar', () => {
+    const errorHandler = jest.fn()
+    expect(() => harness.adapter.onError(errorHandler)).not.toThrow()
   })
 })


### PR DESCRIPTION
## [F3a-31] Teams Mode Strategy

### Archivos creados

| Archivo | Descripción |
|---------|-------------|
| `apps/gateway/src/channels/teams/teams-mode.strategy.ts` | Estrategia de modo Teams completa |
| `apps/gateway/src/channels/teams/index.ts` | Barrel exports del módulo |
| `apps/gateway/src/channels/teams/__tests__/teams-mode.strategy.spec.ts` | Tests unitarios (sin red real) |

### Cambios

- **`IncomingWebhookStrategy`**: POST al webhookUrl con payload Adaptive Card (schema v1.5). Envuelve texto plano en card automáticamente.
- **`BotFrameworkStrategy`**: OAuth2 Bearer token via `login.microsoftonline.com` con caché y auto-renovación 60s antes de expirar. POST a `{serviceUrl}/v3/conversations/{id}/activities`.
- **`createTeamsModeStrategy`**: Factory con auto-detección de modo por shape de secrets. `config.mode` tiene prioridad.
- **`buildAdaptiveTextCard`** / **`buildAdaptiveRichCard`**: Helpers de Adaptive Card v1.5 para texto simple y cards ricas con título, campos, botones e imagen.
- Tests cubren: validación de credenciales, caché de token, POST correcto, `replyToId` en hilos, factory, rich cards.

### Criterio de aceptación

- [x] `IncomingWebhookStrategy.send()` hace POST correcto con Adaptive Card
- [x] `BotFrameworkStrategy.getBearerToken()` obtiene y cachea token de Microsoft
- [x] `BotFrameworkStrategy.send()` hace POST a `{serviceUrl}/v3/conversations/{id}/activities` con Bearer token
- [x] `createTeamsModeStrategy()` detecta modo por credenciales
- [x] `buildAdaptiveTextCard()` y `buildAdaptiveRichCard()` generan Adaptive Cards válidas (schema v1.5)
- [x] Ningún test requiere red real ni Azure AD real

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic message chunking for long Discord messages, preserving formatting on subsequent chunks
  * Enhanced Discord embed and interactive component handling
  * Introduced Teams messaging support with incoming webhook and bot framework connection modes

* **Tests**
  * Added comprehensive test coverage for Discord messaging functionality and Teams messaging strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->