### PR TITLE
feat(F3a-36): ChannelSettings UI — Telegram, WhatsApp, Discord, Teams

### DIFF
--- a/apps/web/src/features/channels/ChannelsPage.tsx
+++ b/apps/web/src/features/channels/ChannelsPage.tsx
@@ -4,6 +4,8 @@
  *
  * Layout: sidebar lista (izquierda) + panel detalle/creación (derecha).
  * Importable en App.tsx como ruta /channels.
+ *
+ * F3a-36: pasa patchChannel y testChannel a ChannelDetail.
  */
 import React, { useState } from 'react';
 import { useChannels }        from './useChannels';
@@ -30,6 +32,8 @@ export default function ChannelsPage() {
     deleteChannel,
     addBinding,
     removeBinding,
+    patchChannel,
+    testChannel,
   } = useChannels();
 
   const [showCreate, setShowCreate] = useState(false);
@@ -42,7 +46,7 @@ export default function ChannelsPage() {
       setShowCreate(false);
     } catch (e) {
       setCreateErr(e instanceof Error ? e.message : 'Error al crear canal');
-      throw e; // para que el panel muestre el error inline
+      throw e;
     }
   }
 
@@ -61,7 +65,6 @@ export default function ChannelsPage() {
           </button>
         </div>
 
-        {/* Loading skeleton */}
         {loading && (
           <div className="channels-page__skeleton">
             {[1, 2, 3].map(i => (
@@ -70,14 +73,12 @@ export default function ChannelsPage() {
           </div>
         )}
 
-        {/* Error */}
         {!loading && error && (
           <div className="channels-page__error">
             <p>{error}</p>
           </div>
         )}
 
-        {/* Empty state */}
         {!loading && !error && channels.length === 0 && (
           <div className="channels-page__empty">
             <p>No hay canales configurados.</p>
@@ -90,7 +91,6 @@ export default function ChannelsPage() {
           </div>
         )}
 
-        {/* Lista */}
         {!loading && channels.length > 0 && (
           <ul className="channels-page__list" role="list">
             {channels.map(ch => (
@@ -125,6 +125,8 @@ export default function ChannelsPage() {
             onDeactivate={deactivateChannel}
             onAddBinding={addBinding}
             onRemoveBinding={removeBinding}
+            onPatchChannel={patchChannel}
+            onTestChannel={testChannel}
             gatewayUrl={GATEWAY_URL}
           />
         )}

--- a/apps/web/src/features/channels/channels.css
+++ b/apps/web/src/features/channels/channels.css
@@ -1,0 +1,319 @@
+/* ── ChannelDetail — Tab Navigation (F3a-36) ──────────────────────────────── */
+.channel-detail__tabs {
+  display: flex;
+  gap: var(--space-1);
+  border-bottom: 1px solid var(--color-divider);
+  padding: 0 var(--space-6);
+  margin-top: var(--space-4);
+}
+
+.channel-detail__tab {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    color var(--transition-interactive),
+    border-color var(--transition-interactive);
+  margin-bottom: -1px;
+}
+
+.channel-detail__tab:hover {
+  color: var(--color-text);
+}
+
+.channel-detail__tab--active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.channel-detail__panel {
+  padding: 0;
+}
+
+/* ── ChannelSettings (F3a-36) ─────────────────────────────────────────────── */
+.channel-settings {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.channel-settings--empty {
+  color: var(--color-text-muted);
+}
+
+.channel-settings__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.channel-settings__channel-name {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.channel-settings__type-badge {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.channel-settings__status {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+}
+
+.channel-settings__status--active {
+  background: var(--color-success-highlight);
+  color: var(--color-success);
+}
+
+.channel-settings__status--inactive {
+  background: var(--color-surface-offset);
+  color: var(--color-text-muted);
+}
+
+/* Webhook row */
+.channel-settings__webhook-row {
+  background: var(--color-surface-offset);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.channel-settings__webhook-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.channel-settings__webhook-value {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.channel-settings__webhook-url {
+  font-family: monospace;
+  font-size: var(--text-xs);
+  color: var(--color-text);
+  word-break: break-all;
+  flex: 1;
+}
+
+.channel-settings__copy-btn {
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background var(--transition-interactive);
+}
+
+.channel-settings__copy-btn:hover {
+  background: var(--color-surface-offset);
+}
+
+.channel-settings__webhook-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+/* Test row */
+.channel-settings__test-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.channel-settings__test-btn {
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background var(--transition-interactive);
+}
+
+.channel-settings__test-btn:hover:not(:disabled) {
+  background: var(--color-surface-offset);
+}
+
+.channel-settings__test-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.channel-settings__test-banner {
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  flex: 1;
+}
+
+.channel-settings__test-banner--testing {
+  background: var(--color-surface-offset);
+  color: var(--color-text-muted);
+}
+
+.channel-settings__test-banner--ok {
+  background: var(--color-success-highlight);
+  color: var(--color-success);
+}
+
+.channel-settings__test-banner--error {
+  background: var(--color-error-highlight);
+  color: var(--color-error);
+}
+
+/* Form */
+.channel-settings__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.channel-settings__fieldset {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.channel-settings__legend {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text);
+  padding: 0 var(--space-2);
+}
+
+.channel-settings__secret-hint {
+  font-weight: 400;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+.channel-settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.channel-settings__label {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.channel-settings__input,
+.channel-settings__select {
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  width: 100%;
+  transition: border-color var(--transition-interactive);
+}
+
+.channel-settings__input:focus,
+.channel-settings__select:focus {
+  border-color: var(--color-primary);
+  outline: none;
+}
+
+.channel-settings__hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.channel-settings__error {
+  font-size: var(--text-sm);
+  color: var(--color-error);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-error-highlight);
+  border-radius: var(--radius-md);
+  margin: 0;
+}
+
+.channel-settings__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-divider);
+}
+
+.channel-settings__btn-reset {
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    background var(--transition-interactive),
+    color var(--transition-interactive);
+}
+
+.channel-settings__btn-reset:hover:not(:disabled) {
+  background: var(--color-surface-offset);
+  color: var(--color-text);
+}
+
+.channel-settings__btn-save {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  cursor: pointer;
+  transition: background var(--transition-interactive);
+}
+
+.channel-settings__btn-save:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.channel-settings__btn-save:disabled,
+.channel-settings__btn-reset:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.channel-settings__no-fields {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}

--- a/apps/web/src/features/channels/components/ChannelDetail.tsx
+++ b/apps/web/src/features/channels/components/ChannelDetail.tsx
@@ -1,12 +1,22 @@
 /**
  * ChannelDetail.tsx
  * Panel de detalle del canal seleccionado.
- * Muestra info, lista de bindings, form para agregar binding, y EmbedSnippet si es webchat activo.
+ * Tabs: General | Configuración | Bindings
+ *
+ * F3a-36: Integra ChannelSettings como pestaña "Configuración".
  */
 import React, { useState } from 'react';
-import type { ChannelConfig, AddBindingPayload } from '../types';
+import type {
+  ChannelConfig,
+  AddBindingPayload,
+  PatchChannelPayload,
+  ChannelTestResult,
+} from '../types';
 import { ChannelTypeIcon } from './ChannelTypeIcon';
 import { EmbedSnippet }    from './EmbedSnippet';
+import { ChannelSettings } from './ChannelSettings';
+
+type ActiveTab = 'overview' | 'settings' | 'bindings';
 
 interface Props {
   channel:          ChannelConfig;
@@ -14,6 +24,8 @@ interface Props {
   onDeactivate:     (id: string) => Promise<void>;
   onAddBinding:     (channelId: string, payload: AddBindingPayload) => Promise<void>;
   onRemoveBinding:  (channelId: string, bindingId: string) => Promise<void>;
+  onPatchChannel:   (id: string, payload: PatchChannelPayload) => Promise<void>;
+  onTestChannel:    (id: string) => Promise<ChannelTestResult>;
   gatewayUrl?:      string;
 }
 
@@ -23,10 +35,19 @@ export function ChannelDetail({
   onDeactivate,
   onAddBinding,
   onRemoveBinding,
-  gatewayUrl,
+  onPatchChannel,
+  onTestChannel,
+  gatewayUrl = '',
 }: Props) {
   const [busy,       setBusy]       = useState(false);
   const [actionErr,  setActionErr]  = useState<string | null>(null);
+  const [activeTab,  setActiveTab]  = useState<ActiveTab>('overview');
+
+  // Reset tab cuando cambia el canal
+  React.useEffect(() => {
+    setActiveTab('overview');
+    setActionErr(null);
+  }, [channel.id]);
 
   // Form agregar binding
   const [newAgentId,    setNewAgentId]    = useState('');
@@ -80,7 +101,9 @@ export function ChannelDetail({
           </span>
         </div>
         <button
-          className={`channel-detail__toggle-btn ${channel.isActive ? 'channel-detail__toggle-btn--off' : 'channel-detail__toggle-btn--on'}`}
+          className={`channel-detail__toggle-btn ${
+            channel.isActive ? 'channel-detail__toggle-btn--off' : 'channel-detail__toggle-btn--on'
+          }`}
           onClick={() => void toggleActive()}
           disabled={busy}
         >
@@ -90,99 +113,146 @@ export function ChannelDetail({
 
       {actionErr && <p className="channel-detail__error">{actionErr}</p>}
 
-      {/* Meta */}
-      <div className="channel-detail__meta">
-        <div className="channel-detail__meta-row">
-          <span className="channel-detail__meta-label">Tipo</span>
-          <span className="channel-detail__meta-value">{channel.type}</span>
-        </div>
-        <div className="channel-detail__meta-row">
-          <span className="channel-detail__meta-label">ID</span>
-          <code className="channel-detail__meta-code">{channel.id}</code>
-        </div>
-        <div className="channel-detail__meta-row">
-          <span className="channel-detail__meta-label">Secrets</span>
-          <span className="channel-detail__meta-value">{channel.hasSecrets ? 'Configurados •••' : 'Ninguno'}</span>
-        </div>
-        <div className="channel-detail__meta-row">
-          <span className="channel-detail__meta-label">Creado</span>
-          <span className="channel-detail__meta-value">{new Date(channel.createdAt).toLocaleString()}</span>
-        </div>
-      </div>
+      {/* Tab navigation — F3a-36 */}
+      <nav className="channel-detail__tabs" role="tablist" aria-label="Secciones del canal">
+        {(['overview', 'settings', 'bindings'] as ActiveTab[]).map(tab => (
+          <button
+            key={tab}
+            role="tab"
+            aria-selected={activeTab === tab}
+            onClick={() => setActiveTab(tab)}
+            className={`channel-detail__tab ${
+              activeTab === tab ? 'channel-detail__tab--active' : ''
+            }`}
+          >
+            {tab === 'overview'  ? 'General'       : ''}
+            {tab === 'settings'  ? 'Configuración' : ''}
+            {tab === 'bindings'  ? 'Bindings'      : ''}
+          </button>
+        ))}
+      </nav>
 
-      {/* Embed snippet para webchat activo */}
-      {channel.type === 'webchat' && channel.isActive && (
-        <EmbedSnippet
-          channelId={channel.id}
-          gatewayUrl={gatewayUrl}
-          title={channel.name}
-        />
+      {/* ── Panel: General ─────────────────────────────────── */}
+      {activeTab === 'overview' && (
+        <div className="channel-detail__panel" role="tabpanel">
+          {/* Meta */}
+          <div className="channel-detail__meta">
+            <div className="channel-detail__meta-row">
+              <span className="channel-detail__meta-label">Tipo</span>
+              <span className="channel-detail__meta-value">{channel.type}</span>
+            </div>
+            <div className="channel-detail__meta-row">
+              <span className="channel-detail__meta-label">ID</span>
+              <code className="channel-detail__meta-code">{channel.id}</code>
+            </div>
+            <div className="channel-detail__meta-row">
+              <span className="channel-detail__meta-label">Secrets</span>
+              <span className="channel-detail__meta-value">
+                {channel.hasSecrets ? 'Configurados •••' : 'Ninguno'}
+              </span>
+            </div>
+            <div className="channel-detail__meta-row">
+              <span className="channel-detail__meta-label">Creado</span>
+              <span className="channel-detail__meta-value">
+                {new Date(channel.createdAt).toLocaleString()}
+              </span>
+            </div>
+          </div>
+
+          {/* Embed snippet para webchat activo */}
+          {channel.type === 'webchat' && channel.isActive && (
+            <EmbedSnippet
+              channelId={channel.id}
+              gatewayUrl={gatewayUrl}
+              title={channel.name}
+            />
+          )}
+        </div>
       )}
 
-      {/* Bindings */}
-      <section className="channel-detail__section">
-        <h3 className="channel-detail__section-title">Bindings</h3>
+      {/* ── Panel: Configuración ── F3a-36 ─────────────────── */}
+      {activeTab === 'settings' && (
+        <div className="channel-detail__panel" role="tabpanel">
+          <ChannelSettings
+            channel={channel}
+            gatewayUrl={gatewayUrl}
+            onSave={onPatchChannel}
+            onTest={onTestChannel}
+          />
+        </div>
+      )}
 
-        {(channel.bindings ?? []).length === 0 ? (
-          <p className="channel-detail__empty">Sin bindings configurados.</p>
-        ) : (
-          <ul className="channel-detail__binding-list">
-            {(channel.bindings ?? []).map(b => (
-              <li key={b.id} className="channel-detail__binding-item">
-                <div className="channel-detail__binding-info">
-                  <span className="channel-detail__binding-agent">
-                    {b.agent?.name ?? b.agentId}
-                  </span>
-                  <span className="channel-detail__binding-scope">{b.scopeLevel}</span>
-                  {b.isDefault && (
-                    <span className="channel-detail__binding-default">default</span>
-                  )}
-                </div>
-                <button
-                  className="channel-detail__binding-remove"
-                  onClick={() => void onRemoveBinding(channel.id, b.id)}
-                  aria-label="Eliminar binding"
+      {/* ── Panel: Bindings ────────────────────────────────── */}
+      {activeTab === 'bindings' && (
+        <div className="channel-detail__panel" role="tabpanel">
+          <section className="channel-detail__section">
+            <h3 className="channel-detail__section-title">Bindings</h3>
+
+            {(channel.bindings ?? []).length === 0 ? (
+              <p className="channel-detail__empty">Sin bindings configurados.</p>
+            ) : (
+              <ul className="channel-detail__binding-list">
+                {(channel.bindings ?? []).map(b => (
+                  <li key={b.id} className="channel-detail__binding-item">
+                    <div className="channel-detail__binding-info">
+                      <span className="channel-detail__binding-agent">
+                        {b.agent?.name ?? b.agentId}
+                      </span>
+                      <span className="channel-detail__binding-scope">{b.scopeLevel}</span>
+                      {b.isDefault && (
+                        <span className="channel-detail__binding-default">default</span>
+                      )}
+                    </div>
+                    <button
+                      className="channel-detail__binding-remove"
+                      onClick={() => void onRemoveBinding(channel.id, b.id)}
+                      aria-label="Eliminar binding"
+                    >
+                      ✕
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {/* Agregar binding */}
+            <form
+              onSubmit={e => void handleAddBinding(e)}
+              className="channel-detail__bind-form"
+            >
+              <h4 className="channel-detail__bind-form-title">Agregar binding</h4>
+              <div className="channel-detail__bind-row">
+                <input
+                  type="text"
+                  placeholder="Agent ID"
+                  value={newAgentId}
+                  onChange={e => setNewAgentId(e.target.value)}
+                  className="channel-detail__bind-input"
+                  aria-label="Agent ID"
+                />
+                <select
+                  value={newScopeLevel}
+                  onChange={e => setNewScopeLevel(e.target.value)}
+                  className="channel-detail__bind-select"
+                  aria-label="Scope level"
                 >
-                  ✕
+                  <option value="agent">agent</option>
+                  <option value="workspace">workspace</option>
+                  <option value="org">org</option>
+                </select>
+                <button
+                  type="submit"
+                  className="channel-detail__bind-submit"
+                  disabled={bindBusy || !newAgentId.trim()}
+                >
+                  {bindBusy ? '…' : 'Agregar'}
                 </button>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        {/* Agregar binding */}
-        <form onSubmit={e => void handleAddBinding(e)} className="channel-detail__bind-form">
-          <h4 className="channel-detail__bind-form-title">Agregar binding</h4>
-          <div className="channel-detail__bind-row">
-            <input
-              type="text"
-              placeholder="Agent ID"
-              value={newAgentId}
-              onChange={e => setNewAgentId(e.target.value)}
-              className="channel-detail__bind-input"
-              aria-label="Agent ID"
-            />
-            <select
-              value={newScopeLevel}
-              onChange={e => setNewScopeLevel(e.target.value)}
-              className="channel-detail__bind-select"
-              aria-label="Scope level"
-            >
-              <option value="agent">agent</option>
-              <option value="workspace">workspace</option>
-              <option value="org">org</option>
-            </select>
-            <button
-              type="submit"
-              className="channel-detail__bind-submit"
-              disabled={bindBusy || !newAgentId.trim()}
-            >
-              {bindBusy ? '…' : 'Agregar'}
-            </button>
-          </div>
-          {bindErr && <p className="channel-detail__error">{bindErr}</p>}
-        </form>
-      </section>
+              </div>
+              {bindErr && <p className="channel-detail__error">{bindErr}</p>}
+            </form>
+          </section>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/channels/components/ChannelSettings.tsx
+++ b/apps/web/src/features/channels/components/ChannelSettings.tsx
@@ -1,0 +1,607 @@
+/**
+ * ChannelSettings.tsx — [F3a-36]
+ *
+ * Formulario de configuración de un canal existente.
+ * Cubre: Telegram, WhatsApp, Discord, Teams.
+ * Montado dentro de ChannelDetail.tsx como pestaña "Configuración".
+ *
+ * Props:
+ *   channel    — ChannelConfig actual (read-only, viene del store)
+ *   onSave     — callback tras PATCH exitoso
+ *   onTest     — callback para lanzar test de conexión
+ *   gatewayUrl — URL base del gateway (para construir webhook URL)
+ */
+
+import React, { useCallback, useId, useReducer, useState } from 'react';
+import type {
+  ChannelConfig,
+  ChannelType,
+  PatchChannelPayload,
+  ChannelTestResult,
+} from '../types';
+import { ChannelTypeIcon } from './ChannelTypeIcon';
+
+// ── Tipos internos ────────────────────────────────────────────────────────────
+
+interface ChannelSettingsProps {
+  channel:    ChannelConfig;
+  gatewayUrl: string;
+  onSave:     (id: string, payload: PatchChannelPayload) => Promise<void>;
+  onTest:     (id: string) => Promise<ChannelTestResult>;
+}
+
+interface FormState {
+  name:    string;
+  config:  Record<string, string>;
+  secrets: Record<string, string>;
+  dirty:   boolean;
+}
+
+type FormAction =
+  | { type: 'SET_NAME';   value: string }
+  | { type: 'SET_CONFIG'; key: string; value: string }
+  | { type: 'SET_SECRET'; key: string; value: string }
+  | { type: 'RESET';      channel: ChannelConfig };
+
+// ── Definición de campos por tipo ─────────────────────────────────────────────
+
+interface FieldDef {
+  key:         string;
+  label:       string;
+  placeholder: string;
+  type:        'text' | 'password' | 'select' | 'tags';
+  options?:    { value: string; label: string }[];
+  hint?:       string;
+  readOnly?:   boolean;
+}
+
+const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
+  telegram: [
+    {
+      key:         'webhookMode',
+      label:       'Modo de recepción',
+      placeholder: '',
+      type:        'select',
+      options: [
+        { value: 'polling', label: 'Long polling (desarrollo)' },
+        { value: 'webhook', label: 'Webhook HTTPS (producción)' },
+      ],
+      hint: 'Usa "webhook" en producción. El bot no puede recibir mensajes si el polling y el webhook están activos a la vez.',
+    },
+    {
+      key:         'parseMode',
+      label:       'Modo de formato',
+      placeholder: '',
+      type:        'select',
+      options: [
+        { value: 'HTML',       label: 'HTML' },
+        { value: 'MarkdownV2', label: 'Markdown V2 (recomendado)' },
+        { value: 'Markdown',   label: 'Markdown (legacy)' },
+      ],
+    },
+    {
+      key:         'allowedUserIds',
+      label:       'User IDs permitidos',
+      placeholder: '123456789, 987654321 (vacío = todos)',
+      type:        'tags',
+      hint:        'IDs numéricos de Telegram separados por coma. Vacío permite todos los usuarios.',
+    },
+  ],
+
+  whatsapp: [
+    {
+      key:         'verifyToken',
+      label:       'Verify Token (webhook)',
+      placeholder: 'mi-token-secreto',
+      type:        'text',
+      hint:        'Debe coincidir con el valor en el dashboard de Meta Business.',
+    },
+    {
+      key:         'apiVersion',
+      label:       'Versión de la API de Meta',
+      placeholder: 'v18.0',
+      type:        'text',
+      hint:        'Formato: v18.0, v19.0, etc.',
+    },
+    {
+      key:         'phoneId',
+      label:       'Phone Number ID',
+      placeholder: '1234567890',
+      type:        'text',
+      hint:        'ID del número en Meta Business. Visible en Meta Developers → WhatsApp → Getting Started.',
+    },
+    {
+      key:         'allowedPhoneNumbers',
+      label:       'Números permitidos (test)',
+      placeholder: '+34612345678, +1234567890 (vacío = todos)',
+      type:        'tags',
+      hint:        'En producción, deja vacío. En desarrollo, restringe a números de prueba.',
+    },
+  ],
+
+  discord: [
+    {
+      key:         'applicationId',
+      label:       'Application ID',
+      placeholder: '1234567890123456789',
+      type:        'text',
+      hint:        'Discord Developer Portal → General Information → Application ID.',
+    },
+    {
+      key:         'guildId',
+      label:       'Guild ID por defecto (opcional)',
+      placeholder: '1234567890123456789',
+      type:        'text',
+      hint:        'Si se rellena, los slash commands se registran solo en este servidor. Vacío = commands globales.',
+    },
+    {
+      key:         'commandPrefix',
+      label:       'Prefijo de comandos',
+      placeholder: '/',
+      type:        'text',
+      hint:        'Normalmente "/" — solo cambiar para entornos de test.',
+    },
+  ],
+
+  teams: [
+    {
+      key:         'tenantId',
+      label:       'Azure AD Tenant ID',
+      placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+      type:        'text',
+      hint:        'Azure Portal → Azure Active Directory → Properties → Tenant ID.',
+    },
+    {
+      key:         'appId',
+      label:       'Microsoft App ID',
+      placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+      type:        'text',
+      hint:        'Azure Bot Service → Configuration → Microsoft App ID.',
+    },
+    {
+      key:         'serviceMode',
+      label:       'Modo de servicio',
+      placeholder: '',
+      type:        'select',
+      options: [
+        { value: 'bot_framework',    label: 'Bot Framework (recibe actividades)' },
+        { value: 'incoming_webhook', label: 'Incoming Webhook (solo envía)' },
+      ],
+      hint: '"Bot Framework" permite conversaciones bidireccionales. "Incoming Webhook" solo envía cards a un canal Teams.',
+    },
+    {
+      key:         'webhookUrl',
+      label:       'Webhook URL de Teams (solo Incoming Webhook)',
+      placeholder: 'https://contoso.webhook.office.com/webhookb2/...',
+      type:        'text',
+      hint:        'Teams → canal → Connectors → Incoming Webhook → URL.',
+    },
+    {
+      key:         'welcomeMessage',
+      label:       'Mensaje de bienvenida',
+      placeholder: '¡Hola! Soy tu agente de soporte.',
+      type:        'text',
+      hint:        'Se envía automáticamente cuando el bot es instalado en un equipo.',
+    },
+  ],
+};
+
+const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
+  telegram: [
+    {
+      key:         'botToken',
+      label:       'Bot Token',
+      placeholder: 'Dejar vacío para no cambiar · 123456:ABC...',
+      type:        'password',
+      hint:        '@BotFather → /token. Rotarlo invalida el token anterior inmediatamente.',
+    },
+  ],
+  whatsapp: [
+    {
+      key:         'token',
+      label:       'API Token (Bearer)',
+      placeholder: 'Dejar vacío para no cambiar',
+      type:        'password',
+      hint:        'Meta Business → System Users → Generate Token.',
+    },
+  ],
+  discord: [
+    {
+      key:         'botToken',
+      label:       'Bot Token',
+      placeholder: 'Dejar vacío para no cambiar · MTk...',
+      type:        'password',
+      hint:        'Discord Developer Portal → Bot → Reset Token.',
+    },
+    {
+      key:         'appPublicKey',
+      label:       'Public Key (verificación de interacciones)',
+      placeholder: 'Dejar vacío para no cambiar',
+      type:        'password',
+      hint:        'Discord Developer Portal → General Information → Public Key.',
+    },
+  ],
+  teams: [
+    {
+      key:         'appPassword',
+      label:       'App Password (Client Secret)',
+      placeholder: 'Dejar vacío para no cambiar',
+      type:        'password',
+      hint:        'Azure Portal → App Registrations → Certificates & Secrets → New client secret.',
+    },
+  ],
+};
+
+// ── Reducer ────────────────────────────────────────────────────────────────────
+
+function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case 'SET_NAME':
+      return { ...state, name: action.value, dirty: true };
+    case 'SET_CONFIG':
+      return {
+        ...state,
+        config: { ...state.config, [action.key]: action.value },
+        dirty:  true,
+      };
+    case 'SET_SECRET':
+      return {
+        ...state,
+        secrets: { ...state.secrets, [action.key]: action.value },
+        dirty:   true,
+      };
+    case 'RESET':
+      return initFormState(action.channel);
+  }
+}
+
+function initFormState(channel: ChannelConfig): FormState {
+  const config: Record<string, string> = {};
+  for (const [k, v] of Object.entries(channel.config ?? {})) {
+    if (Array.isArray(v)) {
+      config[k] = (v as string[]).join(', ');
+    } else {
+      config[k] = String(v ?? '');
+    }
+  }
+  return { name: channel.name, config, secrets: {}, dirty: false };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): PatchChannelPayload {
+  const payload: PatchChannelPayload = {};
+
+  if (state.name.trim() !== originalChannel.name) {
+    payload.name = state.name.trim();
+  }
+
+  const configFields = CONFIG_FIELDS[originalChannel.type] ?? [];
+  const newConfig: Record<string, unknown> = {};
+  let configChanged = false;
+  for (const field of configFields) {
+    const value = state.config[field.key] ?? '';
+    if (field.type === 'tags') {
+      const arr = value.split(',').map(s => s.trim()).filter(Boolean);
+      newConfig[field.key] = arr;
+      const orig = originalChannel.config[field.key];
+      if (JSON.stringify(arr) !== JSON.stringify(orig)) configChanged = true;
+    } else {
+      newConfig[field.key] = value;
+      if (value !== String(originalChannel.config[field.key] ?? '')) configChanged = true;
+    }
+  }
+  if (configChanged) payload.config = newConfig;
+
+  const nonEmptySecrets: Record<string, string> = {};
+  for (const [k, v] of Object.entries(state.secrets)) {
+    if (v.trim()) nonEmptySecrets[k] = v.trim();
+  }
+  if (Object.keys(nonEmptySecrets).length > 0) {
+    payload.secrets = nonEmptySecrets;
+  }
+
+  return payload;
+}
+
+function getWebhookUrl(gatewayUrl: string, channelId: string, channelType: ChannelType): string {
+  const base = gatewayUrl.replace(/\/$/, '');
+  const paths: Partial<Record<ChannelType, string>> = {
+    telegram: `/channels/telegram/${channelId}/webhook`,
+    whatsapp: `/channels/whatsapp/${channelId}/webhook`,
+    discord:  `/channels/discord/${channelId}/interactions`,
+    teams:    `/channels/teams/${channelId}`,
+  };
+  return paths[channelType] ? `${base}${paths[channelType]}` : '';
+}
+
+// ── Componentes internos ───────────────────────────────────────────────────────
+
+function WebhookUrlRow({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [url]);
+
+  if (!url) return null;
+
+  return (
+    <div className="channel-settings__webhook-row">
+      <span className="channel-settings__webhook-label">Webhook URL</span>
+      <div className="channel-settings__webhook-value">
+        <code className="channel-settings__webhook-url">{url}</code>
+        <button
+          type="button"
+          className="channel-settings__copy-btn"
+          onClick={copy}
+          aria-label="Copiar webhook URL"
+        >
+          {copied ? '✓ Copiado' : 'Copiar'}
+        </button>
+      </div>
+      <p className="channel-settings__webhook-hint">
+        Configura esta URL en el proveedor del canal como endpoint de webhook.
+      </p>
+    </div>
+  );
+}
+
+interface TestResultBannerProps {
+  result:  ChannelTestResult | null;
+  testing: boolean;
+}
+function TestResultBanner({ result, testing }: TestResultBannerProps) {
+  if (testing) {
+    return (
+      <div className="channel-settings__test-banner channel-settings__test-banner--testing">
+        <span className="channel-settings__test-spinner" aria-hidden />
+        Probando conexión…
+      </div>
+    );
+  }
+  if (!result) return null;
+  return (
+    <div
+      className={[
+        'channel-settings__test-banner',
+        result.ok
+          ? 'channel-settings__test-banner--ok'
+          : 'channel-settings__test-banner--error',
+      ].join(' ')}
+      role="status"
+    >
+      {result.ok
+        ? `✓ Conexión OK · ${result.latency}ms · ${result.message}`
+        : `✗ ${result.message}`}
+    </div>
+  );
+}
+
+function FieldInput({
+  field,
+  value,
+  onChange,
+}: {
+  field:    FieldDef;
+  value:    string;
+  onChange: (v: string) => void;
+}) {
+  const id = useId();
+
+  if (field.type === 'select') {
+    return (
+      <div className="channel-settings__field">
+        <label htmlFor={id} className="channel-settings__label">{field.label}</label>
+        <select
+          id={id}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          className="channel-settings__select"
+          disabled={field.readOnly}
+        >
+          {field.options?.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+        {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="channel-settings__field">
+      <label htmlFor={id} className="channel-settings__label">{field.label}</label>
+      <input
+        id={id}
+        type={field.type === 'password' ? 'password' : 'text'}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={field.placeholder}
+        className="channel-settings__input"
+        autoComplete={field.type === 'password' ? 'new-password' : 'off'}
+        readOnly={field.readOnly}
+      />
+      {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
+    </div>
+  );
+}
+
+// ── Componente principal ───────────────────────────────────────────────────────
+
+export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: ChannelSettingsProps) {
+  const [state,      dispatch]     = useReducer(formReducer, channel, initFormState);
+  const [saving,     setSaving]    = useState(false);
+  const [testing,    setTesting]   = useState(false);
+  const [saveErr,    setSaveErr]   = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<ChannelTestResult | null>(null);
+
+  const configFields = CONFIG_FIELDS[channel.type]        ?? [];
+  const secretFields = SECRET_ROTATE_FIELDS[channel.type] ?? [];
+  const webhookUrl   = getWebhookUrl(gatewayUrl, channel.id, channel.type);
+
+  React.useEffect(() => {
+    dispatch({ type: 'RESET', channel });
+    setSaveErr(null);
+    setTestResult(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channel.id]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!state.dirty) return;
+    setSaving(true);
+    setSaveErr(null);
+    try {
+      const payload = buildPatchPayload(state, channel);
+      await onSave(channel.id, payload);
+      dispatch({ type: 'RESET', channel: { ...channel, ...payload } });
+    } catch (err) {
+      setSaveErr(err instanceof Error ? err.message : 'Error al guardar');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleTest() {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await onTest(channel.id);
+      setTestResult(result);
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  if (configFields.length === 0 && secretFields.length === 0) {
+    return (
+      <div className="channel-settings channel-settings--empty">
+        <p className="channel-settings__no-fields">
+          Este tipo de canal no tiene configuración adicional editable.
+        </p>
+        <WebhookUrlRow url={webhookUrl} />
+      </div>
+    );
+  }
+
+  return (
+    <section className="channel-settings" aria-label={`Configuración del canal ${channel.name}`}>
+      {/* Header */}
+      <div className="channel-settings__header">
+        <ChannelTypeIcon type={channel.type} size={24} />
+        <div>
+          <h3 className="channel-settings__channel-name">{channel.name}</h3>
+          <span className="channel-settings__type-badge">{channel.type}</span>
+        </div>
+        <span
+          className={[
+            'channel-settings__status',
+            channel.isActive
+              ? 'channel-settings__status--active'
+              : 'channel-settings__status--inactive',
+          ].join(' ')}
+          aria-label={channel.isActive ? 'Activo' : 'Inactivo'}
+        >
+          {channel.isActive ? 'Activo' : 'Inactivo'}
+        </span>
+      </div>
+
+      {/* Webhook URL */}
+      <WebhookUrlRow url={webhookUrl} />
+
+      {/* Test de conexión */}
+      <div className="channel-settings__test-row">
+        <button
+          type="button"
+          className="channel-settings__test-btn"
+          onClick={() => void handleTest()}
+          disabled={testing || saving}
+          aria-busy={testing}
+        >
+          {testing ? 'Probando…' : '⚡ Test de conexión'}
+        </button>
+        <TestResultBanner result={testResult} testing={testing} />
+      </div>
+
+      {/* Formulario */}
+      <form
+        onSubmit={e => void handleSave(e)}
+        className="channel-settings__form"
+        aria-label="Formulario de configuración"
+        noValidate
+      >
+        {/* Nombre */}
+        <div className="channel-settings__field">
+          <label htmlFor="cs-name" className="channel-settings__label">Nombre del canal</label>
+          <input
+            id="cs-name"
+            type="text"
+            value={state.name}
+            onChange={e => dispatch({ type: 'SET_NAME', value: e.target.value })}
+            className="channel-settings__input"
+            placeholder="Nombre descriptivo"
+          />
+        </div>
+
+        {/* Config pública */}
+        {configFields.length > 0 && (
+          <fieldset className="channel-settings__fieldset">
+            <legend className="channel-settings__legend">Configuración</legend>
+            {configFields.map(field => (
+              <FieldInput
+                key={field.key}
+                field={field}
+                value={state.config[field.key] ?? ''}
+                onChange={v => dispatch({ type: 'SET_CONFIG', key: field.key, value: v })}
+              />
+            ))}
+          </fieldset>
+        )}
+
+        {/* Rotación de secrets */}
+        {secretFields.length > 0 && (
+          <fieldset className="channel-settings__fieldset">
+            <legend className="channel-settings__legend">
+              Credenciales
+              <span className="channel-settings__secret-hint"> — deja vacío para conservar el valor actual</span>
+            </legend>
+            {secretFields.map(field => (
+              <FieldInput
+                key={field.key}
+                field={field}
+                value={state.secrets[field.key] ?? ''}
+                onChange={v => dispatch({ type: 'SET_SECRET', key: field.key, value: v })}
+              />
+            ))}
+          </fieldset>
+        )}
+
+        {saveErr && (
+          <p className="channel-settings__error" role="alert">{saveErr}</p>
+        )}
+
+        <div className="channel-settings__footer">
+          <button
+            type="button"
+            className="channel-settings__btn-reset"
+            onClick={() => dispatch({ type: 'RESET', channel })}
+            disabled={!state.dirty || saving}
+          >
+            Descartar cambios
+          </button>
+          <button
+            type="submit"
+            className="channel-settings__btn-save"
+            disabled={!state.dirty || saving}
+            aria-busy={saving}
+          >
+            {saving ? 'Guardando…' : 'Guardar cambios'}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/features/channels/types.ts
+++ b/apps/web/src/features/channels/types.ts
@@ -10,6 +10,7 @@ export type ChannelType =
   | 'whatsapp'
   | 'slack'
   | 'discord'
+  | 'teams'
   | 'webhook';
 
 export interface ChannelBinding {
@@ -57,6 +58,47 @@ export interface AddBindingPayload {
   scopeLevel?: string;
   scopeId?:    string;
   isDefault?:  boolean;
+}
+
+/** Payload para PATCH de un canal existente */
+export interface PatchChannelPayload {
+  name?:    string;
+  config?:  Record<string, unknown>;
+  secrets?: Record<string, unknown>; // nunca se devuelven, solo se envían
+}
+
+/** Resultado de un test de conexión */
+export interface ChannelTestResult {
+  ok:      boolean;
+  latency: number; // ms
+  message: string;
+}
+
+/** Campos de configuración pública por tipo (no secrets) */
+export interface ChannelConfigFields {
+  telegram: {
+    webhookMode:    'polling' | 'webhook';
+    allowedUserIds: string[];
+    parseMode:      'HTML' | 'Markdown' | 'MarkdownV2';
+  };
+  whatsapp: {
+    phoneId:             string;
+    verifyToken:         string;
+    apiVersion:          string;
+    allowedPhoneNumbers: string[];
+  };
+  discord: {
+    applicationId:  string;
+    guildId?:       string;
+    commandPrefix?: string;
+  };
+  teams: {
+    tenantId:        string;
+    appId:           string;
+    serviceMode:     'bot_framework' | 'incoming_webhook';
+    webhookUrl?:     string;
+    welcomeMessage?: string;
+  };
 }
 
 // Respuestas del API

--- a/apps/web/src/features/channels/useChannels.ts
+++ b/apps/web/src/features/channels/useChannels.ts
@@ -15,11 +15,20 @@
  *   deleteChannel(id)
  *   addBinding(channelId, payload)
  *   removeBinding(channelId, bindingId)
+ *   patchChannel(id, payload)  — F3a-36
+ *   testChannel(id)            — F3a-36
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import * as gwApi from '../../lib/gateway-api';
-import type { ChannelConfig, CreateChannelPayload, AddBindingPayload } from './types';
+import type {
+  ChannelConfig,
+  CreateChannelPayload,
+  AddBindingPayload,
+  PatchChannelPayload,
+  ChannelTestResult,
+  ChannelDetailResponse,
+} from './types';
 
 export function useChannels(filters?: { agentId?: string; type?: string; isActive?: boolean }) {
   const [channels,    setChannels]    = useState<ChannelConfig[]>([]);
@@ -105,6 +114,45 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     [],
   );
 
+  // ── F3a-36: patchChannel + testChannel ──────────────────────────────────────
+
+  const patchChannel = useCallback(
+    async (id: string, payload: PatchChannelPayload): Promise<void> => {
+      const res = await fetch(`/api/channels/${id}`, {
+        method:  'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ message: 'Error al actualizar canal' }));
+        throw new Error((err as { message?: string }).message ?? 'Error al actualizar canal');
+      }
+      const updated: ChannelDetailResponse = await res.json();
+      setChannels(prev =>
+        prev.map(ch => (ch.id === id ? updated.data : ch)),
+      );
+      if (selectedId === id) {
+        // forzar re-render del detalle con datos nuevos
+        setSelectedId(null);
+        requestAnimationFrame(() => setSelectedId(id));
+      }
+    },
+    [selectedId],
+  );
+
+  const testChannel = useCallback(
+    async (id: string): Promise<ChannelTestResult> => {
+      const res = await fetch(`/api/channels/${id}/test`, { method: 'POST' });
+      if (!res.ok) {
+        return { ok: false, latency: 0, message: 'No se pudo conectar al canal' };
+      }
+      return res.json() as Promise<ChannelTestResult>;
+    },
+    [],
+  );
+
+  // ── ──────────────────────────────────────────────────────────────────────────
+
   const selected = channels.find(c => c.id === selectedId) ?? null;
 
   return {
@@ -121,5 +169,7 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     deleteChannel,
     addBinding,
     removeBinding,
+    patchChannel,
+    testChannel,
   };
 }


### PR DESCRIPTION
## [F3a-36] ChannelSettings UI — Telegram, WhatsApp, Discord, Teams

### Descripción

Implementa la Channel Settings UI completa: vista de configuración por tipo de canal (Telegram, WhatsApp, Discord, Teams) con edición de config pública, rotación de secrets, webhook URL copiable y test de conexión.

---

### Archivos modificados / creados

| Archivo | Acción | Descripción |
|---------|--------|-------------|
| `apps/web/src/features/channels/types.ts` | **MODIFICADO** | Añade `'teams'` a `ChannelType` + `PatchChannelPayload`, `ChannelTestResult`, `ChannelConfigFields` |
| `apps/web/src/features/channels/useChannels.ts` | **MODIFICADO** | Añade `patchChannel()` y `testChannel()` al hook |
| `apps/web/src/features/channels/components/ChannelSettings.tsx` | **CREADO** | Componente principal F3a-36 |
| `apps/web/src/features/channels/components/ChannelDetail.tsx` | **MODIFICADO** | 3 pestañas: General, Configuración, Bindings |
| `apps/web/src/features/channels/ChannelsPage.tsx` | **MODIFICADO** | Pasa `patchChannel` y `testChannel` a `ChannelDetail` |
| `apps/web/src/features/channels/channels.css` | **CREADO** | Estilos `.channel-settings__*` + `.channel-detail__tabs` |

---

### Campos por canal

**Telegram:** `webhookMode` (select), `parseMode` (select), `allowedUserIds` (tags) + `botToken` (rotate)

**WhatsApp:** `verifyToken`, `apiVersion`, `phoneId`, `allowedPhoneNumbers` + `token` (rotate)

**Discord:** `applicationId`, `guildId`, `commandPrefix` + `botToken` + `appPublicKey` (rotate)

**Teams:** `tenantId`, `appId`, `serviceMode` (select bot_framework/incoming_webhook), `webhookUrl`, `welcomeMessage` + `appPassword` (rotate)

---

### Criterio de aceptación

- [x] `ChannelType` incluye `'teams'`
- [x] `ChannelDetail` tiene 3 pestañas: General, Configuración, Bindings
- [x] Campos correctos por tipo de canal
- [x] Webhook URL copiable (Telegram, WhatsApp, Discord, Teams)
- [x] `Guardar cambios` solo habilitado cuando `dirty === true`
- [x] `Descartar cambios` revierte estado al original
- [x] Secrets vacíos NO se envían en el PATCH
- [x] Test de conexión muestra latency en ms
- [x] webchat/webhook sin campos → mensaje informativo

### Commit
`49bd845154bf16f1f2d76c9bcb9b75ee65761ee2`

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced tabbed interface for channel management with General, Settings, and Bindings sections.
  * Added channel configuration settings with editable fields for channel-specific credentials and settings.
  * Added connection test functionality to verify channel connectivity.
  * Added support for Teams channels.

* **Style**
  * Added comprehensive styling for the new channel interface and settings panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->