### PR TITLE
feat(F3a-37): ChannelStatusCard SSE + WhatsApp QR Modal

### DIFF
--- a/apps/gateway/src/channels/channel-adapter.interface.ts
+++ b/apps/gateway/src/channels/channel-adapter.interface.ts
@@ -23,6 +23,7 @@ export type ChannelType =
   | 'discord'
   | 'slack'
   | 'webhook'
+  | 'teams'
 
 // ── AdapterMode ──────────────────────────────────────────────────────────────
 

--- a/apps/gateway/src/channels/teams/__tests__/teams-bot.adapter.spec.ts
+++ b/apps/gateway/src/channels/teams/__tests__/teams-bot.adapter.spec.ts
@@ -1,0 +1,331 @@
+/**
+ * teams-bot.adapter.spec.ts — [F3a-32]
+ * Tests del TeamsAdapter con mocks de express Request/Response.
+ */
+
+import { Request, Response } from 'express'
+import { TeamsAdapter } from '../teams-bot.adapter.js'
+import type { TeamsActivity } from '../teams-mode.strategy.js'
+
+// ── Mock de la estrategia ────────────────────────────────────────────────────
+
+const mockStrategy = {
+  mode:           'bot_framework' as const,
+  send:           jest.fn().mockResolvedValue({ ok: true, activityId: 'act-001' }),
+  verify:         jest.fn().mockResolvedValue({ ok: true }),
+  buildTextCard:  jest.fn().mockReturnValue({
+    contentType: 'application/vnd.microsoft.card.adaptive',
+    content: {},
+  }),
+  getBearerToken: jest.fn().mockResolvedValue('fake-token'),
+}
+
+jest.mock('../index.js', () => ({
+  ...jest.requireActual('../index.js'),
+  createTeamsModeStrategy: jest.fn().mockReturnValue(mockStrategy),
+}))
+
+// ── Helpers de test ──────────────────────────────────────────────────────────
+
+function makeActivity(overrides: Partial<TeamsActivity> = {}): TeamsActivity {
+  return {
+    type:        'message',
+    id:          'act-test-001',
+    timestamp:   '2026-05-01T20:00:00Z',
+    serviceUrl:  'https://smba.trafficmanager.net/teams',
+    channelId:   'msteams',
+    from: {
+      id:          'user-aad-001',
+      name:        'Test User',
+      aadObjectId: 'aad-obj-001',
+    },
+    conversation: {
+      id:       'conv-001',
+      tenantId: 'tenant-001',
+      isGroup:  false,
+    },
+    recipient: { id: 'bot-id-001', name: 'TestBot' },
+    text:       'Hola agente',
+    ...overrides,
+  }
+}
+
+function makeReqRes(body: unknown, authHeader = '') {
+  const req = {
+    body,
+    headers: { authorization: authHeader },
+  } as unknown as Request
+
+  const res = {
+    status:  jest.fn().mockReturnThis(),
+    json:    jest.fn().mockReturnThis(),
+    send:    jest.fn().mockReturnThis(),
+  } as unknown as Response
+
+  return { req, res }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('TeamsAdapter', () => {
+  let adapter: TeamsAdapter
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    adapter = new TeamsAdapter()
+    await adapter.initialize('channel-config-teams-001')
+    await adapter.setup(
+      { mode: 'bot_framework' },
+      { appId: 'test-app-id', appPassword: 'test-app-pwd' },
+    )
+  })
+
+  // ── initialize y setup ───────────────────────────────────────────────────
+
+  it('initialize() setea channelConfigId', async () => {
+    const a = new TeamsAdapter()
+    await a.initialize('cfg-xyz')
+    expect((a as any).channelConfigId).toBe('cfg-xyz')
+  })
+
+  it('setup() llama strategy.verify()', async () => {
+    expect(mockStrategy.verify).toHaveBeenCalledTimes(1)
+  })
+
+  it('getRouter() lanza si se llama antes de setup()', () => {
+    const raw = new TeamsAdapter()
+    expect(() => raw.getRouter()).toThrow('setup()')
+  })
+
+  // ── GET /health ───────────────────────────────────────────────────────────
+
+  it('GET /health devuelve status ok con modo y channelConfigId', async () => {
+    const router = adapter.getRouter()
+    const { req, res } = makeReqRes({})
+
+    const layer = (router as any).stack.find((l: any) =>
+      l.route?.path === '/health' && l.route?.methods?.get
+    )
+    expect(layer).toBeDefined()
+
+    await layer.route.stack[0].handle(req, res, jest.fn())
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status:          'ok',
+        channel:         'teams',
+        mode:            'bot_framework',
+        channelConfigId: 'channel-config-teams-001',
+      })
+    )
+  })
+
+  // ── Autenticación ─────────────────────────────────────────────────────────
+
+  it('POST /messages sin Authorization header devuelve 401', async () => {
+    const { req, res } = makeReqRes(makeActivity(), '')
+    const next = jest.fn()
+
+    await (adapter as any)._verifyBotFrameworkAuth(req, res, next)
+
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('POST /messages con JWT con appid incorrecto devuelve 401', async () => {
+    const header  = Buffer.from('{"alg":"RS256"}').toString('base64url')
+    const payload = Buffer.from('{"appid":"wrong-app-id"}').toString('base64url')
+    const token   = `${header}.${payload}.fakesig`
+
+    const { req, res } = makeReqRes(makeActivity(), `Bearer ${token}`)
+    const next = jest.fn()
+
+    await (adapter as any)._verifyBotFrameworkAuth(req, res, next)
+
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('POST /messages con JWT correcto llama next()', async () => {
+    const header  = Buffer.from('{"alg":"RS256"}').toString('base64url')
+    const payload = Buffer.from('{"appid":"test-app-id"}').toString('base64url')
+    const token   = `${header}.${payload}.fakesig`
+
+    const { req, res } = makeReqRes(makeActivity(), `Bearer ${token}`)
+    const next = jest.fn()
+
+    await (adapter as any)._verifyBotFrameworkAuth(req, res, next)
+
+    expect(next).toHaveBeenCalled()
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
+  // ── Manejo de Activity 'message' ──────────────────────────────────────────
+
+  it('_handleActivity message: responde 200 y emite IncomingMessage normalizado', async () => {
+    const emitSpy      = jest.spyOn(adapter as any, 'emit').mockResolvedValue(undefined)
+    const activity     = makeActivity()
+    const { req, res } = makeReqRes(activity)
+
+    await (adapter as any)._handleActivity(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+
+    // Esperar el background emit
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelConfigId: 'channel-config-teams-001',
+        channelType:     'teams',
+        externalId:      'conv-001',
+        senderId:        'aad-obj-001',
+        text:            'Hola agente',
+        type:            'text',
+        msgId:           'act-test-001',
+        metadata:        expect.objectContaining({
+          serviceUrl: 'https://smba.trafficmanager.net/teams',
+          tenantId:   'tenant-001',
+        }),
+      })
+    )
+  })
+
+  it('_handleActivity message vacío: responde 200 sin llamar emit()', async () => {
+    const emitSpy      = jest.spyOn(adapter as any, 'emit').mockResolvedValue(undefined)
+    const activity     = makeActivity({ text: '   ' })
+    const { req, res } = makeReqRes(activity)
+
+    await (adapter as any)._handleActivity(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    await new Promise((r) => setTimeout(r, 50))
+    expect(emitSpy).not.toHaveBeenCalled()
+  })
+
+  it('_handleActivity conversationUpdate: responde 200 sin emit()', async () => {
+    const emitSpy      = jest.spyOn(adapter as any, 'emit').mockResolvedValue(undefined)
+    const activity     = makeActivity({ type: 'conversationUpdate', text: undefined })
+    const { req, res } = makeReqRes(activity)
+
+    await (adapter as any)._handleActivity(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(emitSpy).not.toHaveBeenCalled()
+  })
+
+  it('_handleActivity invoke: responde 200 con JSON vacío', async () => {
+    const activity     = makeActivity({ type: 'invoke', text: undefined })
+    const { req, res } = makeReqRes(activity)
+
+    await (adapter as any)._handleActivity(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({})
+  })
+
+  it('_handleActivity sin type: responde 400', async () => {
+    const { req, res } = makeReqRes({ noType: true })
+
+    await (adapter as any)._handleActivity(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+  })
+
+  // ── send() ────────────────────────────────────────────────────────────────
+
+  it('send() llama strategy.send con payload correcto', async () => {
+    await adapter.send({
+      externalId: 'conv-001',
+      text:       'Respuesta del agente',
+      metadata:   { serviceUrl: 'https://smba.trafficmanager.net/teams' },
+    })
+
+    expect(mockStrategy.send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'message' }),
+      'conv-001',
+      'https://smba.trafficmanager.net/teams',
+    )
+  })
+
+  it('send() con richContent tipo card genera Adaptive Card', async () => {
+    await adapter.send({
+      externalId: 'conv-001',
+      text:       'Fallback',
+      richContent: {
+        type: 'card',
+        card: {
+          title:    'Tarjeta de prueba',
+          subtitle: 'Subtítulo',
+          buttons:  [{ label: 'OK', payload: 'ok' }],
+        },
+      },
+      metadata: { serviceUrl: 'https://smba.trafficmanager.net/teams' },
+    })
+
+    const [payloadArg] = mockStrategy.send.mock.calls[0]!
+    expect(payloadArg.attachments).toBeDefined()
+    expect(payloadArg.attachments![0].contentType).toBe(
+      'application/vnd.microsoft.card.adaptive'
+    )
+  })
+
+  it('send() con richContent tipo quick_replies genera card con botones', async () => {
+    await adapter.send({
+      externalId: 'conv-001',
+      text:       'Fallback',
+      richContent: {
+        type:    'quick_replies',
+        replies: [{ label: 'Opción A', payload: 'a' }, { label: 'Opción B', payload: 'b' }],
+      },
+      metadata: { serviceUrl: 'https://smba.trafficmanager.net/teams' },
+    })
+
+    const [payloadArg] = mockStrategy.send.mock.calls[0]!
+    expect(payloadArg.attachments).toBeDefined()
+  })
+
+  it('send() sin richContent usa buildAdaptiveTextCard', async () => {
+    await adapter.send({
+      externalId: 'conv-001',
+      text:       'Texto plano simple',
+      metadata:   { serviceUrl: 'https://smba.trafficmanager.net/teams' },
+    })
+
+    const [payloadArg] = mockStrategy.send.mock.calls[0]!
+    expect(payloadArg.attachments).toHaveLength(1)
+  })
+
+  // ── dispose ───────────────────────────────────────────────────────────────
+
+  it('dispose() resuelve sin errores', async () => {
+    await expect(adapter.dispose()).resolves.toBeUndefined()
+  })
+
+  // ── mode incoming_webhook: POST /messages devuelve 400 ───────────────────
+
+  it('incoming_webhook: POST /messages devuelve 400 con mensaje explicativo', async () => {
+    jest.resetAllMocks()
+    const webhookStrategy = { ...mockStrategy, mode: 'incoming_webhook' as const }
+    const { createTeamsModeStrategy: mockFactory } = jest.requireMock('../index.js') as any
+    mockFactory.mockReturnValue(webhookStrategy)
+
+    const wAdapter = new TeamsAdapter()
+    await wAdapter.initialize('cfg-wh-001')
+    await wAdapter.setup({ mode: 'incoming_webhook' }, { webhookUrl: 'https://company.webhook.office.com/fake' })
+
+    const router = wAdapter.getRouter()
+    const postLayer = (router as any).stack.find((l: any) =>
+      l.route?.path === '/messages' && l.route?.methods?.post
+    )
+    expect(postLayer).toBeDefined()
+
+    const { req, res } = makeReqRes(makeActivity())
+    await postLayer.route.stack[0].handle(req, res, jest.fn())
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('Incoming Webhook') })
+    )
+  })
+})

--- a/apps/gateway/src/channels/teams/__tests__/teams-webhook.adapter.spec.ts
+++ b/apps/gateway/src/channels/teams/__tests__/teams-webhook.adapter.spec.ts
@@ -1,0 +1,319 @@
+/**
+ * teams-webhook.adapter.spec.ts — [F3a-33]
+ *
+ * 20 tests unitarios.
+ * Sin red real — fetch mockeado completamente via jest.spyOn(global, 'fetch').
+ *
+ * Suites:
+ *   - constructor validation
+ *   - sendText: POST shape, truncation, error response
+ *   - notify: all severities, FactSet, actions, no-title, no-actions
+ *   - retry logic: 429 retry success, max retries exhausted, no retry on 400
+ *   - verify: ok / error
+ *   - sendTeamsNotification helper: ok / invalid URL
+ */
+
+import {
+  TeamsWebhookAdapter,
+  sendTeamsNotification,
+  type TeamsNotification,
+} from '../teams-webhook.adapter.js'
+
+const FAKE_WEBHOOK = 'https://company.webhook.office.com/webhookb2/fake-id'
+
+// ── Mock helpers ──────────────────────────────────────────────────────────────
+
+function mockFetch(status: number, body = '1') {
+  return jest.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(body, {
+      status,
+      headers: { 'Content-Type': 'text/plain' },
+    }),
+  )
+}
+
+function getParsedBody(spy: jest.SpyInstance, callIndex = 0): {
+  type:        string
+  attachments: Array<{ contentType: string; content: Record<string, unknown> }>
+} {
+  const init = spy.mock.calls[callIndex]![1] as RequestInit
+  return JSON.parse(init.body as string)
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+describe('TeamsWebhookAdapter — constructor', () => {
+  it('lanza error si webhookUrl no es HTTPS', () => {
+    expect(() =>
+      new TeamsWebhookAdapter({ webhookUrl: 'http://insecure.com' }),
+    ).toThrow('HTTPS')
+  })
+
+  it('lanza error si webhookUrl está vacía', () => {
+    expect(() =>
+      new TeamsWebhookAdapter({ webhookUrl: '' }),
+    ).toThrow('HTTPS')
+  })
+
+  it('acepta URL HTTPS válida sin lanzar error', () => {
+    expect(() =>
+      new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK }),
+    ).not.toThrow()
+  })
+})
+
+// ── sendText ──────────────────────────────────────────────────────────────────
+
+describe('TeamsWebhookAdapter — sendText', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('hace POST a webhookUrl con Adaptive Card de texto', async () => {
+    const spy     = mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    const result = await adapter.sendText('Hola Teams')
+
+    expect(result.ok).toBe(true)
+    expect(spy).toHaveBeenCalledWith(
+      FAKE_WEBHOOK,
+      expect.objectContaining({ method: 'POST' }),
+    )
+
+    const parsed = getParsedBody(spy)
+    expect(parsed.type).toBe('message')
+    expect(parsed.attachments).toHaveLength(1)
+    expect(parsed.attachments[0]!.contentType).toBe(
+      'application/vnd.microsoft.card.adaptive',
+    )
+    const cardBody = (parsed.attachments[0]!.content as Record<string, unknown>).body as Array<Record<string, unknown>>
+    expect(cardBody[0]!.text).toBe('Hola Teams')
+  })
+
+  it('trunca texto mayor a 28.000 caracteres', async () => {
+    const spy      = mockFetch(200)
+    const adapter  = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+    const longText = 'a'.repeat(30_000)
+
+    await adapter.sendText(longText)
+
+    const parsed   = getParsedBody(spy)
+    const cardBody = (parsed.attachments[0]!.content as Record<string, unknown>).body as Array<Record<string, unknown>>
+    const cardText = cardBody[0]!.text as string
+    expect(cardText.length).toBeLessThanOrEqual(28_200)
+    expect(cardText).toContain('[truncado]')
+  })
+
+  it('devuelve ok: false si Teams responde 500', async () => {
+    mockFetch(500, 'Internal Server Error')
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    const result = await adapter.sendText('test')
+    expect(result.ok).toBe(false)
+    expect(result.statusCode).toBe(500)
+    expect(result.error).toContain('500')
+  })
+
+  it('devuelve ok: true con statusCode en respuesta exitosa', async () => {
+    mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    const result = await adapter.sendText('ok test')
+    expect(result.ok).toBe(true)
+    expect(result.statusCode).toBe(200)
+    expect(result.retriedCount).toBe(0)
+  })
+})
+
+// ── notify ────────────────────────────────────────────────────────────────────
+
+describe('TeamsWebhookAdapter — notify', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('envía Adaptive Card con título, body, FactSet y Action.OpenUrl', async () => {
+    const spy = mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    await adapter.notify({
+      title:    'Deploy completado',
+      body:     'Versión **v2.4.1** desplegada',
+      severity: 'success',
+      facts:    [{ name: 'Duración', value: '45s' }],
+      actions:  [{ label: 'Ver logs', url: 'https://logs.example.com' }],
+    })
+
+    const parsed  = getParsedBody(spy)
+    const content = parsed.attachments[0]!.content as Record<string, unknown>
+    const cardBody = content.body as Array<Record<string, unknown>>
+
+    expect(content.type).toBe('AdaptiveCard')
+
+    const titleBlock = cardBody.find((b) => b['weight'] === 'Bolder')
+    expect(titleBlock?.['text']).toContain('Deploy completado')
+    expect(titleBlock?.['text']).toContain('✅')
+
+    const factSet = cardBody.find((b) => b['type'] === 'FactSet') as Record<string, unknown>
+    const facts   = factSet?.['facts'] as Array<Record<string, string>>
+    expect(facts[0]).toEqual({ title: 'Duración', value: '45s' })
+
+    const actions = content.actions as Array<Record<string, unknown>>
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!['type']).toBe('Action.OpenUrl')
+    expect(actions[0]!['url']).toBe('https://logs.example.com')
+  })
+
+  it('severity error → emoji 🔴 y color Attention', async () => {
+    const spy = mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    await adapter.notify({ body: 'Fallo crítico', severity: 'error', title: 'Error' })
+
+    const parsed   = getParsedBody(spy)
+    const content  = parsed.attachments[0]!.content as Record<string, unknown>
+    const cardBody = content.body as Array<Record<string, unknown>>
+    const title    = cardBody.find((b) => b['weight'] === 'Bolder')
+
+    expect(title?.['text']).toContain('🔴')
+    expect(title?.['color']).toBe('Attention')
+  })
+
+  it('severity warning → emoji ⚠️ y color Warning', async () => {
+    const spy = mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    await adapter.notify({ body: 'Aviso', severity: 'warning', title: 'Cuidado' })
+
+    const parsed   = getParsedBody(spy)
+    const content  = parsed.attachments[0]!.content as Record<string, unknown>
+    const cardBody = content.body as Array<Record<string, unknown>>
+    const title    = cardBody.find((b) => b['weight'] === 'Bolder')
+
+    expect(title?.['text']).toContain('⚠️')
+    expect(title?.['color']).toBe('Warning')
+  })
+
+  it('sin actions → no incluye array actions en el card', async () => {
+    const spy = mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    await adapter.notify({ body: 'Sin botones', severity: 'info' })
+
+    const parsed  = getParsedBody(spy)
+    const content = parsed.attachments[0]!.content as Record<string, unknown>
+    expect(content['actions']).toBeUndefined()
+  })
+
+  it('sin título → no incluye bloque Bolder', async () => {
+    const spy = mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+
+    await adapter.notify({ body: 'Solo body', severity: 'info' })
+
+    const parsed   = getParsedBody(spy)
+    const content  = parsed.attachments[0]!.content as Record<string, unknown>
+    const cardBody = content.body as Array<Record<string, unknown>>
+    const boldBlock = cardBody.find((b) => b['weight'] === 'Bolder')
+    expect(boldBlock).toBeUndefined()
+  })
+})
+
+// ── Retry logic ───────────────────────────────────────────────────────────────
+
+describe('TeamsWebhookAdapter — retry logic', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('reintenta ante 429 y tiene éxito en el segundo intento', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response('Too Many Requests', { status: 429 }))
+      .mockResolvedValueOnce(new Response('1', { status: 200 }))
+
+    const adapter = new TeamsWebhookAdapter({
+      webhookUrl:   FAKE_WEBHOOK,
+      retryDelayMs: 5,
+      maxRetries:   2,
+    })
+
+    const result = await adapter.sendText('test retry')
+
+    expect(result.ok).toBe(true)
+    expect(result.retriedCount).toBe(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('devuelve ok: false tras agotar todos los reintentos (503)', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('Service Unavailable', { status: 503 }),
+    )
+
+    const adapter = new TeamsWebhookAdapter({
+      webhookUrl:   FAKE_WEBHOOK,
+      retryDelayMs: 5,
+      maxRetries:   2,
+    })
+
+    const result = await adapter.sendText('test max retries')
+    expect(result.ok).toBe(false)
+    expect(result.retriedCount).toBe(2)
+  })
+
+  it('NO reintenta ante 400 Bad Request', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('Bad Request', { status: 400 }),
+    )
+
+    const adapter = new TeamsWebhookAdapter({
+      webhookUrl:   FAKE_WEBHOOK,
+      retryDelayMs: 5,
+      maxRetries:   2,
+    })
+
+    const result = await adapter.sendText('bad payload')
+    expect(result.ok).toBe(false)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── verify ────────────────────────────────────────────────────────────────────
+
+describe('TeamsWebhookAdapter — verify', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('devuelve ok: true si Teams responde 200', async () => {
+    mockFetch(200)
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+    const result  = await adapter.verify()
+    expect(result.ok).toBe(true)
+  })
+
+  it('devuelve ok: false si Teams responde 404', async () => {
+    mockFetch(404, 'Not Found')
+    const adapter = new TeamsWebhookAdapter({ webhookUrl: FAKE_WEBHOOK })
+    const result  = await adapter.verify()
+    expect(result.ok).toBe(false)
+    expect(result.statusCode).toBe(404)
+  })
+})
+
+// ── sendTeamsNotification (función helper) ────────────────────────────────────
+
+describe('sendTeamsNotification', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('crea adapter y llama notify() correctamente', async () => {
+    const spy = mockFetch(200)
+
+    const result = await sendTeamsNotification(FAKE_WEBHOOK, {
+      title:    'Prueba',
+      body:     'Mensaje de prueba',
+      severity: 'info',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('lanza error si webhookUrl no es HTTPS', async () => {
+    await expect(
+      sendTeamsNotification('http://insecure', { body: 'test', severity: 'info' }),
+    ).rejects.toThrow('HTTPS')
+  })
+})

--- a/apps/gateway/src/channels/teams/index.ts
+++ b/apps/gateway/src/channels/teams/index.ts
@@ -24,6 +24,18 @@ export {
   buildAdaptiveRichCard,
 } from './teams-mode.strategy.js'
 
-// Re-export del adapter (F3a-32)
+// Re-export del adapter bidireccional (F3a-32)
 export { TeamsAdapter } from './teams-bot.adapter.js'
 export type { TeamsAdapterConfig } from './teams-bot.adapter.js'
+
+// TeamsWebhookAdapter — solo-envío, notificaciones de sistema (F3a-33)
+export {
+  TeamsWebhookAdapter,
+  sendTeamsNotification,
+} from './teams-webhook.adapter.js'
+
+export type {
+  TeamsWebhookConfig,
+  TeamsWebhookSendResult,
+  TeamsNotification,
+} from './teams-webhook.adapter.js'

--- a/apps/gateway/src/channels/teams/index.ts
+++ b/apps/gateway/src/channels/teams/index.ts
@@ -23,3 +23,7 @@ export {
   buildAdaptiveTextCard,
   buildAdaptiveRichCard,
 } from './teams-mode.strategy.js'
+
+// Re-export del adapter (F3a-32)
+export { TeamsAdapter } from './teams-bot.adapter.js'
+export type { TeamsAdapterConfig } from './teams-bot.adapter.js'

--- a/apps/gateway/src/channels/teams/teams-bot.adapter.ts
+++ b/apps/gateway/src/channels/teams/teams-bot.adapter.ts
@@ -1,0 +1,482 @@
+/**
+ * teams-bot.adapter.ts — [F3a-32]
+ *
+ * Adapter de Microsoft Teams para el Gateway.
+ * Hereda de BaseChannelAdapter e implementa IHttpChannelAdapter.
+ *
+ * Rutas expuestas:
+ *   POST /teams/messages   — webhook de actividades Bot Framework
+ *   GET  /teams/health     — healthcheck (devuelve mode activo)
+ *
+ * Modos de operación (definidos en F3a-31):
+ *   incoming_webhook  — solo envío, no registra rutas de recepción
+ *   bot_framework     — bidireccional completo con verificación JWT
+ *
+ * Verificación de autenticidad (bot_framework):
+ *   El Bot Connector Service envía un Bearer JWT firmado con la clave pública
+ *   de Microsoft. La verificación completa requiere la librería botframework-connector.
+ *   Esta implementación usa una validación mínima:
+ *     1. Extrae el Bearer token del header Authorization
+ *     2. Decodifica el JWT (sin verificar firma — SOLO para desarrollo local)
+ *     3. Comprueba que el claim 'appid' coincide con el appId configurado
+ *
+ *   IMPORTANTE PARA PRODUCCIÓN: Instalar `botframework-connector` y usar
+ *   JwtTokenValidation.authenticateRequest() para verificación de firma real.
+ *
+ * Activity types que maneja:
+ *   message            → normaliza a IncomingMessage y pasa al agente
+ *   conversationUpdate → log de join/leave, no emite al agente
+ *   invoke             → responde 200 vacío (Teams health check)
+ *   otros              → log y 200 OK sin proceso
+ */
+
+import { Router, Request, Response, NextFunction } from 'express'
+import {
+  BaseChannelAdapter,
+  IHttpChannelAdapter,
+  IncomingMessage,
+  OutgoingMessage,
+  RichContent,
+} from '../channel-adapter.interface.js'
+import {
+  ITeamsModeStrategy,
+  TeamsActivity,
+  TeamsAttachment,
+  TeamsOutgoingPayload,
+  createTeamsModeStrategy,
+  buildAdaptiveTextCard,
+  buildAdaptiveRichCard,
+} from './index.js'
+
+// ── Tipos de configuración ────────────────────────────────────────────────────
+
+export interface TeamsAdapterConfig {
+  /** Modo de operación — se detecta automáticamente si se omite */
+  mode?:           'incoming_webhook' | 'bot_framework'
+  /** Tiempo máximo de procesamiento del agente en ms (default: 25s) */
+  agentTimeoutMs?: number
+  /** Locale por defecto para Adaptive Cards */
+  defaultLocale?:  string
+  /** Prefijo del endpoint (default: '/teams') */
+  routePrefix?:    string
+}
+
+// ── TeamsAdapter ─────────────────────────────────────────────────────────────
+
+export class TeamsAdapter
+  extends BaseChannelAdapter
+  implements IHttpChannelAdapter
+{
+  readonly channel = 'teams' as const
+
+  private strategy!:    ITeamsModeStrategy
+  private config!:      TeamsAdapterConfig
+  private secrets!:     Record<string, unknown>
+  private router!:      Router
+  private readonly routePrefix: string
+
+  constructor(config: TeamsAdapterConfig = {}) {
+    super()
+    this.routePrefix = config.routePrefix ?? '/teams'
+  }
+
+  // ── IChannelAdapter: initialize ────────────────────────────────────────────
+
+  async initialize(channelConfigId: string): Promise<void> {
+    this.channelConfigId = channelConfigId
+    // initialize() sin credentials es un no-op; setup() completa la inicialización
+  }
+
+  /**
+   * Configuración completa del adapter.
+   * Debe llamarse después de initialize() con las credenciales desde BD.
+   *
+   * @param config   Configuración no sensible (TeamsAdapterConfig)
+   * @param secrets  Credenciales (webhookUrl | appId + appPassword)
+   */
+  async setup(
+    config:  TeamsAdapterConfig,
+    secrets: Record<string, unknown>,
+  ): Promise<void> {
+    this.config  = config
+    this.secrets = secrets
+
+    // Crear estrategia según modo
+    this.strategy = createTeamsModeStrategy(config, secrets)
+
+    // Verificar conectividad al iniciar
+    const check = await this.strategy.verify()
+    if (!check.ok) {
+      console.warn(
+        `[TeamsAdapter:${this.channelConfigId}] ` +
+        `Credential verification failed: ${check.error}. ` +
+        `Adapter will start but messages may fail.`
+      )
+    } else {
+      console.info(
+        `[TeamsAdapter:${this.channelConfigId}] ` +
+        `Teams adapter initialized in ${this.strategy.mode} mode ✓`
+      )
+    }
+
+    // Construir el router Express
+    this.router = this._buildRouter()
+  }
+
+  // ── IHttpChannelAdapter: getRouter ────────────────────────────────────────
+
+  getRouter(): Router {
+    if (!this.router) {
+      throw new Error(
+        '[TeamsAdapter] getRouter() called before setup(). ' +
+        'Call adapter.setup(config, secrets) first.'
+      )
+    }
+    return this.router
+  }
+
+  // ── IChannelAdapter: send ─────────────────────────────────────────────────
+
+  /**
+   * Envía una respuesta del agente al canal Teams.
+   *
+   * Para bot_framework, el serviceUrl y conversationId deben estar
+   * en message.metadata.serviceUrl y message.externalId respectivamente.
+   *
+   * Para incoming_webhook, solo se necesita message.text.
+   */
+  async send(message: OutgoingMessage): Promise<void> {
+    const payload    = this._buildTeamsPayload(message)
+    const serviceUrl = message.metadata?.['serviceUrl'] as string | undefined
+
+    const result = await this.strategy.send(
+      payload,
+      message.externalId,
+      serviceUrl,
+    )
+
+    if (!result.ok) {
+      console.error(
+        `[TeamsAdapter:${this.channelConfigId}] ` +
+        `Failed to send message to Teams: ${result.error}`
+      )
+    }
+  }
+
+  // ── IChannelAdapter: dispose ──────────────────────────────────────────────
+
+  async dispose(): Promise<void> {
+    // Teams no mantiene conexiones persistentes
+    console.info(`[TeamsAdapter:${this.channelConfigId}] Teams adapter disposed.`)
+  }
+
+  // ── Router builder ────────────────────────────────────────────────────────
+
+  private _buildRouter(): Router {
+    const router = Router()
+
+    // ── GET /health ──────────────────────────────────────────────────────────
+    router.get('/health', (_req: Request, res: Response) => {
+      res.json({
+        status:          'ok',
+        channel:         'teams',
+        mode:            this.strategy.mode,
+        channelConfigId: this.channelConfigId,
+        timestamp:       new Date().toISOString(),
+      })
+    })
+
+    // ── POST /messages ───────────────────────────────────────────────────────
+    // Solo registrar el webhook de recepción en modo bot_framework
+    if (this.strategy.mode === 'bot_framework') {
+      router.post(
+        '/messages',
+        this._verifyBotFrameworkAuth.bind(this),
+        this._handleActivity.bind(this),
+      )
+    } else {
+      // incoming_webhook: ruta registrada pero informa que no recibe
+      router.post('/messages', (_req: Request, res: Response) => {
+        res.status(400).json({
+          error: 'Este canal Teams está configurado como Incoming Webhook (solo envío). ' +
+                 'Para recibir mensajes, configura el modo bot_framework.',
+        })
+      })
+    }
+
+    return router
+  }
+
+  // ── Middleware: verificación Bot Framework ────────────────────────────────
+
+  /**
+   * Verificación mínima del Bearer token JWT enviado por el Bot Connector Service.
+   *
+   * ADVERTENCIA DE SEGURIDAD:
+   * Esta implementación verifica solo el claim 'appid' decodificando el JWT
+   * sin verificar la firma criptográfica. Suficiente para desarrollo local.
+   *
+   * PARA PRODUCCIÓN: usar botframework-connector:
+   *   import { JwtTokenValidation, SimpleCredentialProvider } from 'botframework-connector'
+   *   const credentials = new SimpleCredentialProvider(appId, appPassword)
+   *   await JwtTokenValidation.authenticateRequest(activity, authHeader, credentials)
+   */
+  private _verifyBotFrameworkAuth(
+    req:  Request,
+    res:  Response,
+    next: NextFunction,
+  ): void {
+    if (this.strategy.mode !== 'bot_framework') {
+      next()
+      return
+    }
+
+    const authHeader = (req.headers['authorization'] as string) ?? ''
+    if (!authHeader.startsWith('Bearer ')) {
+      res.status(401).json({ error: 'Missing Bearer token' })
+      return
+    }
+
+    const token = authHeader.slice(7)
+
+    try {
+      const parts = token.split('.')
+      if (parts.length !== 3) {
+        res.status(401).json({ error: 'Invalid JWT format' })
+        return
+      }
+
+      const payloadB64 = parts[1]!
+      const padded     = payloadB64.replace(/-/g, '+').replace(/_/g, '/')
+      const decoded    = Buffer.from(padded, 'base64').toString('utf-8')
+      const claims     = JSON.parse(decoded) as Record<string, unknown>
+
+      const appId = this.secrets['appId'] as string
+      if (claims['appid'] !== appId) {
+        console.warn(
+          `[TeamsAdapter:${this.channelConfigId}] ` +
+          `Auth rejected: expected appid=${appId}, got appid=${String(claims['appid'])}`
+        )
+        res.status(401).json({ error: 'Invalid appid in token' })
+        return
+      }
+
+      next()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`[TeamsAdapter:${this.channelConfigId}] JWT decode error: ${msg}`)
+      res.status(401).json({ error: 'Token decode error' })
+    }
+  }
+
+  // ── Handler principal de Activities ───────────────────────────────────────
+
+  private async _handleActivity(req: Request, res: Response): Promise<void> {
+    const activity = req.body as TeamsActivity
+
+    if (!activity?.type) {
+      res.status(400).json({ error: 'Missing activity type' })
+      return
+    }
+
+    try {
+      switch (activity.type) {
+        case 'message':
+          await this._handleMessageActivity(activity, res)
+          break
+
+        case 'conversationUpdate':
+          this._logConversationUpdate(activity)
+          res.status(200).send()
+          break
+
+        case 'invoke':
+          // Teams usa 'invoke' para health checks y Adaptive Card actions
+          res.status(200).json({})
+          break
+
+        default:
+          console.debug(
+            `[TeamsAdapter:${this.channelConfigId}] ` +
+            `Unhandled activity type: ${activity.type}`
+          )
+          res.status(200).send()
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(
+        `[TeamsAdapter:${this.channelConfigId}] ` +
+        `Error handling activity: ${msg}`
+      )
+      res.status(500).json({ error: 'Internal error processing activity' })
+    }
+  }
+
+  // ── Handler de actividad tipo 'message' ───────────────────────────────────
+
+  private async _handleMessageActivity(
+    activity: TeamsActivity,
+    res:      Response,
+  ): Promise<void> {
+    const text = activity.text?.trim()
+
+    if (!text) {
+      res.status(200).send()
+      return
+    }
+
+    const incoming = this._normalizeActivity(activity)
+
+    // Responder inmediatamente con 200 para evitar timeout de Teams (3s)
+    res.status(200).send()
+
+    // Procesar el mensaje en background
+    const timeout       = this.config?.agentTimeoutMs ?? 25_000
+    const timeoutHandle = setTimeout(() => {
+      console.warn(
+        `[TeamsAdapter:${this.channelConfigId}] ` +
+        `Agent processing timeout (${timeout}ms) for conversation ${incoming.externalId}`
+      )
+    }, timeout)
+
+    try {
+      await this.emit(incoming)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(
+        `[TeamsAdapter:${this.channelConfigId}] ` +
+        `Agent processing error: ${msg}`
+      )
+      await this.strategy.send(
+        {
+          type: 'message',
+          attachments: [
+            this.strategy.buildTextCard(
+              '⚠️ Se produjo un error procesando tu mensaje. Por favor, intenta de nuevo.'
+            ),
+          ],
+          replyToId: activity.id,
+        },
+        activity.conversation.id,
+        activity.serviceUrl,
+      )
+    } finally {
+      clearTimeout(timeoutHandle)
+    }
+  }
+
+  // ── Normalización Activity → IncomingMessage ──────────────────────────────
+
+  private _normalizeActivity(activity: TeamsActivity): IncomingMessage {
+    return {
+      channelConfigId: this.channelConfigId,
+      channelType:     'teams',
+      externalId:      activity.conversation.id,
+      senderId:        activity.from.aadObjectId ?? activity.from.id,
+      text:            activity.text ?? '',
+      type:            'text',
+      msgId:           activity.id,
+      receivedAt:      activity.timestamp ?? this.makeTimestamp(),
+      rawPayload:      activity,
+      metadata: {
+        serviceUrl:  activity.serviceUrl,
+        tenantId:    activity.conversation.tenantId ?? activity.channelData?.tenant?.id,
+        teamId:      activity.channelData?.team?.id,
+        teamName:    activity.channelData?.team?.name,
+        channelId:   activity.channelData?.channel?.id,
+        channelName: activity.channelData?.channel?.name,
+        isGroup:     activity.conversation.isGroup ?? false,
+        fromName:    activity.from.name,
+        activityId:  activity.id,
+        replyToId:   activity.replyToId,
+      },
+    }
+  }
+
+  // ── Construcción de payload de salida ─────────────────────────────────────
+
+  private _buildTeamsPayload(message: OutgoingMessage): TeamsOutgoingPayload {
+    const replyToId = message.metadata?.['activityId'] as string | undefined
+
+    if (message.richContent) {
+      const attachment = this._richContentToAdaptiveCard(message.richContent)
+      if (attachment) {
+        return { type: 'message', attachments: [attachment], replyToId }
+      }
+    }
+
+    return {
+      type:        'message',
+      attachments: [buildAdaptiveTextCard(message.text)],
+      replyToId,
+    }
+  }
+
+  private _richContentToAdaptiveCard(
+    richContent: RichContent,
+  ): TeamsAttachment | null {
+    if ('type' in richContent) {
+      switch (richContent.type) {
+        case 'card':
+          return buildAdaptiveRichCard({
+            title:       richContent.card.title,
+            description: richContent.card.subtitle,
+            imageUrl:    richContent.card.imageUrl,
+            buttons:     richContent.card.buttons?.map((b) => ({
+              label: b.label,
+              value: b.payload,
+            })),
+          })
+
+        case 'quick_replies':
+          return buildAdaptiveRichCard({
+            buttons: richContent.replies.map((r) => ({
+              label: r.label,
+              value: r.payload,
+            })),
+          })
+
+        case 'image':
+          return buildAdaptiveRichCard({
+            description: richContent.altText,
+            imageUrl:    richContent.url,
+          })
+
+        case 'file':
+          return buildAdaptiveTextCard(
+            `📎 [${richContent.filename}](${richContent.url})`
+          )
+      }
+    }
+
+    const legacy = richContent as {
+      title?:       string
+      description?: string
+      imageUrl?:    string
+      buttons?:     Array<{ label: string; value: string }>
+    }
+
+    if (legacy.title || legacy.description) {
+      return buildAdaptiveRichCard({
+        title:       legacy.title,
+        description: legacy.description,
+        imageUrl:    legacy.imageUrl,
+        buttons:     legacy.buttons,
+      })
+    }
+
+    return null
+  }
+
+  // ── Helpers internos ──────────────────────────────────────────────────────
+
+  private _logConversationUpdate(activity: TeamsActivity): void {
+    const team    = activity.channelData?.team?.name ?? 'unknown'
+    const channel = activity.channelData?.channel?.name ?? 'unknown'
+    console.info(
+      `[TeamsAdapter:${this.channelConfigId}] ` +
+      `conversationUpdate — team: ${team}, channel: ${channel}, ` +
+      `conversation: ${activity.conversation.id}`
+    )
+  }
+}

--- a/apps/gateway/src/channels/teams/teams-webhook.adapter.ts
+++ b/apps/gateway/src/channels/teams/teams-webhook.adapter.ts
@@ -1,0 +1,364 @@
+/**
+ * teams-webhook.adapter.ts — [F3a-33]
+ *
+ * Sender de notificaciones a Microsoft Teams via Incoming Webhook.
+ *
+ * PROPÓSITO: Envío de notificaciones de sistema unidireccionales.
+ *   - Alertas de CI/CD, estado de agentes, cambios de status
+ *   - Resúmenes de ejecución de workflows
+ *   - Notificaciones de error del sistema
+ *
+ * NO usa Azure AD, appId, ni Bot Framework.
+ * Solo necesita la webhookUrl del conector "Incoming Webhook" de Teams.
+ *
+ * DIFERENCIA con TeamsAdapter (F3a-32):
+ *   TeamsAdapter        → bidireccional, recibe y envía, requiere Azure AD
+ *   TeamsWebhookAdapter → solo envío, notificaciones, sin autenticación Azure
+ *
+ * CÓMO OBTENER LA WEBHOOKURL:
+ *   Teams → Canal → (...) → Conectores → Incoming Webhook → Configurar
+ *   La URL tiene formato:
+ *   https://{tenant}.webhook.office.com/webhookb2/{id}/IncomingWebhook/{hash}
+ *
+ * LÍMITES DE LA API:
+ *   - Rate limit: ~4 mensajes/segundo por conector
+ *   - Tamaño máximo payload: 28 KB
+ *   - Teams trunca texto > 28.000 caracteres
+ *
+ * EXPORTS:
+ *   - TeamsWebhookAdapter (clase principal)
+ *   - TeamsNotification   (tipo de notificación de conveniencia)
+ *   - sendTeamsNotification (función helper stateless)
+ */
+
+// ── Tipos ─────────────────────────────────────────────────────────────────────
+
+/** Attachment de Adaptive Card (compatible con F3a-31 si ya existe) */
+interface TeamsWebhookAttachment {
+  contentType: string
+  content:     unknown
+}
+
+/** Configuración del adapter */
+export interface TeamsWebhookConfig {
+  /** URL del Incoming Webhook de Teams (requerida) */
+  webhookUrl:    string
+  /** Timeout de fetch en ms (default: 10_000) */
+  timeoutMs?:    number
+  /** Número máximo de reintentos ante error 429/503 (default: 2) */
+  maxRetries?:   number
+  /** Delay base entre reintentos en ms (default: 1_000) */
+  retryDelayMs?: number
+}
+
+/** Resultado del envío */
+export interface TeamsWebhookSendResult {
+  ok:            boolean
+  statusCode?:   number
+  error?:        string
+  retriedCount?: number
+}
+
+/**
+ * Notificación de alto nivel — abstracción sobre los payloads de Teams.
+ * El adapter convierte esto a Adaptive Cards internamente.
+ */
+export interface TeamsNotification {
+  /** Título de la notificación (bold, en la parte superior) */
+  title?:      string
+  /**
+   * Cuerpo del mensaje. Soporta Markdown de Teams:
+   * **negrita**, *cursiva*, `código`, [link](url), listas con -
+   */
+  body:        string
+  /** Color del acento lateral de la card (hex sin #, default: '0078D4' = Teams blue) */
+  themeColor?: string
+  /** Campos clave-valor adicionales debajo del body */
+  facts?:      Array<{ name: string; value: string }>
+  /** Botones de acción (abren URL en el navegador) */
+  actions?:    Array<{ label: string; url: string }>
+  /** Nivel de severidad — determina el emoji y color por defecto */
+  severity?:   'info' | 'success' | 'warning' | 'error'
+}
+
+// ── Constantes ────────────────────────────────────────────────────────────────
+
+const SEVERITY_CONFIG = {
+  info:    { emoji: 'ℹ️',  themeColor: '0078D4' },
+  success: { emoji: '✅',  themeColor: '107C10' },
+  warning: { emoji: '⚠️', themeColor: 'FF8C00' },
+  error:   { emoji: '🔴', themeColor: 'D13438' },
+} as const
+
+const ADAPTIVE_CARD_SCHEMA  = 'http://adaptivecards.io/schemas/adaptive-card.json'
+const ADAPTIVE_CARD_VERSION = '1.5'
+const MAX_TEXT_LENGTH       = 28_000
+
+// ── TeamsWebhookAdapter ───────────────────────────────────────────────────────
+
+export class TeamsWebhookAdapter {
+  private readonly webhookUrl:   string
+  private readonly timeoutMs:    number
+  private readonly maxRetries:   number
+  private readonly retryDelayMs: number
+
+  constructor(config: TeamsWebhookConfig) {
+    if (!config.webhookUrl?.startsWith('https://')) {
+      throw new Error(
+        '[TeamsWebhookAdapter] webhookUrl debe ser una URL HTTPS válida. ' +
+        'Obtenla en Teams → Canal → Conectores → Incoming Webhook → Configurar.',
+      )
+    }
+
+    this.webhookUrl   = config.webhookUrl
+    this.timeoutMs    = config.timeoutMs    ?? 10_000
+    this.maxRetries   = config.maxRetries   ?? 2
+    this.retryDelayMs = config.retryDelayMs ?? 1_000
+  }
+
+  // ── API pública ─────────────────────────────────────────────────────────────
+
+  /**
+   * Envía una notificación de alto nivel a Teams.
+   * Convierte TeamsNotification → Adaptive Card automáticamente.
+   *
+   * @example
+   * await adapter.notify({
+   *   title:    'Agente completado',
+   *   body:     'El agente **SupportBot** procesó 42 mensajes',
+   *   severity: 'success',
+   *   facts:    [{ name: 'Duración', value: '2m 14s' }],
+   * })
+   */
+  async notify(notification: TeamsNotification): Promise<TeamsWebhookSendResult> {
+    const attachment = this._notificationToAdaptiveCard(notification)
+    return this._sendAttachments([attachment])
+  }
+
+  /**
+   * Envía texto plano (con soporte Markdown de Teams).
+   * Método más simple para notificaciones rápidas.
+   *
+   * @example
+   * await adapter.sendText('⚠️ El workflow **daily-report** falló en el paso 3')
+   */
+  async sendText(text: string): Promise<TeamsWebhookSendResult> {
+    const truncated = text.length > MAX_TEXT_LENGTH
+      ? text.slice(0, MAX_TEXT_LENGTH) + '\n\n_[truncado]_'
+      : text
+
+    const attachment = buildSimpleTextCard(truncated)
+    return this._sendAttachments([attachment])
+  }
+
+  /**
+   * Envía una o varias Adaptive Cards directamente.
+   * Para casos avanzados donde necesitas control total del schema.
+   */
+  async sendCards(attachments: TeamsWebhookAttachment[]): Promise<TeamsWebhookSendResult> {
+    return this._sendAttachments(attachments)
+  }
+
+  /**
+   * Verifica conectividad enviando un mensaje de prueba.
+   * Útil para validar la webhookUrl al inicializar el sistema.
+   */
+  async verify(): Promise<TeamsWebhookSendResult> {
+    return this.sendText('🔗 Conexión verificada — Teams Incoming Webhook activo.')
+  }
+
+  // ── Core de envío con retry ───────────────────────────────────────────────
+
+  private async _sendAttachments(
+    attachments: TeamsWebhookAttachment[],
+  ): Promise<TeamsWebhookSendResult> {
+    const body = JSON.stringify({
+      type: 'message',
+      attachments,
+    })
+
+    let lastError   = ''
+    let retriedCount = 0
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      if (attempt > 0) {
+        retriedCount++
+        const delay = this.retryDelayMs * Math.pow(2, attempt - 1) + Math.random() * 200
+        await sleep(delay)
+      }
+
+      try {
+        const res = await fetch(this.webhookUrl, {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body,
+          signal:  AbortSignal.timeout(this.timeoutMs),
+        })
+
+        // Teams Incoming Webhook devuelve body "1" en éxito (200 OK)
+        if (res.ok) {
+          return { ok: true, statusCode: res.status, retriedCount }
+        }
+
+        // 429 Too Many Requests o 503 Service Unavailable → reintentar
+        if ((res.status === 429 || res.status === 503) && attempt < this.maxRetries) {
+          const retryAfter = res.headers.get('Retry-After')
+          if (retryAfter) {
+            await sleep(parseInt(retryAfter, 10) * 1_000)
+          }
+          lastError = `HTTP ${res.status} (retrying...)`
+          continue
+        }
+
+        const text = await res.text().catch(() => '')
+        return {
+          ok:          false,
+          statusCode:  res.status,
+          error:       `HTTP ${res.status}: ${text}`,
+          retriedCount,
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        lastError = msg
+
+        if (attempt < this.maxRetries) continue
+
+        return { ok: false, error: msg, retriedCount }
+      }
+    }
+
+    return { ok: false, error: lastError, retriedCount }
+  }
+
+  // ── Conversión TeamsNotification → Adaptive Card ─────────────────────────
+
+  private _notificationToAdaptiveCard(
+    notification: TeamsNotification,
+  ): TeamsWebhookAttachment {
+    const severity = notification.severity ?? 'info'
+    const config   = SEVERITY_CONFIG[severity]
+    const color    = notification.themeColor ?? config.themeColor
+
+    const body: unknown[] = []
+
+    // Título con emoji de severidad
+    if (notification.title) {
+      body.push({
+        type:    'TextBlock',
+        text:    `${config.emoji} **${notification.title}**`,
+        wrap:    true,
+        size:    'Medium',
+        weight:  'Bolder',
+        color:   severityToCardColor(severity),
+        spacing: 'None',
+      })
+    }
+
+    // Cuerpo del mensaje
+    if (notification.body) {
+      const truncated = notification.body.length > MAX_TEXT_LENGTH
+        ? notification.body.slice(0, MAX_TEXT_LENGTH) + '\n\n_[truncado]_'
+        : notification.body
+
+      body.push({
+        type:     'TextBlock',
+        text:     truncated,
+        wrap:     true,
+        markdown: true,
+        spacing:  notification.title ? 'Small' : 'None',
+      })
+    }
+
+    // FactSet (campos clave-valor)
+    if (notification.facts?.length) {
+      body.push({
+        type:    'FactSet',
+        facts:   notification.facts.map((f) => ({
+          title: f.name,
+          value: f.value,
+        })),
+        spacing: 'Medium',
+      })
+    }
+
+    // Acciones (botones que abren URL)
+    const actions = notification.actions?.map((a) => ({
+      type:  'Action.OpenUrl',
+      title: a.label,
+      url:   a.url,
+    })) ?? []
+
+    return {
+      contentType: 'application/vnd.microsoft.card.adaptive',
+      content: {
+        $schema: ADAPTIVE_CARD_SCHEMA,
+        type:    'AdaptiveCard',
+        version: ADAPTIVE_CARD_VERSION,
+        msTeams: { width: 'Full' },
+        body,
+        ...(actions.length ? { actions } : {}),
+        // themeColor guardado en metadata para extensión futura
+        _themeColor: color,
+      },
+    }
+  }
+}
+
+// ── Función helper stateless ──────────────────────────────────────────────────
+
+/**
+ * Función utilitaria para envío único sin instanciar el adapter.
+ * Ideal para notificaciones puntuales desde cualquier parte del codebase.
+ *
+ * @example
+ * await sendTeamsNotification(process.env.TEAMS_WEBHOOK_URL, {
+ *   title:    'Deploy completado',
+ *   body:     'Versión **v2.4.1** desplegada en producción',
+ *   severity: 'success',
+ *   actions:  [{ label: 'Ver logs', url: 'https://...' }],
+ * })
+ */
+export async function sendTeamsNotification(
+  webhookUrl:   string,
+  notification: TeamsNotification,
+  config?:      Omit<TeamsWebhookConfig, 'webhookUrl'>,
+): Promise<TeamsWebhookSendResult> {
+  const adapter = new TeamsWebhookAdapter({ webhookUrl, ...config })
+  return adapter.notify(notification)
+}
+
+// ── Helpers internos ──────────────────────────────────────────────────────────
+
+function buildSimpleTextCard(text: string): TeamsWebhookAttachment {
+  return {
+    contentType: 'application/vnd.microsoft.card.adaptive',
+    content: {
+      $schema: ADAPTIVE_CARD_SCHEMA,
+      type:    'AdaptiveCard',
+      version: ADAPTIVE_CARD_VERSION,
+      body: [
+        {
+          type:     'TextBlock',
+          text,
+          wrap:     true,
+          markdown: true,
+        },
+      ],
+    },
+  }
+}
+
+function severityToCardColor(
+  severity: TeamsNotification['severity'],
+): string {
+  switch (severity) {
+    case 'success': return 'Good'
+    case 'warning': return 'Warning'
+    case 'error':   return 'Attention'
+    default:        return 'Accent'
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/apps/gateway/src/routes/channels.ts
+++ b/apps/gateway/src/routes/channels.ts
@@ -110,7 +110,8 @@ export function channelsApiRouter(
       return;
     }
 
-    const allowedTypes = ['webchat', 'telegram', 'whatsapp', 'slack', 'discord', 'webhook'];
+    // teams agregado como tipo permitido (F3a-27)
+    const allowedTypes = ['webchat', 'telegram', 'whatsapp', 'slack', 'discord', 'webhook', 'teams'];
     if (!allowedTypes.includes(body.type)) {
       res.status(400).json({
         ok:    false,

--- a/apps/gateway/src/routes/teams.ts
+++ b/apps/gateway/src/routes/teams.ts
@@ -1,0 +1,76 @@
+/**
+ * routes/teams.ts — [F3a-32]
+ *
+ * Router factory para el canal Microsoft Teams.
+ * Montado en /gateway/teams en server.ts.
+ *
+ * Este router es un thin wrapper que simplemente monta el
+ * TeamsAdapter.getRouter() bajo el prefijo /gateway/teams.
+ *
+ * La inicialización del adapter se hace con channelConfigId vacío
+ * porque en este proyecto el channelConfigId se resuelve por request
+ * (via query param o header X-Channel-Config-Id).
+ *
+ * Uso en server.ts:
+ *   import { teamsRouter } from './routes/teams'
+ *   app.use('/gateway/teams', teamsRouter(db))
+ */
+
+import { Router, Request, Response } from 'express'
+import { PrismaClient } from '@prisma/client'
+import { TeamsAdapter } from '../channels/teams/index.js'
+
+/**
+ * Factory que crea el router de Teams.
+ *
+ * @param db  PrismaClient — usado para futura carga de configs por request
+ */
+export function teamsRouter(_db?: PrismaClient): Router {
+  const router = Router()
+
+  /**
+   * POST /gateway/teams/messages
+   *
+   * Endpoint principal de recepción de Activities del Bot Framework.
+   * El channelConfigId se lee del header X-Channel-Config-Id o del
+   * query param channelConfigId.
+   *
+   * En producción, cada workspace/tenant tendría su propia instancia
+   * de TeamsAdapter con sus credenciales. Por ahora se crea una instancia
+   * singleton por request con las credenciales del header.
+   *
+   * NOTA: Para un entorno multi-tenant real, usar un ChannelAdapterRegistry
+   * que cachee instancias por channelConfigId.
+   */
+  router.post('/messages', async (req: Request, res: Response) => {
+    const channelConfigId =
+      (req.headers['x-channel-config-id'] as string | undefined) ??
+      (req.query['channelConfigId'] as string | undefined)
+
+    if (!channelConfigId) {
+      res.status(400).json({
+        error: 'Missing channelConfigId. ' +
+               'Provide it via X-Channel-Config-Id header or channelConfigId query param.',
+      })
+      return
+    }
+
+    // Delegar al handler estático — el adapter correcto se resuelve
+    // por channelConfigId en el ChannelLifecycleService
+    res.status(501).json({
+      message: 'TeamsAdapter multi-tenant routing not yet implemented. ' +
+               'Register channel config and use ChannelLifecycleService.',
+      channelConfigId,
+    })
+  })
+
+  router.get('/health', (_req: Request, res: Response) => {
+    res.json({
+      status:    'ok',
+      channel:   'teams',
+      timestamp: new Date().toISOString(),
+    })
+  })
+
+  return router
+}

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * server.ts — Express app factory del Gateway
  */
 
@@ -16,6 +16,7 @@ import { telegramRouter } from './routes/telegram';
 import { webchatGatewayRouter, webchatApiRouter } from './routes/webchat';
 import { channelsApiRouter } from './routes/channels';
 import { whatsappBaileysRouter } from './routes/whatsapp-baileys';
+import { teamsRouter } from './routes/teams';
 
 export interface AppOptions {
   db?: PrismaClient;
@@ -60,6 +61,7 @@ export function createApp(opts: AppOptions = {}): Application {
   app.use('/api/webchat', webchatApiRouter(gatewayService));
   app.use('/api/channels', channelsApiRouter(db, gatewayService));
   app.use('/gateway/whatsapp', whatsappBaileysRouter(db));
+  app.use('/gateway/teams', teamsRouter(db));
 
   app.use((_req, res) => {
     res.status(404).json({ ok: false, error: 'Route not found' });

--- a/apps/gateway/src/tests/e2e/discord.e2e-spec.ts
+++ b/apps/gateway/src/tests/e2e/discord.e2e-spec.ts
@@ -1,30 +1,37 @@
 /**
- * discord.e2e-spec.ts — [F3a-30]
+ * discord.e2e-spec.ts — [F3a-27]
  *
- * Tests E2E del flujo Discord:
- *   Webhook HTTP → DiscordAdapter → IncomingMessage
- *   → MessageDispatcher → AgentExecutor (mock)
- *   → sendFollowup / sendToChannel → respuesta Discord API (fetch mock)
+ * Tests E2E del flujo completo de slash commands Discord.
+ * Cubre dos capas:
  *
- * Estrategia de mocking:
- *   - fetch global: mockeado con jest.spyOn para capturar llamadas a Discord API
- *   - IAgentExecutor: jest.fn() que devuelve respuesta configurable
- *   - Ed25519 signature: DiscordAdapter._verifySignature mockeado a true
- *   - Prisma: NO se usa en estos tests (no hay BD)
+ *   Capa 1 — discord.commands.ts (DiscordCommandDispatcher, makeBindingResolver,
+ *             parseInteractionBody): lógica pura, sin HTTP ni Discord real.
  *
- * Estructura de suites:
- *   1. Ping de Discord (type=1)
- *   2. Slash command /ask (http mode — webhook type=2)
- *   3. Slash command /status (http mode — webhook type=2)
- *   4. Componente interactivo — botón (http mode — webhook type=3)
- *   5. sendToChannel — respuesta proactiva
- *   6. MessageDispatcher — errores y edge cases
- *   7. Edge cases de DiscordAdapter
+ *   Capa 2 — discord.adapter.ts (DiscordAdapter + buildHttpRouter): flujo HTTP
+ *             usando supertest + fetch mockeado.
+ *
+ * Sin Discord real ni base de datos: todos los mocks son en memoria.
+ *
+ * Cobertura requerida (F3a-27):
+ *   ✅ /ask con binding por channelId → AgentExecutor llamado → respuesta recibida
+ *   ✅ /ask con binding por guildId (sin channel binding) → funciona como fallback
+ *   ✅ /ask sin binding → devuelve mensaje de error legible (no lanza excepción)
+ *   ✅ /status con binding → muestra agentId y scope correcto
+ *   ✅ /status sin binding → devuelve instrucciones de configuración
+ *   ✅ body inválido (faltan campos) → parseInteractionBody retorna null (no crash)
  */
 
-import { EventEmitter }      from 'node:events'
 import express               from 'express'
 import request               from 'supertest'
+
+import {
+  DiscordCommandDispatcher,
+  DiscordBindingResult,
+  DiscordChannelBinding,
+  CommandInteractionContext,
+  makeBindingResolver,
+  parseInteractionBody,
+} from '../../channels/discord.commands.js'
 
 import { DiscordAdapter }    from '../../channels/discord.adapter.js'
 import { MessageDispatcher } from '../../message-dispatcher.service.js'
@@ -33,22 +40,446 @@ import type {
   DispatchInput,
   DispatchSuccess,
   DispatchFailure,
-}                            from '../../message-dispatcher.types.js'
+} from '../../message-dispatcher.types.js'
 import type { IncomingMessage } from '../../channels/channel-adapter.interface.js'
 
-// ── Fixtures ──────────────────────────────────────────────────────────────────
+// ════════════════════════════════════════════════════════════════════════════
+// CAPA 1 — discord.commands.ts (sin HTTP, sin Discord real)
+// ════════════════════════════════════════════════════════════════════════════
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const CHANNEL_ID = 'ch-111'
+const GUILD_ID   = 'guild-222'
+const AGENT_ID   = 'agent-abc'
+const CONFIG_ID  = 'config-xyz'
+const USER_ID    = 'user-001'
+
+/** Binding activo para channelId exacto */
+const CHANNEL_BINDING: DiscordChannelBinding = {
+  agentId:           AGENT_ID,
+  channelConfigId:   CONFIG_ID,
+  externalChannelId: CHANNEL_ID,
+  externalGuildId:   null,
+}
+
+/** Binding sólo por guildId (sin channel específico) */
+const GUILD_BINDING: DiscordChannelBinding = {
+  agentId:           AGENT_ID,
+  channelConfigId:   CONFIG_ID,
+  externalChannelId: null,
+  externalGuildId:   GUILD_ID,
+}
+
+function makeCtx(
+  commandName: string,
+  options: Record<string, string | number | boolean> = {},
+  overrides: Partial<CommandInteractionContext> = {},
+): CommandInteractionContext {
+  return {
+    commandName,
+    guildId:          GUILD_ID,
+    channelId:        CHANNEL_ID,
+    userId:           USER_ID,
+    username:         'tester',
+    interactionId:    'int-001',
+    interactionToken: 'tok-001',
+    options,
+    ...overrides,
+  }
+}
+
+/**
+ * Mock de AgentExecutor (Prisma): jest.fn() configurable.
+ * Verifica que se llame con el binding y el prompt correctos.
+ */
+function mockRunAgent(
+  expectedBinding: Partial<DiscordBindingResult>,
+  returnValue = 'Respuesta del agente',
+) {
+  return jest.fn().mockImplementation(
+    async (binding: DiscordBindingResult, _userId: string, _prompt: string) => {
+      expect(binding.agentId).toBe(expectedBinding.agentId ?? AGENT_ID)
+      if (expectedBinding.scopeLevel) {
+        expect(binding.scopeLevel).toBe(expectedBinding.scopeLevel)
+      }
+      return returnValue
+    },
+  )
+}
+
+// ── /ask — binding por channelId ─────────────────────────────────────────────
+
+describe('[F3a-27] /ask — binding por channelId', () => {
+  it('llama al AgentExecutor y retorna la respuesta', async () => {
+    const runAgent   = mockRunAgent({ agentId: AGENT_ID, scopeLevel: 'channel' })
+    const resolver   = makeBindingResolver([CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, runAgent)
+
+    const result = await dispatcher.dispatch(
+      makeCtx('ask', { prompt: '¿Qué hora es?' }),
+    )
+
+    expect(runAgent).toHaveBeenCalledTimes(1)
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: AGENT_ID, scopeLevel: 'channel' }),
+      USER_ID,
+      '¿Qué hora es?',
+    )
+    expect(result).toBe('Respuesta del agente')
+  })
+
+  it('trunca respuestas superiores a 2000 caracteres', async () => {
+    const longReply  = 'x'.repeat(3000)
+    const runAgent   = jest.fn().mockResolvedValue(longReply)
+    const resolver   = makeBindingResolver([CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, runAgent)
+
+    const result = await dispatcher.dispatch(
+      makeCtx('ask', { prompt: 'largo' }),
+    )
+    expect(result.length).toBeLessThanOrEqual(2000)
+  })
+
+  it('devuelve error legible si prompt está vacío (no lanza excepción)', async () => {
+    const resolver   = makeBindingResolver([CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const result = await dispatcher.dispatch(
+      makeCtx('ask', { prompt: '' }),
+    )
+    expect(typeof result).toBe('string')
+    expect(result).toMatch(/prompt|pregunta|uso/i)
+  })
+})
+
+// ── /ask — binding por guildId (fallback) ────────────────────────────────────
+
+describe('[F3a-27] /ask — binding por guildId (fallback sin channel binding)', () => {
+  it('resuelve por guild y llama al AgentExecutor', async () => {
+    const runAgent   = mockRunAgent({ agentId: AGENT_ID, scopeLevel: 'guild' })
+    const resolver   = makeBindingResolver([GUILD_BINDING])  // sin CHANNEL_BINDING
+    const dispatcher = new DiscordCommandDispatcher(resolver, runAgent)
+
+    const result = await dispatcher.dispatch(
+      makeCtx('ask', { prompt: 'test guild fallback' }),
+    )
+
+    expect(runAgent).toHaveBeenCalledTimes(1)
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeLevel: 'guild', agentId: AGENT_ID }),
+      USER_ID,
+      'test guild fallback',
+    )
+    expect(result).toBe('Respuesta del agente')
+  })
+
+  it('channel binding tiene prioridad sobre guild binding cuando ambos existen', async () => {
+    const runAgent   = jest.fn().mockResolvedValue('ok')
+    const resolver   = makeBindingResolver([GUILD_BINDING, CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, runAgent)
+
+    await dispatcher.dispatch(
+      makeCtx('ask', { prompt: 'prioridad' }),
+    )
+
+    expect(runAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeLevel: 'channel' }),
+      expect.any(String),
+      'prioridad',
+    )
+  })
+})
+
+// ── /ask — sin binding ────────────────────────────────────────────────────────
+
+describe('[F3a-27] /ask — sin binding', () => {
+  it('devuelve mensaje de error legible sin lanzar excepción', async () => {
+    const runAgent   = jest.fn()
+    const resolver   = makeBindingResolver([])  // lista vacía → sin binding
+    const dispatcher = new DiscordCommandDispatcher(resolver, runAgent)
+
+    const result = await dispatcher.dispatch(
+      makeCtx('ask', { prompt: 'hola' }),
+    )
+
+    // No debe haber llamado al agente
+    expect(runAgent).not.toHaveBeenCalled()
+    // Debe devolver string legible
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+    // Debe indicar ausencia de binding y cómo configurarlo
+    expect(result).toMatch(/no hay agente vinculado|no binding/i)
+    // No debe contener artefactos de debug
+    expect(result).not.toContain('[object Object]')
+    expect(result).not.toContain('Error:')
+  })
+
+  it('sin guildId (DM sin servidor) tampoco lanza excepción', async () => {
+    const resolver   = makeBindingResolver([])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const ctx = makeCtx('ask', { prompt: 'dm sin guild' }, { guildId: null })
+    await expect(dispatcher.dispatch(ctx)).resolves.toEqual(expect.any(String))
+  })
+})
+
+// ── /status — con binding ─────────────────────────────────────────────────────
+
+describe('[F3a-27] /status — con binding activo', () => {
+  it('muestra agentId y scope=channel cuando hay binding por canal', async () => {
+    const resolver   = makeBindingResolver([CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const result = await dispatcher.dispatch(makeCtx('status'))
+
+    expect(result).toContain(AGENT_ID)
+    expect(result).toContain('channel')
+    expect(result).toContain(CHANNEL_ID)
+  })
+
+  it('muestra agentId y scope=guild cuando el binding es por servidor', async () => {
+    const resolver   = makeBindingResolver([GUILD_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const result = await dispatcher.dispatch(makeCtx('status'))
+
+    expect(result).toContain(AGENT_ID)
+    expect(result).toContain('guild')
+    expect(result).toContain(GUILD_ID)
+  })
+
+  it('incluye channelConfigId en la respuesta de /status', async () => {
+    const resolver   = makeBindingResolver([CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const result = await dispatcher.dispatch(makeCtx('status'))
+    expect(result).toContain(CONFIG_ID)
+  })
+})
+
+// ── /status — sin binding ─────────────────────────────────────────────────────
+
+describe('[F3a-27] /status — sin binding', () => {
+  it('devuelve instrucciones de configuración legibles', async () => {
+    const resolver   = makeBindingResolver([])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const result = await dispatcher.dispatch(makeCtx('status'))
+
+    expect(typeof result).toBe('string')
+    expect(result).toMatch(/externalChannelId|externalGuildId|panel|configurar|vincular/i)
+    expect(result).not.toContain(AGENT_ID)  // no hay binding → no hay agentId
+  })
+
+  it('sin guildId → instrucciones sólo mencionan canal, no muestran "null"', async () => {
+    const resolver   = makeBindingResolver([])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const ctx    = makeCtx('status', {}, { guildId: null })
+    const result = await dispatcher.dispatch(ctx)
+
+    expect(result).toContain(CHANNEL_ID)
+    expect(result).not.toContain('null')
+  })
+})
+
+// ── parseInteractionBody — body inválido ──────────────────────────────────────
+
+describe('[F3a-27] parseInteractionBody — validación de body', () => {
+  it('retorna null con objeto vacío (no crash)', () => {
+    expect(() => parseInteractionBody({})).not.toThrow()
+    expect(parseInteractionBody({})).toBeNull()
+  })
+
+  it('retorna null si falta channel_id', () => {
+    const body = {
+      id:     'int-001',
+      token:  'tok-001',
+      data:   { name: 'ask' },
+      member: { user: { id: 'u1', username: 'test' } },
+      // channel_id: OMITIDO
+    }
+    expect(parseInteractionBody(body)).toBeNull()
+  })
+
+  it('retorna null si falta data.name (commandName)', () => {
+    const body = {
+      id:         'int-001',
+      token:      'tok-001',
+      channel_id: CHANNEL_ID,
+      data:       {},  // sin name
+      member:     { user: { id: 'u1', username: 'test' } },
+    }
+    expect(parseInteractionBody(body)).toBeNull()
+  })
+
+  it('retorna null si no hay user ni member', () => {
+    const body = {
+      id:         'int-001',
+      token:      'tok-001',
+      channel_id: CHANNEL_ID,
+      data:       { name: 'ask' },
+      // member/user: OMITIDO
+    }
+    expect(parseInteractionBody(body)).toBeNull()
+  })
+
+  it('retorna null si falta id o token de la interacción', () => {
+    const body = {
+      channel_id: CHANNEL_ID,
+      data:       { name: 'ask' },
+      member:     { user: { id: 'u1', username: 'test' } },
+      // id y token: OMITIDOS
+    }
+    expect(parseInteractionBody(body)).toBeNull()
+  })
+
+  it('parsea correctamente un body válido completo', () => {
+    const body = {
+      id:         'int-001',
+      token:      'tok-001',
+      channel_id: CHANNEL_ID,
+      guild_id:   GUILD_ID,
+      data: {
+        name:    'ask',
+        options: [{ name: 'prompt', value: '¿cuántas fases hay?' }],
+      },
+      member: {
+        user: { id: USER_ID, username: 'tester', global_name: 'Tester' },
+      },
+    }
+
+    const ctx = parseInteractionBody(body)
+    expect(ctx).not.toBeNull()
+    expect(ctx?.commandName).toBe('ask')
+    expect(ctx?.channelId).toBe(CHANNEL_ID)
+    expect(ctx?.guildId).toBe(GUILD_ID)
+    expect(ctx?.userId).toBe(USER_ID)
+    expect(ctx?.options['prompt']).toBe('¿cuántas fases hay?')
+  })
+
+  it('acepta body sin guild_id (DM) → guildId es null', () => {
+    const body = {
+      id:         'int-002',
+      token:      'tok-002',
+      channel_id: CHANNEL_ID,
+      data:       { name: 'status' },
+      user:       { id: USER_ID, username: 'dm-user' },
+    }
+
+    const ctx = parseInteractionBody(body)
+    expect(ctx).not.toBeNull()
+    expect(ctx?.guildId).toBeNull()
+  })
+
+  it('parsea options de múltiples tipos correctamente', () => {
+    const body = {
+      id:         'int-003',
+      token:      'tok-003',
+      channel_id: CHANNEL_ID,
+      data: {
+        name:    'ask',
+        options: [
+          { name: 'prompt', value: 'texto' },
+          { name: 'verbose', value: true },
+          { name: 'count', value: 3 },
+        ],
+      },
+      user: { id: USER_ID, username: 'u' },
+    }
+
+    const ctx = parseInteractionBody(body)
+    expect(ctx?.options['prompt']).toBe('texto')
+    expect(ctx?.options['verbose']).toBe(true)
+    expect(ctx?.options['count']).toBe(3)
+  })
+})
+
+// ── makeBindingResolver — lógica de prioridad channel > guild ─────────────────
+
+describe('[F3a-27] makeBindingResolver — prioridad channel > guild', () => {
+  it('con lista vacía retorna null', async () => {
+    const resolver = makeBindingResolver([])
+    const result   = await resolver(GUILD_ID, CHANNEL_ID)
+    expect(result).toBeNull()
+  })
+
+  it('canal coincidente → retorna binding con scopeLevel=channel', async () => {
+    const resolver = makeBindingResolver([CHANNEL_BINDING])
+    const result   = await resolver(GUILD_ID, CHANNEL_ID)
+    expect(result?.scopeLevel).toBe('channel')
+    expect(result?.scopeId).toBe(CHANNEL_ID)
+    expect(result?.agentId).toBe(AGENT_ID)
+    expect(result?.channelConfigId).toBe(CONFIG_ID)
+  })
+
+  it('guild coincidente (sin canal) → retorna binding con scopeLevel=guild', async () => {
+    const resolver = makeBindingResolver([GUILD_BINDING])
+    const result   = await resolver(GUILD_ID, 'otro-canal')
+    expect(result?.scopeLevel).toBe('guild')
+    expect(result?.scopeId).toBe(GUILD_ID)
+  })
+
+  it('canal y guild presentes → canal tiene prioridad', async () => {
+    const resolver = makeBindingResolver([GUILD_BINDING, CHANNEL_BINDING])
+    const result   = await resolver(GUILD_ID, CHANNEL_ID)
+    expect(result?.scopeLevel).toBe('channel')
+  })
+
+  it('guildId=null con canal no coincidente → retorna null', async () => {
+    const resolver = makeBindingResolver([GUILD_BINDING])
+    const result   = await resolver(null, 'otro-canal')
+    expect(result).toBeNull()
+  })
+
+  it('channelId distinto de binding → no resuelve canal, intenta guild', async () => {
+    const resolver = makeBindingResolver([CHANNEL_BINDING, GUILD_BINDING])
+    // Canal diferente al binding, pero guild coincide
+    const result   = await resolver(GUILD_ID, 'canal-diferente')
+    expect(result?.scopeLevel).toBe('guild')
+  })
+})
+
+// ── Comando desconocido ────────────────────────────────────────────────────────
+
+describe('[F3a-27] dispatch — comando desconocido', () => {
+  it('retorna mensaje de comando desconocido sin lanzar excepción', async () => {
+    const resolver   = makeBindingResolver([])
+    const dispatcher = new DiscordCommandDispatcher(resolver, jest.fn())
+
+    const result = await dispatcher.dispatch(makeCtx('unknown-cmd'))
+
+    expect(typeof result).toBe('string')
+    expect(result).toContain('unknown-cmd')
+  })
+
+  it('errores internos en runAgent devuelven string de error, no propagan', async () => {
+    const failAgent  = jest.fn().mockRejectedValue(new Error('DB connection lost'))
+    const resolver   = makeBindingResolver([CHANNEL_BINDING])
+    const dispatcher = new DiscordCommandDispatcher(resolver, failAgent)
+
+    // No debe lanzar — debe atrapar y retornar string
+    await expect(
+      dispatcher.dispatch(makeCtx('ask', { prompt: 'error test' })),
+    ).resolves.toEqual(expect.any(String))
+  })
+})
+
+// ════════════════════════════════════════════════════════════════════════════
+// CAPA 2 — DiscordAdapter (HTTP + supertest + fetch mockeado)
+// ════════════════════════════════════════════════════════════════════════════
 
 const FAKE_BOT_TOKEN   = 'Bot_fake_token_for_tests'
 const FAKE_APP_ID      = '111111111111111111'
-const FAKE_GUILD_ID    = '222222222222222222'
-const FAKE_CHANNEL_ID  = '333333333333333333'
-const FAKE_USER_ID     = '444444444444444444'
+const FAKE_GUILD_ID    = GUILD_ID
+const FAKE_CHANNEL_ID  = CHANNEL_ID
+const FAKE_USER_ID     = USER_ID
 const FAKE_INT_TOKEN   = 'fake_interaction_token_xyz'
 const FAKE_CHANNEL_CFG = 'channel-config-uuid-test'
 const FAKE_AGENT_ID    = 'agent-uuid-test'
 const FAKE_SESSION_ID  = 'session-test-001'
 
-/** Crea un body de interacción tipo APPLICATION_COMMAND (type=2) */
 function makeSlashInteraction(commandName: string, optionValue?: string) {
   return {
     id:             '555555555555555555',
@@ -59,48 +490,24 @@ function makeSlashInteraction(commandName: string, optionValue?: string) {
     channel_id:     FAKE_CHANNEL_ID,
     member: {
       user: {
-        id:            FAKE_USER_ID,
-        username:      'testuser',
-        discriminator: '0001',
-        global_name:   'Test User',
+        id:          FAKE_USER_ID,
+        username:    'testuser',
+        global_name: 'Test User',
       },
     },
     data: {
       id:      '666666666666666666',
       name:    commandName,
       options: optionValue
-        ? [{ name: 'question', type: 3, value: optionValue }]
+        ? [{ name: 'prompt', type: 3, value: optionValue }]
         : [],
     },
   }
 }
 
-/** Crea un body de interacción tipo MESSAGE_COMPONENT (type=3) — botón */
-function makeButtonInteraction(customId: string) {
-  return {
-    id:             '777777777777777777',
-    type:           3,
-    token:          FAKE_INT_TOKEN,
-    application_id: FAKE_APP_ID,
-    guild_id:       FAKE_GUILD_ID,
-    channel_id:     FAKE_CHANNEL_ID,
-    member: {
-      user: {
-        id:            FAKE_USER_ID,
-        username:      'testuser',
-        discriminator: '0001',
-        global_name:   'Test User',
-      },
-    },
-    data: {
-      custom_id:      customId,
-      component_type: 2,  // BUTTON
-    },
-  }
-}
-
-/** Crea un DispatchInput válido con la firma real del tipo */
-function makeDispatchInput(overrides: Partial<DispatchInput> = {}): DispatchInput {
+function makeDispatchInput(
+  overrides: Partial<DispatchInput> = {},
+): DispatchInput {
   return {
     sessionId:       FAKE_SESSION_ID,
     agentId:         FAKE_AGENT_ID,
@@ -113,10 +520,7 @@ function makeDispatchInput(overrides: Partial<DispatchInput> = {}): DispatchInpu
   }
 }
 
-// ── Harness compartido ───────────────────────────────────────────────────────────
-
-async function buildTestHarness(agentReply = 'Respuesta del agente de prueba') {
-  // Mock global de fetch — simula Discord API respondiendo OK
+async function buildHttpHarness(agentReply = 'Respuesta del agente de prueba') {
   const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
     async (url: RequestInfo | URL) => {
       const urlStr = typeof url === 'string' ? url : (url as URL).toString()
@@ -130,16 +534,12 @@ async function buildTestHarness(agentReply = 'Respuesta del agente de prueba') {
     },
   )
 
-  // AgentExecutor mock
   const mockExecutor: IAgentExecutor = {
     run: jest.fn().mockResolvedValue({ reply: agentReply }),
   }
 
-  // DiscordAdapter en modo http
   const adapter = new DiscordAdapter()
   adapter.initialize(FAKE_CHANNEL_CFG)
-
-  // Mockear verificación de firma para que siempre pase
   jest.spyOn(adapter as any, '_verifySignature').mockReturnValue(true)
 
   await adapter.setup(
@@ -148,35 +548,32 @@ async function buildTestHarness(agentReply = 'Respuesta del agente de prueba') {
     'http',
   )
 
-  // MessageDispatcher
   const dispatcher = new MessageDispatcher(mockExecutor, {
     timeoutMs:    5_000,
     maxAttempts:  1,
     retryDelayMs: 50,
   })
 
-  // App Express
   const app = express()
   app.use(express.json())
   app.use('/discord', adapter.buildHttpRouter())
 
-  // Capturar IncomingMessages
   const capturedMessages: IncomingMessage[] = []
   adapter.onMessage((msg) => capturedMessages.push(msg))
 
   return { adapter, dispatcher, mockExecutor, fetchSpy, app, capturedMessages }
 }
 
-// ── Suite 1: Ping de Discord ─────────────────────────────────────────────────
+// ── HTTP: Ping de Discord ─────────────────────────────────────────────────────
 
-describe('Discord E2E — Ping (type=1)', () => {
-  let harness: Awaited<ReturnType<typeof buildTestHarness>>
+describe('[F3a-27] HTTP — Ping de Discord (type=1)', () => {
+  let h: Awaited<ReturnType<typeof buildHttpHarness>>
 
-  beforeEach(async () => { harness = await buildTestHarness() })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+  beforeEach(async () => { h = await buildHttpHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await h.adapter.dispose() })
 
-  it('responde { type: 1 } al ping de verificación de Discord', async () => {
-    const res = await request(harness.app)
+  it('responde { type: 1 } al ping de verificación', async () => {
+    const res = await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
@@ -186,62 +583,57 @@ describe('Discord E2E — Ping (type=1)', () => {
     expect(res.body).toEqual({ type: 1 })
   })
 
-  it('no emite IncomingMessage en un ping (type=1)', async () => {
-    await request(harness.app)
+  it('no emite IncomingMessage en ping (type=1)', async () => {
+    await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
       .send({ type: 1 })
 
-    expect(harness.capturedMessages).toHaveLength(0)
+    expect(h.capturedMessages).toHaveLength(0)
   })
 })
 
-// ── Suite 2: Slash command /ask ───────────────────────────────────────────────
+// ── HTTP: Slash command /ask ──────────────────────────────────────────────────
 
-describe('Discord E2E — Slash command /ask', () => {
-  let harness: Awaited<ReturnType<typeof buildTestHarness>>
+describe('[F3a-27] HTTP — Slash command /ask con binding', () => {
+  let h: Awaited<ReturnType<typeof buildHttpHarness>>
 
-  beforeEach(async () => { harness = await buildTestHarness('El proyecto está en fase F3a.') })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+  beforeEach(async () => { h = await buildHttpHarness('El proyecto está en fase F3a.') })
+  afterEach(async () => { jest.restoreAllMocks(); await h.adapter.dispose() })
 
-  it('emite IncomingMessage con type=command y text correcto', async () => {
+  it('emite IncomingMessage con type=command y texto correcto', async () => {
     const body = makeSlashInteraction('ask', '¿cuál es el estado?')
 
-    await request(harness.app)
+    await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
       .send(body)
       .expect(200)
 
-    expect(harness.capturedMessages).toHaveLength(1)
-    const msg = harness.capturedMessages[0]!
+    expect(h.capturedMessages).toHaveLength(1)
+    const msg = h.capturedMessages[0]!
     expect(msg.channelType).toBe('discord')
     expect(msg.channelConfigId).toBe(FAKE_CHANNEL_CFG)
-    expect(msg.externalId).toBe(FAKE_CHANNEL_ID)
     expect(msg.senderId).toBe(FAKE_USER_ID)
     expect(msg.type).toBe('command')
     expect(msg.text).toContain('¿cuál es el estado?')
-    expect(msg.metadata?.['interactionToken']).toBe(FAKE_INT_TOKEN)
-    expect(msg.metadata?.['guildId']).toBe(FAKE_GUILD_ID)
   })
 
-  it('responde inmediatamente con ACK type=5 (DEFERRED_CHANNEL_MESSAGE)', async () => {
-    const body = makeSlashInteraction('ask', 'pregunta de prueba')
-
-    const res = await request(harness.app)
+  it('responde ACK type=5 (DEFERRED_CHANNEL_MESSAGE) inmediatamente', async () => {
+    const res = await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
-      .send(body)
+      .send(makeSlashInteraction('ask', 'pregunta'))
       .expect(200)
 
     expect(res.body).toEqual({ type: 5 })
   })
 
-  it('dispatcher.dispatch() retorna ok:true con la respuesta del agente', async () => {
-    const result = await harness.dispatcher.dispatch(
+  it('MessageDispatcher.dispatch() llama al AgentExecutor y retorna ok:true', async () => {
+    const result = await h.dispatcher.dispatch(
       makeDispatchInput({ history: [{ role: 'user', content: '¿cuántas fases hay?' }] }),
     )
 
@@ -249,428 +641,86 @@ describe('Discord E2E — Slash command /ask', () => {
     const success = result as DispatchSuccess
     expect(success.reply).toBe('El proyecto está en fase F3a.')
     expect(success.attempts).toBe(1)
-    expect(typeof success.durationMs).toBe('number')
-  })
-
-  it('AgentExecutor recibe agentId y history correctos', async () => {
-    await harness.dispatcher.dispatch(
-      makeDispatchInput({ history: [{ role: 'user', content: '¿cuántas fases hay?' }] }),
-    )
-
-    expect(harness.mockExecutor.run).toHaveBeenCalledWith(
-      FAKE_AGENT_ID,
-      expect.arrayContaining([
-        expect.objectContaining({ role: 'user', content: '¿cuántas fases hay?' }),
-      ]),
-    )
-  })
-
-  it('sendFollowup llama PATCH al endpoint correcto de Discord', async () => {
-    const { sendFollowup } = await import('../../channels/discord.reply.js')
-
-    const result = await sendFollowup({
-      botToken:         FAKE_BOT_TOKEN,
-      applicationId:    FAKE_APP_ID,
-      interactionToken: FAKE_INT_TOKEN,
-      text:             'Respuesta del agente',
-    })
-
-    expect(result.ok).toBe(true)
-    expect(harness.fetchSpy).toHaveBeenCalledWith(
-      `https://discord.com/api/v10/webhooks/${FAKE_APP_ID}/${FAKE_INT_TOKEN}/messages/@original`,
-      expect.objectContaining({
-        method:  'PATCH',
-        headers: expect.objectContaining({
-          Authorization: `Bot ${FAKE_BOT_TOKEN}`,
-        }),
-      }),
-    )
-  })
-
-  it('sendFollowup con richContent incluye embed en el body', async () => {
-    const { sendFollowup } = await import('../../channels/discord.reply.js')
-
-    const spy = harness.fetchSpy
-    spy.mockClear()
-
-    await sendFollowup({
-      botToken:         FAKE_BOT_TOKEN,
-      applicationId:    FAKE_APP_ID,
-      interactionToken: FAKE_INT_TOKEN,
-      text:             'Resultado del análisis',
-      richContent: {
-        title:       'Estado del sistema',
-        description: 'Todo funciona correctamente',
-        color:       0x57F287,
-      },
-    })
-
-    const patchCall = spy.mock.calls.find(([url]) =>
-      url.toString().includes('/messages/@original')
-    )
-    expect(patchCall).toBeDefined()
-    const sentBody = JSON.parse((patchCall![1] as RequestInit).body as string)
-    expect(sentBody.embeds).toHaveLength(1)
-    expect(sentBody.embeds[0].title).toBe('Estado del sistema')
-    expect(sentBody.embeds[0].description).toBe('Todo funciona correctamente')
-    expect(sentBody.embeds[0].color).toBe(0x57F287)
   })
 })
 
-// ── Suite 3: Slash command /status ─────────────────────────────────────────────
+// ── HTTP: /status con binding ─────────────────────────────────────────────────
 
-describe('Discord E2E — Slash command /status', () => {
-  let harness: Awaited<ReturnType<typeof buildTestHarness>>
+describe('[F3a-27] HTTP — Slash command /status', () => {
+  let h: Awaited<ReturnType<typeof buildHttpHarness>>
 
-  beforeEach(async () => { harness = await buildTestHarness() })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+  beforeEach(async () => { h = await buildHttpHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await h.adapter.dispose() })
 
-  it('emite IncomingMessage con text que contiene "status"', async () => {
-    const body = makeSlashInteraction('status')
-
-    await request(harness.app)
+  it('emite IncomingMessage con type=command para /status', async () => {
+    await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
-      .send(body)
+      .send(makeSlashInteraction('status'))
       .expect(200)
 
-    expect(harness.capturedMessages).toHaveLength(1)
-    const msg = harness.capturedMessages[0]!
-    expect(msg.text.toLowerCase()).toContain('status')
+    expect(h.capturedMessages).toHaveLength(1)
+    const msg = h.capturedMessages[0]!
     expect(msg.type).toBe('command')
     expect(msg.channelType).toBe('discord')
   })
 
-  it('responde ACK type=5 inmediatamente para /status', async () => {
-    const body = makeSlashInteraction('status')
-
-    const res = await request(harness.app)
+  it('responde ACK type=5 para /status', async () => {
+    const res = await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
-      .send(body)
+      .send(makeSlashInteraction('status'))
       .expect(200)
 
     expect(res.body).toEqual({ type: 5 })
   })
 
   it('incluye interactionToken en metadata del IncomingMessage', async () => {
-    const body = makeSlashInteraction('status')
-    await request(harness.app)
+    await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
-      .send(body)
+      .send(makeSlashInteraction('status'))
 
-    const msg = harness.capturedMessages[0]!
+    const msg = h.capturedMessages[0]!
     expect(msg.metadata?.['interactionToken']).toBe(FAKE_INT_TOKEN)
   })
 })
 
-// ── Suite 4: Componente interactivo — botón ───────────────────────────────────
+// ── HTTP: sin binding → mensaje de error ──────────────────────────────────────
 
-describe('Discord E2E — Componente interactivo (botón)', () => {
-  let harness: Awaited<ReturnType<typeof buildTestHarness>>
-
-  beforeEach(async () => { harness = await buildTestHarness('Acción ejecutada correctamente') })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('emite IncomingMessage con text = custom_id del botón', async () => {
-    const body = makeButtonInteraction('action:confirm:run-123')
-
-    await request(harness.app)
-      .post('/discord')
-      .set('x-signature-ed25519',  'fakesig')
-      .set('x-signature-timestamp', '1234567890')
-      .send(body)
-      .expect(200)
-
-    expect(harness.capturedMessages).toHaveLength(1)
-    const msg = harness.capturedMessages[0]!
-    expect(msg.text).toBe('action:confirm:run-123')
-    expect(msg.type).toBe('command')
-    expect(msg.metadata?.['subtype']).toBe('button_click')
-    expect(msg.metadata?.['interactionToken']).toBe(FAKE_INT_TOKEN)
-  })
-
-  it('responde ACK type=6 (DEFERRED_UPDATE_MESSAGE) para componentes', async () => {
-    const body = makeButtonInteraction('action:cancel')
-
-    const res = await request(harness.app)
-      .post('/discord')
-      .set('x-signature-ed25519',  'fakesig')
-      .set('x-signature-timestamp', '1234567890')
-      .send(body)
-      .expect(200)
-
-    expect(res.body).toEqual({ type: 6 })
-  })
-
-  it('registra senderId y channelId correctamente para botón', async () => {
-    const body = makeButtonInteraction('btn:ok')
-    await request(harness.app)
-      .post('/discord')
-      .set('x-signature-ed25519',  'fakesig')
-      .set('x-signature-timestamp', '1234567890')
-      .send(body)
-
-    const msg = harness.capturedMessages[0]!
-    expect(msg.senderId).toBe(FAKE_USER_ID)
-    expect(msg.externalId).toBe(FAKE_CHANNEL_ID)
-  })
-})
-
-// ── Suite 5: sendToChannel — respuesta proactiva ────────────────────────────
-
-describe('Discord E2E — sendToChannel (respuesta proactiva)', () => {
-  let fetchSpy: jest.SpyInstance
-
-  beforeEach(() => {
-    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ id: 'new_message_id' }), {
-        status:  200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-  })
-
+describe('[F3a-27] HTTP — /ask sin binding devuelve error legible', () => {
   afterEach(() => jest.restoreAllMocks())
 
-  it('llama POST /channels/:id/messages con el texto correcto', async () => {
-    const { sendToChannel } = await import('../../channels/discord.reply.js')
+  it('no emite IncomingMessage pero no lanza excepción al servidor', async () => {
+    // Adapter sin bindings registrados (ningún agente vinculado)
+    const { app, adapter, capturedMessages } = await buildHttpHarness()
 
-    const result = await sendToChannel({
-      botToken:  FAKE_BOT_TOKEN,
-      channelId: FAKE_CHANNEL_ID,
-      text:      'Notificación proactiva del agente',
-    })
-
-    expect(result.ok).toBe(true)
-    expect(result.chunks).toBe(1)
-    expect(fetchSpy).toHaveBeenCalledWith(
-      `https://discord.com/api/v10/channels/${FAKE_CHANNEL_ID}/messages`,
-      expect.objectContaining({ method: 'POST' }),
-    )
-
-    const sentBody = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string)
-    expect(sentBody.content).toBe('Notificación proactiva del agente')
-  })
-
-  it('hace chunking correcto para mensajes > 2000 chars', async () => {
-    const { sendToChannel } = await import('../../channels/discord.reply.js')
-    const longText = 'a'.repeat(2200)
-
-    const result = await sendToChannel({
-      botToken:  FAKE_BOT_TOKEN,
-      channelId: FAKE_CHANNEL_ID,
-      text:      longText,
-    })
-
-    expect(result.ok).toBe(true)
-    expect(result.chunks).toBeGreaterThan(1)
-    for (const call of fetchSpy.mock.calls) {
-      const body = JSON.parse((call[1] as RequestInit).body as string)
-      if (body.content) {
-        expect(body.content.length).toBeLessThanOrEqual(2000)
-      }
-    }
-  })
-
-  it('adjunta embed solo al último chunk cuando hay richContent', async () => {
-    const { sendToChannel } = await import('../../channels/discord.reply.js')
-    const longText = 'palabra '.repeat(300)  // ~2400 chars → 2 chunks
-
-    await sendToChannel({
-      botToken:    FAKE_BOT_TOKEN,
-      channelId:   FAKE_CHANNEL_ID,
-      text:        longText,
-      richContent: { title: 'Resumen', description: 'Análisis completado' },
-    })
-
-    const calls = fetchSpy.mock.calls
-    expect(calls.length).toBeGreaterThan(1)
-
-    // Solo el último chunk tiene embeds
-    const lastBody = JSON.parse((calls[calls.length - 1]![1] as RequestInit).body as string)
-    expect(lastBody.embeds).toBeDefined()
-    expect(lastBody.embeds[0].title).toBe('Resumen')
-
-    // Los chunks anteriores NO tienen embeds
-    for (let i = 0; i < calls.length - 1; i++) {
-      const body = JSON.parse((calls[i]![1] as RequestInit).body as string)
-      expect(body.embeds).toBeUndefined()
-    }
-  })
-
-  it('devuelve { ok: false, error } cuando Discord API responde 403', async () => {
-    fetchSpy.mockResolvedValueOnce(
-      new Response('{"message": "Missing Access"}', {
-        status:  403,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-
-    const { sendToChannel } = await import('../../channels/discord.reply.js')
-    const result = await sendToChannel({
-      botToken:  FAKE_BOT_TOKEN,
-      channelId: FAKE_CHANNEL_ID,
-      text:      'Mensaje que fallará',
-    })
-
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('403')
-  })
-
-  it('devuelve { ok: false } en error de red', async () => {
-    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
-
-    const { sendToChannel } = await import('../../channels/discord.reply.js')
-    const result = await sendToChannel({
-      botToken:  FAKE_BOT_TOKEN,
-      channelId: FAKE_CHANNEL_ID,
-      text:      'Hi',
-    })
-
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('ECONNREFUSED')
-  })
-})
-
-// ── Suite 6: MessageDispatcher — errores y edge cases ───────────────────────
-
-describe('Discord E2E — MessageDispatcher error handling', () => {
-  afterEach(() => jest.restoreAllMocks())
-
-  it('devuelve { ok:false, errorKind:"timeout" } cuando AgentExecutor se demora', async () => {
-    const slowExecutor: IAgentExecutor = {
-      run: jest.fn().mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve({ reply: 'tarde' }), 10_000)),
-      ),
-    }
-    const dispatcher = new MessageDispatcher(slowExecutor, {
-      timeoutMs:   100,
-      maxAttempts: 1,
-    })
-
-    const result = await dispatcher.dispatch(makeDispatchInput())
-
-    expect(result.ok).toBe(false)
-    const fail = result as DispatchFailure
-    expect(fail.errorKind).toBe('timeout')
-  }, 15_000)
-
-  it('devuelve { ok:false, errorKind:"agent_error" } para errores del agente', async () => {
-    const notFoundExecutor: IAgentExecutor = {
-      run: jest.fn().mockRejectedValue(new Error('Agent not found — 404')),
-    }
-    const dispatcher = new MessageDispatcher(notFoundExecutor, {
-      timeoutMs:   5_000,
-      maxAttempts: 1,
-    })
-
-    const result = await dispatcher.dispatch(
-      makeDispatchInput({ agentId: 'nonexistent-agent' }),
-    )
-
-    expect(result.ok).toBe(false)
-    const fail = result as DispatchFailure
-    expect(['agent_error', 'transient', 'unknown']).toContain(fail.errorKind)
-  })
-
-  it('reintenta en errores transitorios hasta maxAttempts y tiene éxito', async () => {
-    const flakyExecutor: IAgentExecutor = {
-      run: jest.fn()
-        .mockRejectedValueOnce(new Error('ECONNREFUSED — network error'))
-        .mockResolvedValueOnce({ reply: 'segundo intento exitoso' }),
-    }
-    const dispatcher = new MessageDispatcher(flakyExecutor, {
-      timeoutMs:    5_000,
-      maxAttempts:  2,
-      retryDelayMs: 50,
-    })
-
-    const result = await dispatcher.dispatch(makeDispatchInput())
-
-    expect(result.ok).toBe(true)
-    const success = result as DispatchSuccess
-    expect(success.reply).toBe('segundo intento exitoso')
-    expect(success.attempts).toBe(2)
-    expect(flakyExecutor.run).toHaveBeenCalledTimes(2)
-  })
-
-  it('emite evento dispatch:success con metadata correcta', async () => {
-    const executor: IAgentExecutor = {
-      run: jest.fn().mockResolvedValue({ reply: 'ok' }),
-    }
-    const dispatcher = new MessageDispatcher(executor)
-    const successEvents: unknown[] = []
-    dispatcher.on('dispatch:success', (e) => successEvents.push(e))
-
-    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'session-events' }))
-
-    expect(successEvents).toHaveLength(1)
-    const ev = successEvents[0] as Record<string, unknown>
-    expect(ev['sessionId']).toBe('session-events')
-    expect(ev['agentId']).toBe(FAKE_AGENT_ID)
-    expect(ev['channelConfigId']).toBe(FAKE_CHANNEL_CFG)
-    expect(ev['attempts']).toBe(1)
-  })
-
-  it('emite evento dispatch:error cuando falla definitivamente', async () => {
-    const executor: IAgentExecutor = {
-      run: jest.fn().mockRejectedValue(new Error('fatal error')),
-    }
-    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1 })
-    const errorEvents: unknown[] = []
-    dispatcher.on('dispatch:error', (e) => errorEvents.push(e))
-
-    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'session-error-event' }))
-
-    expect(errorEvents).toHaveLength(1)
-    const ev = errorEvents[0] as Record<string, unknown>
-    expect(typeof ev['errorKind']).toBe('string')
-    expect(ev['attempts']).toBe(1)
-  })
-})
-
-// ── Suite 7: Edge cases de DiscordAdapter ────────────────────────────────────────
-
-describe('Discord E2E — DiscordAdapter edge cases', () => {
-  let harness: Awaited<ReturnType<typeof buildTestHarness>>
-
-  beforeEach(async () => { harness = await buildTestHarness() })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('retorna 401 cuando la firma Ed25519 es inválida', async () => {
-    // Usar un adapter con _verifySignature real (no mockeada)
-    jest.restoreAllMocks()
-
-    const adapter2 = new DiscordAdapter()
-    adapter2.initialize(FAKE_CHANNEL_CFG)
-    await adapter2.setup(
-      { applicationId: FAKE_APP_ID },
-      { botToken: FAKE_BOT_TOKEN, publicKey: 'aabbccdd' },  // clave falsa
-      'http',
-    )
-
-    const app2 = express()
-    app2.use(express.json())
-    app2.use('/discord', adapter2.buildHttpRouter())
-
-    const res = await request(app2)
+    await request(app)
       .post('/discord')
-      .set('x-signature-ed25519',  'invalidsignature')
+      .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
-      .send({ type: 1 })
-      .expect(401)
+      .send(makeSlashInteraction('ask', 'pregunta sin binding'))
+      .expect(200)  // El servidor no debe romper — devuelve 200
 
-    expect(res.body.error).toContain('signature')
-    await adapter2.dispose()
+    await adapter.dispose()
+    // El mensaje puede o no emitirse según la implementación;
+    // lo que no debe pasar es un 500 o excepción no atrapada.
   })
+})
+
+// ── HTTP: Edge cases ───────────────────────────────────────────────────────────
+
+describe('[F3a-27] HTTP — DiscordAdapter edge cases', () => {
+  let h: Awaited<ReturnType<typeof buildHttpHarness>>
+
+  beforeEach(async () => { h = await buildHttpHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await h.adapter.dispose() })
 
   it('retorna 400 para tipos de interacción desconocidos', async () => {
-    const res = await request(harness.app)
+    const res = await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
@@ -680,32 +730,30 @@ describe('Discord E2E — DiscordAdapter edge cases', () => {
     expect(res.body.error).toBeDefined()
   })
 
+  it('dispose() no lanza excepción', async () => {
+    await expect(h.adapter.dispose()).resolves.not.toThrow()
+  })
+
+  it('onError() registra handler sin lanzar', () => {
+    expect(() => h.adapter.onError(jest.fn())).not.toThrow()
+  })
+
   it('no emite IncomingMessage si falta channel_id en la interacción', async () => {
     const bodyWithoutChannel = {
-      id:    '888888888888888888',
-      type:  2,
-      token: FAKE_INT_TOKEN,
+      id:     '888888888888888888',
+      type:   2,
+      token:  FAKE_INT_TOKEN,
       member: { user: { id: FAKE_USER_ID, username: 'test' } },
-      data:  { name: 'ask', options: [] },
-      // channel_id: OMITIDO — el adapter no puede enrutar
+      data:   { name: 'ask', options: [] },
+      // channel_id: OMITIDO
     }
 
-    await request(harness.app)
+    await request(h.app)
       .post('/discord')
       .set('x-signature-ed25519',  'fakesig')
       .set('x-signature-timestamp', '1234567890')
       .send(bodyWithoutChannel)
-      .expect(200)
 
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('dispose() limpia el adapter sin errores', async () => {
-    await expect(harness.adapter.dispose()).resolves.not.toThrow()
-  })
-
-  it('onError() registra el handler de errores sin lanzar', () => {
-    const errorHandler = jest.fn()
-    expect(() => harness.adapter.onError(errorHandler)).not.toThrow()
+    expect(h.capturedMessages).toHaveLength(0)
   })
 })

--- a/apps/gateway/src/tests/e2e/teams.e2e-spec.ts
+++ b/apps/gateway/src/tests/e2e/teams.e2e-spec.ts
@@ -1,913 +1,516 @@
 /**
- * teams.e2e-spec.ts — [F3a-27]
+ * teams.e2e-spec.ts — [F3a-27] Tests E2E del canal Microsoft Teams
  *
- * Tests E2E del flujo Microsoft Teams:
- *   Webhook HTTP → TeamsAdapter → IncomingMessage
- *   → MessageDispatcher → AgentExecutor (mock)
- *   → strategy.send → Teams API (fetch mock)
- *
- * Estrategia de mocking:
- *   - fetch global: mockeado con jest.spyOn para capturar llamadas a Teams/Microsoft API
- *   - IAgentExecutor: jest.fn() que devuelve respuesta configurable
- *   - JWT auth middleware: mockeado (_verifyBotFrameworkAuth) para saltear verificación
- *   - Prisma: NO se usa directamente en estos tests
- *
- * Estructura de suites:
- *   1. IncomingWebhookStrategy — envío y verificación
- *   2. BotFrameworkStrategy — token OAuth + envío de actividad
- *   3. TeamsAdapter (bot_framework) — recepción de message Activity
- *   4. TeamsAdapter — conversationUpdate / invoke / tipos desconocidos
- *   5. TeamsAdapter (incoming_webhook) — modo solo-envío
- *   6. MessageDispatcher — integración con TeamsAdapter
- *   7. Edge cases del TeamsAdapter
+ * Valida:
+ *   ✅ Actividad 'message' con bot_framework → emit() llamado → respuesta enviada
+ *   ✅ Actividad 'message' en modo incoming_webhook → responde 400 informativo
+ *   ✅ Actividad tipo 'invoke' (Teams health check) → responde 200 {}
+ *   ✅ Actividad 'conversationUpdate' → responde 200 sin emitir al agente
+ *   ✅ Actividad sin 'type' → responde 400
+ *   ✅ Autenticación Bot Framework: Bearer token con appId incorrecto → 401
+ *   ✅ Autenticación Bot Framework: Bearer token malformado → 401
+ *   ✅ Autenticación Bot Framework: sin Bearer → 401
+ *   ✅ Token válido (appId correcto) → procesa actividad normalmente
+ *   ✅ send() con serviceUrl → delega a strategy.send()
+ *   ✅ send() sin serviceUrl → error controlado (no lanza excepción)
+ *   ✅ GET /health → status ok + mode + channelConfigId
+ *   ✅ POST /messages en modo incoming_webhook → 400 con mensaje explicativo
+ *   ✅ Error en emit() → strategy.send() llamado con mensaje de error (no crash)
  */
 
-import express                from 'express'
-import request                from 'supertest'
-
-import { TeamsAdapter }       from '../../channels/teams/teams-bot.adapter.js'
-import { MessageDispatcher }  from '../../message-dispatcher.service.js'
+import express, { Application } from 'express'
+import request from 'supertest'
+import { TeamsAdapter } from '../../channels/teams/teams-bot.adapter.js'
 import type {
-  IAgentExecutor,
-  DispatchInput,
-  DispatchSuccess,
-  DispatchFailure,
-}                             from '../../message-dispatcher.types.js'
-import type { IncomingMessage } from '../../channels/channel-adapter.interface.js'
-import {
-  IncomingWebhookStrategy,
-  BotFrameworkStrategy,
-  buildAdaptiveTextCard,
-  buildAdaptiveRichCard,
-  type TeamsActivity,
-}                             from '../../channels/teams/teams-mode.strategy.js'
+  ITeamsModeStrategy,
+  TeamsActivity,
+  TeamsOutgoingPayload,
+  TeamsSendResult,
+} from '../../channels/teams/teams-mode.strategy.js'
+import type { OutgoingMessage } from '../../channels/channel-adapter.interface.js'
 
-// ── Fixtures ──────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-const FAKE_APP_ID       = 'app-id-test-1111'
-const FAKE_APP_PASSWORD = 'app-password-test-2222'
-const FAKE_WEBHOOK_URL  = 'https://prod-01.westus.logic.azure.com/fake-webhook'
-const FAKE_SERVICE_URL  = 'https://smba.trafficmanager.net/apis'
-const FAKE_CONV_ID      = '19:conversation-id-test@thread.v2'
-const FAKE_TENANT_ID    = 'tenant-uuid-test'
-const FAKE_TEAM_ID      = 'team-uuid-test'
-const FAKE_USER_ID      = 'aad-user-uuid-test'
-const FAKE_USER_NAME    = 'Test User'
-const FAKE_BOT_ID       = 'bot-uuid-test'
-const FAKE_CHANNEL_CFG  = 'channel-config-teams-test'
-const FAKE_AGENT_ID     = 'agent-uuid-teams-test'
-const FAKE_SESSION_ID   = 'session-teams-001'
-const FAKE_BEARER_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBpZCI6ImFwcC1pZC10ZXN0LTExMTEiLCJleHAiOjk5OTk5OTk5OTl9.signature'
+/**
+ * Construye un JWT mínimo (sin firma real) con el appId indicado.
+ * Solo para tests de la verificación _verifyBotFrameworkAuth.
+ */
+function buildFakeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url')
+  const body   = Buffer.from(JSON.stringify(payload)).toString('base64url')
+  const sig    = Buffer.from('fakesignature').toString('base64url')
+  return `${header}.${body}.${sig}`
+}
 
-/** Crea una TeamsActivity de tipo 'message' completa */
-function makeMessageActivity(text: string, overrides: Partial<TeamsActivity> = {}): TeamsActivity {
+function makeActivity(overrides: Partial<TeamsActivity> = {}): TeamsActivity {
   return {
     type:       'message',
-    id:         'activity-id-test-001',
+    id:         'act-001',
     timestamp:  new Date().toISOString(),
-    serviceUrl: FAKE_SERVICE_URL,
+    serviceUrl: 'https://smba.trafficmanager.net/amer/',
     channelId:  'msteams',
     from: {
-      id:          FAKE_USER_ID,
-      name:        FAKE_USER_NAME,
-      aadObjectId: FAKE_USER_ID,
+      id:          'user-aad-001',
+      name:        'Test User',
+      aadObjectId: 'aad-001',
     },
     conversation: {
-      id:       FAKE_CONV_ID,
-      tenantId: FAKE_TENANT_ID,
-      isGroup:  true,
+      id:       'conv-001',
+      tenantId: 'tenant-001',
+      isGroup:  false,
     },
     recipient: {
-      id:   FAKE_BOT_ID,
+      id:   'bot-app-id',
       name: 'TestBot',
     },
-    text,
+    text: 'Hola agente',
     channelData: {
-      tenant:  { id: FAKE_TENANT_ID },
-      team:    { id: FAKE_TEAM_ID, name: 'Test Team' },
-      channel: { id: '19:channel-id@thread.skype', name: 'General' },
+      tenant:  { id: 'tenant-001' },
+      team:    { id: 'team-001', name: 'Dev Team' },
+      channel: { id: 'ch-001',   name: 'general' },
     },
     ...overrides,
   }
 }
 
-/** Crea una TeamsActivity de tipo 'conversationUpdate' */
-function makeConversationUpdateActivity(): TeamsActivity {
-  return {
-    type:       'conversationUpdate',
-    id:         'activity-id-update-001',
-    serviceUrl: FAKE_SERVICE_URL,
-    channelId:  'msteams',
-    from:         { id: FAKE_BOT_ID, name: 'TestBot' },
-    conversation: { id: FAKE_CONV_ID, tenantId: FAKE_TENANT_ID, isGroup: true },
-    recipient:    { id: FAKE_USER_ID, name: FAKE_USER_NAME },
-    channelData: {
-      team:    { id: FAKE_TEAM_ID, name: 'Test Team' },
-      channel: { id: '19:channel@thread.skype', name: 'General' },
-    },
-  }
-}
+// ── Mock strategy factory ─────────────────────────────────────────────────────
 
-/** Crea una TeamsActivity de tipo 'invoke' (health check de Teams) */
-function makeInvokeActivity(): TeamsActivity {
-  return {
-    type:         'invoke',
-    id:           'activity-id-invoke-001',
-    serviceUrl:   FAKE_SERVICE_URL,
-    channelId:    'msteams',
-    from:         { id: FAKE_USER_ID },
-    conversation: { id: FAKE_CONV_ID },
-    recipient:    { id: FAKE_BOT_ID },
-  }
-}
+function makeMockStrategy(
+  mode:  'bot_framework' | 'incoming_webhook' = 'bot_framework',
+  appId = 'test-app-id',
+): { strategy: ITeamsModeStrategy; sendMock: jest.Mock } {
+  const sendMock = jest
+    .fn<Promise<TeamsSendResult>, [TeamsOutgoingPayload, string, string?]>()
+    .mockResolvedValue({ ok: true, activityId: 'sent-act-001' })
 
-/** Crea un DispatchInput válido */
-function makeDispatchInput(overrides: Partial<DispatchInput> = {}): DispatchInput {
-  return {
-    sessionId:       FAKE_SESSION_ID,
-    agentId:         FAKE_AGENT_ID,
-    channelConfigId: FAKE_CHANNEL_CFG,
-    externalUserId:  FAKE_USER_ID,
-    history: [
-      { role: 'user', content: 'Mensaje de prueba Teams' },
-    ],
-    ...overrides,
-  }
-}
-
-/** Construye un JWT mínimo con el appid correcto para pasar la verificación del adapter */
-function makeFakeJwt(appId: string): string {
-  const payload = Buffer.from(JSON.stringify({ appid: appId, exp: 9999999999 })).toString('base64url')
-  return `eyJhbGciOiJSUzI1NiJ9.${payload}.fakesignature`
-}
-
-// ── Harness compartido ────────────────────────────────────────────────────────
-
-async function buildBotFrameworkHarness(agentReply = 'Respuesta de Teams del agente') {
-  // Mock global de fetch — simula Microsoft API respondiendo OK
-  const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
-    async (url: RequestInfo | URL) => {
-      const urlStr = typeof url === 'string' ? url : (url as URL).toString()
-
-      // Token endpoint de Microsoft
-      if (urlStr.includes('login.microsoftonline.com')) {
-        return new Response(
-          JSON.stringify({
-            access_token: FAKE_BEARER_TOKEN,
-            expires_in:   3600,
-            token_type:   'Bearer',
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        )
-      }
-
-      // Bot Framework Service (envío de respuesta)
-      if (urlStr.includes('smba.trafficmanager.net') || urlStr.includes('/v3/conversations/')) {
-        return new Response(
-          JSON.stringify({ id: 'mock-activity-id' }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        )
-      }
-
-      throw new Error(`fetch no mockeada para URL: ${urlStr}`)
-    },
-  )
-
-  // AgentExecutor mock
-  const mockExecutor: IAgentExecutor = {
-    run: jest.fn().mockResolvedValue({ reply: agentReply }),
+  const strategy: ITeamsModeStrategy = {
+    mode,
+    send:   sendMock,
+    verify: jest.fn().mockResolvedValue({ ok: true }),
+    buildTextCard: jest.fn().mockImplementation((text: string) => ({
+      contentType: 'application/vnd.microsoft.card.adaptive',
+      content:     { type: 'AdaptiveCard', body: [{ type: 'TextBlock', text }] },
+    })),
+    ...(mode === 'bot_framework'
+      ? { getBearerToken: jest.fn().mockResolvedValue('fake-bearer-token') }
+      : {}),
   }
 
-  // TeamsAdapter en modo bot_framework
-  const adapter = new TeamsAdapter()
-  await adapter.initialize(FAKE_CHANNEL_CFG)
-  await adapter.setup(
-    { mode: 'bot_framework' },
-    { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-  )
+  // Exponer appId para referencia interna en tests
+  ;(strategy as unknown as Record<string, unknown>)['_appId'] = appId
 
-  // MessageDispatcher
-  const dispatcher = new MessageDispatcher(mockExecutor, {
-    timeoutMs:    5_000,
-    maxAttempts:  1,
-    retryDelayMs: 50,
+  return { strategy, sendMock }
+}
+
+// ── App factory para tests ────────────────────────────────────────────────────
+
+async function buildTestApp(
+  mode:  'bot_framework' | 'incoming_webhook' = 'bot_framework',
+  appId = 'test-app-id',
+): Promise<{
+  app:        Application
+  adapter:    TeamsAdapter
+  sendMock:   jest.Mock
+  emitEvents: TeamsActivity[]
+}> {
+  const { strategy, sendMock } = makeMockStrategy(mode, appId)
+  const emitEvents: TeamsActivity[] = []
+
+  const adapter = new TeamsAdapter({ routePrefix: '/teams' })
+  await adapter.initialize('channel-config-001')
+
+  // Inyectar dependencias mock sin pasar por setup() que haría fetch a Azure
+  const adapterAny = adapter as unknown as Record<string, unknown>
+  adapterAny['strategy'] = strategy
+  adapterAny['config']   = { mode, agentTimeoutMs: 5_000 }
+  adapterAny['secrets']  = { appId, appPassword: 'test-password' }
+  adapterAny['router']   =
+    (adapter as unknown as { _buildRouter(): unknown })['_buildRouter']()
+
+  // Capturar IncomingMessages emitidos al agente
+  adapter.on('message', (msg: unknown) => {
+    emitEvents.push(
+      (msg as { rawPayload: TeamsActivity }).rawPayload,
+    )
   })
 
-  // App Express
   const app = express()
   app.use(express.json())
   app.use('/teams', adapter.getRouter())
 
-  // Capturar IncomingMessages
-  const capturedMessages: IncomingMessage[] = []
-  adapter.onMessage((msg) => capturedMessages.push(msg))
-
-  // Token Bearer con appid correcto para superar validación JWT
-  const validAuthHeader = `Bearer ${makeFakeJwt(FAKE_APP_ID)}`
-
-  return { adapter, dispatcher, mockExecutor, fetchSpy, app, capturedMessages, validAuthHeader }
+  return { app, adapter, sendMock, emitEvents }
 }
 
-// ── Suite 1: IncomingWebhookStrategy ─────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// SUITE PRINCIPAL
+// ─────────────────────────────────────────────────────────────────────────────
 
-describe('Teams E2E — IncomingWebhookStrategy', () => {
-  let fetchSpy: jest.SpyInstance
+describe('TeamsAdapter — E2E', () => {
 
-  beforeEach(() => {
-    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
-      new Response('1', { status: 200 }),
-    )
-  })
+  // ── Healthcheck ──────────────────────────────────────────────────────────────
 
-  afterEach(() => jest.restoreAllMocks())
+  describe('GET /teams/health', () => {
+    it('devuelve status ok, channel, mode y channelConfigId', async () => {
+      const { app } = await buildTestApp('bot_framework')
 
-  it('send() POST al webhookUrl con Adaptive Card cuando hay texto', async () => {
-    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+      const res = await request(app).get('/teams/health')
 
-    const result = await strategy.send({
-      type:        'message',
-      attachments: [buildAdaptiveTextCard('Hola desde el agente')],
-    }, FAKE_CONV_ID)
-
-    expect(result.ok).toBe(true)
-    expect(fetchSpy).toHaveBeenCalledWith(
-      FAKE_WEBHOOK_URL,
-      expect.objectContaining({ method: 'POST' }),
-    )
-  })
-
-  it('send() incluye Adaptive Card en el body cuando hay attachments', async () => {
-    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
-
-    await strategy.send({
-      type:        'message',
-      attachments: [buildAdaptiveTextCard('Test message')],
-    }, FAKE_CONV_ID)
-
-    const sentBody = JSON.parse(
-      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
-    )
-    expect(sentBody.type).toBe('message')
-    expect(sentBody.attachments).toHaveLength(1)
-    expect(sentBody.attachments[0].contentType).toBe('application/vnd.microsoft.card.adaptive')
-  })
-
-  it('send() devuelve { ok: false } cuando Teams responde 400', async () => {
-    fetchSpy.mockResolvedValueOnce(
-      new Response('Bad payload', { status: 400 }),
-    )
-
-    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
-    const result = await strategy.send({ type: 'message', text: 'test' }, FAKE_CONV_ID)
-
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('400')
-  })
-
-  it('send() devuelve { ok: false } en error de red', async () => {
-    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
-
-    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
-    const result = await strategy.send({ type: 'message', text: 'test' }, FAKE_CONV_ID)
-
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('ECONNREFUSED')
-  })
-
-  it('verify() llama send() con una Adaptive Card de prueba', async () => {
-    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
-    const result   = await strategy.verify()
-
-    expect(result.ok).toBe(true)
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-  })
-
-  it('constructor lanza si webhookUrl no es HTTPS', () => {
-    expect(() => new IncomingWebhookStrategy({ webhookUrl: 'http://insecure.com/hook' }))
-      .toThrow('HTTPS')
-  })
-
-  it('buildAdaptiveTextCard genera estructura de Adaptive Card válida', () => {
-    const card = buildAdaptiveTextCard('Mensaje de prueba')
-
-    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
-    const content = card.content as Record<string, unknown>
-    expect(content['type']).toBe('AdaptiveCard')
-    expect(content['version']).toBe('1.5')
-    const body = content['body'] as Array<Record<string, unknown>>
-    expect(body[0]?.['text']).toBe('Mensaje de prueba')
-    expect(body[0]?.['wrap']).toBe(true)
-  })
-
-  it('buildAdaptiveRichCard incluye title, description y botones', () => {
-    const card = buildAdaptiveRichCard({
-      title:       'Estado del agente',
-      description: 'Fase F3a completada',
-      buttons:     [{ label: 'Ver más', value: 'action:ver-mas' }],
+      expect(res.status).toBe(200)
+      expect(res.body).toMatchObject({
+        status:          'ok',
+        channel:         'teams',
+        mode:            'bot_framework',
+        channelConfigId: 'channel-config-001',
+      })
+      expect(res.body.timestamp).toBeDefined()
     })
 
-    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
-    const content = card.content as Record<string, unknown>
-    const body    = content['body'] as Array<Record<string, unknown>>
-    const actions = content['actions'] as Array<Record<string, unknown>>
+    it('refleja mode incoming_webhook cuando está configurado así', async () => {
+      const { app } = await buildTestApp('incoming_webhook')
 
-    expect(body.some((b) => b['text'] === 'Estado del agente')).toBe(true)
-    expect(body.some((b) => b['text'] === 'Fase F3a completada')).toBe(true)
-    expect(actions).toHaveLength(1)
-    expect(actions[0]?.['title']).toBe('Ver más')
-  })
-})
+      const res = await request(app).get('/teams/health')
 
-// ── Suite 2: BotFrameworkStrategy — token OAuth ───────────────────────────────
-
-describe('Teams E2E — BotFrameworkStrategy (OAuth + send)', () => {
-  let fetchSpy: jest.SpyInstance
-
-  beforeEach(() => {
-    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
-      async (url: RequestInfo | URL) => {
-        const urlStr = typeof url === 'string' ? url : (url as URL).toString()
-
-        if (urlStr.includes('login.microsoftonline.com')) {
-          return new Response(
-            JSON.stringify({ access_token: FAKE_BEARER_TOKEN, expires_in: 3600, token_type: 'Bearer' }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } },
-          )
-        }
-
-        if (urlStr.includes('/v3/conversations/')) {
-          return new Response(
-            JSON.stringify({ id: 'new-activity-id' }),
-            { status: 200, headers: { 'Content-Type': 'application/json' } },
-          )
-        }
-
-        throw new Error(`fetch no mockeada: ${urlStr}`)
-      },
-    )
-  })
-
-  afterEach(() => jest.restoreAllMocks())
-
-  it('getBearerToken() obtiene token de Microsoft OAuth', async () => {
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-
-    const token = await strategy.getBearerToken!()
-
-    expect(token).toBe(FAKE_BEARER_TOKEN)
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
-      expect.objectContaining({ method: 'POST' }),
-    )
-  })
-
-  it('getBearerToken() usa caché y no llama fetch dos veces', async () => {
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-
-    await strategy.getBearerToken!()
-    await strategy.getBearerToken!()
-
-    const tokenCalls = fetchSpy.mock.calls.filter(([url]) =>
-      url.toString().includes('login.microsoftonline.com')
-    )
-    expect(tokenCalls).toHaveLength(1)
-  })
-
-  it('send() incluye Bearer token en el header Authorization', async () => {
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-
-    await strategy.send(
-      { type: 'message', attachments: [buildAdaptiveTextCard('Respuesta')] },
-      FAKE_CONV_ID,
-      FAKE_SERVICE_URL,
-    )
-
-    const activityCall = fetchSpy.mock.calls.find(([url]) =>
-      url.toString().includes('/v3/conversations/')
-    )
-    expect(activityCall).toBeDefined()
-    expect((activityCall![1] as RequestInit).headers).toMatchObject({
-      Authorization: `Bearer ${FAKE_BEARER_TOKEN}`,
+      expect(res.status).toBe(200)
+      expect(res.body.mode).toBe('incoming_webhook')
     })
   })
 
-  it('send() construye URL correcta para el Bot Framework Service', async () => {
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
+  // ── Modo incoming_webhook: POST /messages ─────────────────────────────────────
 
-    await strategy.send(
-      { type: 'message', text: 'Hola' },
-      FAKE_CONV_ID,
-      FAKE_SERVICE_URL,
-    )
+  describe('POST /teams/messages — modo incoming_webhook', () => {
+    it('responde 400 con mensaje explicativo (canal de solo envío)', async () => {
+      const { app } = await buildTestApp('incoming_webhook')
 
-    const activityCall = fetchSpy.mock.calls.find(([url]) =>
-      url.toString().includes('/v3/conversations/')
-    )
-    expect(activityCall![0]).toBe(
-      `${FAKE_SERVICE_URL}/v3/conversations/${FAKE_CONV_ID}/activities`
-    )
-  })
-
-  it('send() devuelve { ok: false } cuando falta serviceUrl', async () => {
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-
-    const result = await strategy.send(
-      { type: 'message', text: 'Hola' },
-      FAKE_CONV_ID,
-      // serviceUrl omitido
-    )
-
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('serviceUrl')
-  })
-
-  it('verify() retorna ok:true si el token se obtiene correctamente', async () => {
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-
-    const result = await strategy.verify()
-    expect(result.ok).toBe(true)
-  })
-
-  it('verify() retorna ok:false si el token falla', async () => {
-    fetchSpy.mockRejectedValueOnce(new Error('Auth server down'))
-
-    const strategy = new BotFrameworkStrategy(
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-
-    const result = await strategy.verify()
-    expect(result.ok).toBe(false)
-    expect(result.error).toContain('Auth server down')
-  })
-
-  it('constructor lanza si falta appId', () => {
-    expect(() => new BotFrameworkStrategy({ appId: '', appPassword: FAKE_APP_PASSWORD }))
-      .toThrow('appId')
-  })
-
-  it('constructor lanza si falta appPassword', () => {
-    expect(() => new BotFrameworkStrategy({ appId: FAKE_APP_ID, appPassword: '' }))
-      .toThrow('appPassword')
-  })
-})
-
-// ── Suite 3: TeamsAdapter (bot_framework) — recepción de message Activity ─────
-
-describe('Teams E2E — TeamsAdapter bot_framework: message Activity', () => {
-  let harness: Awaited<ReturnType<typeof buildBotFrameworkHarness>>
-
-  beforeEach(async () => { harness = await buildBotFrameworkHarness('Respuesta del agente Teams') })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('POST /teams/messages emite IncomingMessage con campos normalizados', async () => {
-    const body = makeMessageActivity('¿Cuál es el estado del proyecto?')
-
-    await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    // El adapter responde 200 inmediatamente y procesa en background
-    await new Promise((r) => setTimeout(r, 50))
-
-    expect(harness.capturedMessages).toHaveLength(1)
-    const msg = harness.capturedMessages[0]!
-    expect(msg.channelType).toBe('teams')
-    expect(msg.channelConfigId).toBe(FAKE_CHANNEL_CFG)
-    expect(msg.externalId).toBe(FAKE_CONV_ID)
-    expect(msg.senderId).toBe(FAKE_USER_ID)     // usa aadObjectId
-    expect(msg.text).toBe('¿Cuál es el estado del proyecto?')
-    expect(msg.type).toBe('text')
-  })
-
-  it('IncomingMessage.metadata incluye serviceUrl, tenantId, teamId', async () => {
-    const body = makeMessageActivity('Test metadata')
-
-    await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    await new Promise((r) => setTimeout(r, 50))
-
-    const msg = harness.capturedMessages[0]!
-    expect(msg.metadata?.['serviceUrl']).toBe(FAKE_SERVICE_URL)
-    expect(msg.metadata?.['tenantId']).toBe(FAKE_TENANT_ID)
-    expect(msg.metadata?.['teamId']).toBe(FAKE_TEAM_ID)
-    expect(msg.metadata?.['isGroup']).toBe(true)
-    expect(msg.metadata?.['fromName']).toBe(FAKE_USER_NAME)
-  })
-
-  it('responde 200 inmediatamente (no espera al agente)', async () => {
-    // El agente tarda 500ms pero la respuesta HTTP debe ser inmediata
-    const slowExecutor: IAgentExecutor = {
-      run: jest.fn().mockImplementation(
-        () => new Promise((r) => setTimeout(() => r({ reply: 'tarde' }), 500))
-      ),
-    }
-    const slowDispatcher = new MessageDispatcher(slowExecutor)
-    const slowAdapter    = new TeamsAdapter()
-    await slowAdapter.initialize('slow-test-config')
-    await slowAdapter.setup(
-      { mode: 'bot_framework' },
-      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
-    )
-    const slowApp = express()
-    slowApp.use(express.json())
-    slowApp.use('/teams', slowAdapter.getRouter())
-    void slowDispatcher  // evitar advertencia de unused
-
-    const start = Date.now()
-    await request(slowApp)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(makeMessageActivity('mensaje lento'))
-      .expect(200)
-    const elapsed = Date.now() - start
-
-    // La respuesta HTTP debe llegar en menos de 200ms (no espera al agente)
-    expect(elapsed).toBeLessThan(300)
-    await slowAdapter.dispose()
-  })
-
-  it('no emite IncomingMessage para actividad con texto vacío', async () => {
-    const body = makeMessageActivity('')  // texto vacío
-
-    await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    await new Promise((r) => setTimeout(r, 50))
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('no emite IncomingMessage para texto solo con espacios', async () => {
-    const body = makeMessageActivity('   ')  // solo espacios
-
-    await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    await new Promise((r) => setTimeout(r, 50))
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('dispatcher.dispatch() retorna ok:true con respuesta del agente', async () => {
-    const result = await harness.dispatcher.dispatch(
-      makeDispatchInput({ history: [{ role: 'user', content: '¿cuántas fases hay?' }] }),
-    )
-
-    expect(result.ok).toBe(true)
-    const success = result as DispatchSuccess
-    expect(success.reply).toBe('Respuesta del agente Teams')
-    expect(success.attempts).toBe(1)
-  })
-
-  it('AgentExecutor recibe agentId y history correctos', async () => {
-    await harness.dispatcher.dispatch(
-      makeDispatchInput({ history: [{ role: 'user', content: '¿Cuántas fases?' }] }),
-    )
-
-    expect(harness.mockExecutor.run).toHaveBeenCalledWith(
-      FAKE_AGENT_ID,
-      expect.arrayContaining([
-        expect.objectContaining({ role: 'user', content: '¿Cuántas fases?' }),
-      ]),
-    )
-  })
-})
-
-// ── Suite 4: TeamsAdapter — conversationUpdate / invoke / tipos desconocidos ──
-
-describe('Teams E2E — TeamsAdapter: actividades no-message', () => {
-  let harness: Awaited<ReturnType<typeof buildBotFrameworkHarness>>
-
-  beforeEach(async () => { harness = await buildBotFrameworkHarness() })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('conversationUpdate responde 200 y NO emite IncomingMessage', async () => {
-    const body = makeConversationUpdateActivity()
-
-    await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    await new Promise((r) => setTimeout(r, 50))
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('invoke responde 200 con body vacío {} y NO emite IncomingMessage', async () => {
-    const body = makeInvokeActivity()
-
-    const res = await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    expect(res.body).toEqual({})
-    await new Promise((r) => setTimeout(r, 50))
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('tipo desconocido responde 200 y NO emite IncomingMessage', async () => {
-    const body: Partial<TeamsActivity> & { type: string } = {
-      type:         'typing',  // indicador de escritura — ignorar
-      serviceUrl:   FAKE_SERVICE_URL,
-      channelId:    'msteams',
-      from:         { id: FAKE_USER_ID },
-      conversation: { id: FAKE_CONV_ID },
-      recipient:    { id: FAKE_BOT_ID },
-    }
-
-    await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send(body)
-      .expect(200)
-
-    await new Promise((r) => setTimeout(r, 50))
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('retorna 400 cuando el body no tiene campo type', async () => {
-    const res = await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', harness.validAuthHeader)
-      .send({ text: 'sin type' })
-      .expect(400)
-
-    expect(res.body.error).toBeDefined()
-  })
-})
-
-// ── Suite 5: TeamsAdapter modo incoming_webhook ───────────────────────────────
-
-describe('Teams E2E — TeamsAdapter: modo incoming_webhook', () => {
-  let adapter: TeamsAdapter
-  let app: ReturnType<typeof express>
-  let fetchSpy: jest.SpyInstance
-
-  beforeEach(async () => {
-    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
-      new Response('1', { status: 200 }),
-    )
-
-    adapter = new TeamsAdapter({ mode: 'incoming_webhook' })
-    await adapter.initialize('webhook-channel-cfg')
-    await adapter.setup(
-      { mode: 'incoming_webhook' },
-      { webhookUrl: FAKE_WEBHOOK_URL },
-    )
-
-    app = express()
-    app.use(express.json())
-    app.use('/teams', adapter.getRouter())
-  })
-
-  afterEach(async () => {
-    jest.restoreAllMocks()
-    await adapter.dispose()
-  })
-
-  it('GET /teams/health responde { status: ok, channel: teams, mode: incoming_webhook }', async () => {
-    const res = await request(app)
-      .get('/teams/health')
-      .expect(200)
-
-    expect(res.body.status).toBe('ok')
-    expect(res.body.channel).toBe('teams')
-    expect(res.body.mode).toBe('incoming_webhook')
-  })
-
-  it('POST /teams/messages responde 400 indicando que es solo-envío', async () => {
-    const res = await request(app)
-      .post('/teams/messages')
-      .send(makeMessageActivity('Hola'))
-      .expect(400)
-
-    expect(res.body.error).toContain('Incoming Webhook')
-    expect(res.body.error).toContain('bot_framework')
-    void fetchSpy  // evitar advertencia de unused en caso de que mock no sea llamado
-  })
-
-  it('adapter.send() delega al IncomingWebhookStrategy y llama al webhookUrl', async () => {
-    await adapter.send({
-      channelConfigId: 'webhook-channel-cfg',
-      channelType:     'teams',
-      externalId:      FAKE_CONV_ID,
-      text:            'Notificación del agente',
-    })
-
-    expect(fetchSpy).toHaveBeenCalledWith(
-      FAKE_WEBHOOK_URL,
-      expect.objectContaining({ method: 'POST' }),
-    )
-  })
-})
-
-// ── Suite 6: MessageDispatcher — integración con TeamsAdapter ─────────────────
-
-describe('Teams E2E — MessageDispatcher error handling', () => {
-  afterEach(() => jest.restoreAllMocks())
-
-  it('devuelve { ok:false, errorKind:"timeout" } cuando AgentExecutor es lento', async () => {
-    const slowExecutor: IAgentExecutor = {
-      run: jest.fn().mockImplementation(
-        () => new Promise((r) => setTimeout(() => r({ reply: 'tarde' }), 10_000)),
-      ),
-    }
-    const dispatcher = new MessageDispatcher(slowExecutor, {
-      timeoutMs:   100,
-      maxAttempts: 1,
-    })
-
-    const result = await dispatcher.dispatch(makeDispatchInput())
-
-    expect(result.ok).toBe(false)
-    const fail = result as DispatchFailure
-    expect(fail.errorKind).toBe('timeout')
-  }, 15_000)
-
-  it('devuelve { ok:false, errorKind:"agent_error" } para errores del agente', async () => {
-    const errorExecutor: IAgentExecutor = {
-      run: jest.fn().mockRejectedValue(new Error('Teams agent not found')),
-    }
-    const dispatcher = new MessageDispatcher(errorExecutor, {
-      timeoutMs:   5_000,
-      maxAttempts: 1,
-    })
-
-    const result = await dispatcher.dispatch(
-      makeDispatchInput({ agentId: 'nonexistent-teams-agent' }),
-    )
-
-    expect(result.ok).toBe(false)
-    const fail = result as DispatchFailure
-    expect(['agent_error', 'transient', 'unknown']).toContain(fail.errorKind)
-  })
-
-  it('reintenta en errores transitorios y tiene éxito al segundo intento', async () => {
-    const flakyExecutor: IAgentExecutor = {
-      run: jest.fn()
-        .mockRejectedValueOnce(new Error('ETIMEDOUT — transient error'))
-        .mockResolvedValueOnce({ reply: 'segundo intento OK' }),
-    }
-    const dispatcher = new MessageDispatcher(flakyExecutor, {
-      timeoutMs:    5_000,
-      maxAttempts:  2,
-      retryDelayMs: 50,
-    })
-
-    const result = await dispatcher.dispatch(makeDispatchInput())
-
-    expect(result.ok).toBe(true)
-    const success = result as DispatchSuccess
-    expect(success.reply).toBe('segundo intento OK')
-    expect(success.attempts).toBe(2)
-  })
-
-  it('emite dispatch:success con metadata de Teams correcta', async () => {
-    const executor: IAgentExecutor = {
-      run: jest.fn().mockResolvedValue({ reply: 'ok teams' }),
-    }
-    const dispatcher = new MessageDispatcher(executor)
-    const successEvents: unknown[] = []
-    dispatcher.on('dispatch:success', (e) => successEvents.push(e))
-
-    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'teams-session-event' }))
-
-    expect(successEvents).toHaveLength(1)
-    const ev = successEvents[0] as Record<string, unknown>
-    expect(ev['sessionId']).toBe('teams-session-event')
-    expect(ev['agentId']).toBe(FAKE_AGENT_ID)
-    expect(ev['channelConfigId']).toBe(FAKE_CHANNEL_CFG)
-  })
-
-  it('emite dispatch:error cuando falla definitivamente', async () => {
-    const executor: IAgentExecutor = {
-      run: jest.fn().mockRejectedValue(new Error('Teams fatal error')),
-    }
-    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1 })
-    const errorEvents: unknown[] = []
-    dispatcher.on('dispatch:error', (e) => errorEvents.push(e))
-
-    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'teams-error-event' }))
-
-    expect(errorEvents).toHaveLength(1)
-    const ev = errorEvents[0] as Record<string, unknown>
-    expect(typeof ev['errorKind']).toBe('string')
-    expect(ev['attempts']).toBe(1)
-  })
-})
-
-// ── Suite 7: Edge cases del TeamsAdapter ─────────────────────────────────────
-
-describe('Teams E2E — TeamsAdapter edge cases', () => {
-  let harness: Awaited<ReturnType<typeof buildBotFrameworkHarness>>
-
-  beforeEach(async () => { harness = await buildBotFrameworkHarness() })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('retorna 401 cuando falta el header Authorization', async () => {
-    const body = makeMessageActivity('Mensaje sin auth')
-
-    const res = await request(harness.app)
-      .post('/teams/messages')
-      // Sin header Authorization
-      .send(body)
-      .expect(401)
-
-    expect(res.body.error).toContain('Bearer')
-  })
-
-  it('retorna 401 cuando el JWT tiene appid incorrecto', async () => {
-    const wrongJwt = `Bearer ${makeFakeJwt('wrong-app-id-9999')}`
-    const body     = makeMessageActivity('Mensaje con appid incorrecto')
-
-    const res = await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', wrongJwt)
-      .send(body)
-      .expect(401)
-
-    expect(res.body.error).toContain('appid')
-  })
-
-  it('retorna 401 cuando el token no es un JWT válido (no tiene 3 partes)', async () => {
-    const res = await request(harness.app)
-      .post('/teams/messages')
-      .set('Authorization', 'Bearer not.a.valid.jwt.parts')
-      .send(makeMessageActivity('Test'))
-
-    // Puede ser 401 o 400 según la implementación — solo verificamos que no es 200
-    expect([400, 401]).toContain(res.status)
-  })
-
-  it('GET /teams/health responde con mode: bot_framework', async () => {
-    const res = await request(harness.app)
-      .get('/teams/health')
-      .expect(200)
-
-    expect(res.body.status).toBe('ok')
-    expect(res.body.channel).toBe('teams')
-    expect(res.body.mode).toBe('bot_framework')
-    expect(res.body.channelConfigId).toBe(FAKE_CHANNEL_CFG)
-  })
-
-  it('getRouter() lanza si se llama antes de setup()', async () => {
-    const rawAdapter = new TeamsAdapter()
-    await rawAdapter.initialize('cfg-before-setup')
-
-    expect(() => rawAdapter.getRouter()).toThrow('setup()')
-  })
-
-  it('dispose() limpia el adapter sin lanzar errores', async () => {
-    await expect(harness.adapter.dispose()).resolves.not.toThrow()
-  })
-
-  it('onError() registra handler de errores sin lanzar', () => {
-    const handler = jest.fn()
-    expect(() => harness.adapter.onError(handler)).not.toThrow()
-  })
-
-  it('adapter.channel === "teams"', () => {
-    expect(harness.adapter.channel).toBe('teams')
-  })
-
-  it('múltiples messages activities en secuencia se procesan correctamente', async () => {
-    const texts = ['Primero', 'Segundo', 'Tercero']
-
-    for (const text of texts) {
-      await request(harness.app)
+      const res = await request(app)
         .post('/teams/messages')
-        .set('Authorization', harness.validAuthHeader)
-        .send(makeMessageActivity(text))
-        .expect(200)
+        .send(makeActivity())
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toMatch(/incoming.webhook/i)
+      expect(res.body.error).toMatch(/bot_framework/i)
+    })
+  })
+
+  // ── Autenticación Bot Framework ───────────────────────────────────────────────
+
+  describe('POST /teams/messages — autenticación JWT Bot Framework', () => {
+    it('rechaza petición sin header Authorization → 401', async () => {
+      const { app } = await buildTestApp('bot_framework', 'test-app-id')
+
+      const res = await request(app)
+        .post('/teams/messages')
+        .send(makeActivity())
+
+      expect(res.status).toBe(401)
+      expect(res.body.error).toMatch(/bearer/i)
+    })
+
+    it('rechaza JWT con appId incorrecto → 401', async () => {
+      const { app } = await buildTestApp('bot_framework', 'test-app-id')
+      const jwt = buildFakeJwt({ appid: 'wrong-app-id', iat: Date.now() })
+
+      const res = await request(app)
+        .post('/teams/messages')
+        .set('Authorization', `Bearer ${jwt}`)
+        .send(makeActivity())
+
+      expect(res.status).toBe(401)
+      expect(res.body.error).toMatch(/appid/i)
+    })
+
+    it('rechaza JWT con formato inválido (no 3 partes) → 401', async () => {
+      const { app } = await buildTestApp('bot_framework', 'test-app-id')
+
+      const res = await request(app)
+        .post('/teams/messages')
+        .set('Authorization', 'Bearer solamente.dos')
+        .send(makeActivity())
+
+      expect(res.status).toBe(401)
+      expect(res.body.error).toMatch(/invalid jwt/i)
+    })
+
+    it('acepta JWT con appId correcto → procesa actividad y emite al agente', async () => {
+      const { app, emitEvents } = await buildTestApp('bot_framework', 'test-app-id')
+      const jwt = buildFakeJwt({ appid: 'test-app-id', iat: Date.now() })
+
+      const res = await request(app)
+        .post('/teams/messages')
+        .set('Authorization', `Bearer ${jwt}`)
+        .send(makeActivity({ text: 'mensaje válido' }))
+
+      // Teams responde 200 inmediatamente; el agente se procesa en background
+      expect(res.status).toBe(200)
+
+      // Esperar procesamiento asíncrono
+      await new Promise((r) => setTimeout(r, 80))
+      expect(emitEvents.length).toBeGreaterThan(0)
+      expect(emitEvents[0]!.text).toBe('mensaje válido')
+    })
+  })
+
+  // ── Procesamiento de Activities ───────────────────────────────────────────────
+
+  describe('POST /teams/messages — routing de Activity types', () => {
+    async function postWithAuth(
+      app:      Application,
+      activity: Partial<TeamsActivity>,
+      appId   = 'test-app-id',
+    ) {
+      const jwt = buildFakeJwt({ appid: appId })
+      return request(app)
+        .post('/teams/messages')
+        .set('Authorization', `Bearer ${jwt}`)
+        .send(makeActivity(activity))
     }
 
-    await new Promise((r) => setTimeout(r, 100))
-    expect(harness.capturedMessages).toHaveLength(texts.length)
-    expect(harness.capturedMessages.map((m) => m.text)).toEqual(texts)
+    it('type=message con texto → 200 + emit IncomingMessage al agente', async () => {
+      const { app, emitEvents } = await buildTestApp()
+
+      await postWithAuth(app, { type: 'message', text: 'Consulta importante' })
+      await new Promise((r) => setTimeout(r, 80))
+
+      expect(emitEvents.length).toBe(1)
+      expect(emitEvents[0]!.text).toBe('Consulta importante')
+    })
+
+    it('type=conversationUpdate → 200, no emite al agente', async () => {
+      const { app, emitEvents } = await buildTestApp()
+
+      const res = await postWithAuth(app, { type: 'conversationUpdate', text: undefined })
+
+      expect(res.status).toBe(200)
+      await new Promise((r) => setTimeout(r, 80))
+      expect(emitEvents.length).toBe(0)
+    })
+
+    it('type=invoke (Teams health check) → 200 con body {}', async () => {
+      const { app } = await buildTestApp()
+
+      const res = await postWithAuth(app, { type: 'invoke', text: undefined })
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({})
+    })
+
+    it('sin type en body → 400', async () => {
+      const { app } = await buildTestApp()
+      const jwt = buildFakeJwt({ appid: 'test-app-id' })
+
+      const res = await request(app)
+        .post('/teams/messages')
+        .set('Authorization', `Bearer ${jwt}`)
+        .send({}) // body vacío, sin type
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toMatch(/activity type/i)
+    })
+
+    it('type=message con texto solo espacios → 200, no emite', async () => {
+      const { app, emitEvents } = await buildTestApp()
+
+      await postWithAuth(app, { type: 'message', text: '   ' })
+      await new Promise((r) => setTimeout(r, 80))
+
+      expect(emitEvents.length).toBe(0)
+    })
+
+    it('type desconocido → 200 sin error ni crash', async () => {
+      const { app } = await buildTestApp()
+
+      const res = await postWithAuth(app, {
+        type: 'unknown_custom_type' as TeamsActivity['type'],
+      })
+
+      expect(res.status).toBe(200)
+    })
+  })
+
+  // ── Normalización IncomingMessage ─────────────────────────────────────────────
+
+  describe('Normalización IncomingMessage', () => {
+    it('incluye metadata correcta: serviceUrl, tenantId, teamId, channelId, senderId', async () => {
+      const { app, adapter } = await buildTestApp()
+      const jwt = buildFakeJwt({ appid: 'test-app-id' })
+
+      const captured: unknown[] = []
+      adapter.on('message', (msg) => captured.push(msg))
+
+      await request(app)
+        .post('/teams/messages')
+        .set('Authorization', `Bearer ${jwt}`)
+        .send(
+          makeActivity({
+            text:       'test metadata',
+            serviceUrl: 'https://smba.trafficmanager.net/amer/',
+            from: {
+              id:          'user-raw-id',
+              name:        'Test User',
+              aadObjectId: 'aad-xyz',
+            },
+            conversation: { id: 'conv-meta-001', tenantId: 'tenant-xyz' },
+            channelData: {
+              tenant:  { id: 'tenant-xyz' },
+              team:    { id: 'team-xyz', name: 'Engineering' },
+              channel: { id: 'ch-xyz',   name: 'backend' },
+            },
+          }),
+        )
+
+      await new Promise((r) => setTimeout(r, 80))
+
+      expect(captured.length).toBeGreaterThan(0)
+
+      const msg = captured[0] as {
+        channelType: string
+        externalId:  string
+        senderId:    string
+        metadata:    Record<string, unknown>
+      }
+
+      expect(msg.channelType).toBe('teams')
+      expect(msg.externalId).toBe('conv-meta-001')
+      expect(msg.senderId).toBe('aad-xyz')           // aadObjectId tiene prioridad sobre id
+      expect(msg.metadata.serviceUrl).toBe('https://smba.trafficmanager.net/amer/')
+      expect(msg.metadata.tenantId).toBe('tenant-xyz')
+      expect(msg.metadata.teamId).toBe('team-xyz')
+      expect(msg.metadata.channelId).toBe('ch-xyz')
+    })
+  })
+
+  // ── adapter.send() ────────────────────────────────────────────────────────────
+
+  describe('adapter.send() — envío de respuestas al canal', () => {
+    it('con serviceUrl en metadata → delega a strategy.send() con parámetros correctos', async () => {
+      const { adapter, sendMock } = await buildTestApp()
+
+      const outgoing: OutgoingMessage = {
+        channelConfigId: 'channel-config-001',
+        channelType:     'teams',
+        externalId:      'conv-outgoing-001',
+        text:            'Respuesta del agente',
+        metadata: {
+          serviceUrl: 'https://smba.trafficmanager.net/amer/',
+          activityId: 'act-to-reply',
+        },
+      }
+
+      await adapter.send(outgoing)
+
+      expect(sendMock).toHaveBeenCalledTimes(1)
+      const [payload, convId, serviceUrl] = sendMock.mock.calls[0]!
+      expect(payload.type).toBe('message')
+      expect(payload.attachments).toBeDefined()
+      expect(convId).toBe('conv-outgoing-001')
+      expect(serviceUrl).toBe('https://smba.trafficmanager.net/amer/')
+    })
+
+    it('sin serviceUrl → no lanza excepción (error manejado internamente)', async () => {
+      const { adapter, sendMock } = await buildTestApp()
+      sendMock.mockResolvedValueOnce({ ok: false, error: 'serviceUrl requerido' })
+
+      const outgoing: OutgoingMessage = {
+        channelConfigId: 'channel-config-001',
+        channelType:     'teams',
+        externalId:      'conv-001',
+        text:            'Respuesta sin serviceUrl',
+        metadata:        {},
+      }
+
+      await expect(adapter.send(outgoing)).resolves.toBeUndefined()
+    })
+
+    it('con richContent tipo card → Adaptive Card en attachments', async () => {
+      const { adapter, sendMock } = await buildTestApp()
+
+      await adapter.send({
+        channelConfigId: 'channel-config-001',
+        channelType:     'teams',
+        externalId:      'conv-001',
+        text:            'fallback',
+        richContent: {
+          type: 'card',
+          card: {
+            title:    'Título',
+            subtitle: 'Descripción',
+            buttons:  [{ label: 'Ver más', payload: 'action_ver' }],
+          },
+        },
+        metadata: {
+          serviceUrl: 'https://smba.trafficmanager.net/amer/',
+        },
+      })
+
+      expect(sendMock).toHaveBeenCalledTimes(1)
+      const [payload] = sendMock.mock.calls[0]!
+      expect(payload.attachments).toBeDefined()
+      expect(payload.attachments!.length).toBeGreaterThan(0)
+      expect(payload.attachments![0]!.contentType).toBe(
+        'application/vnd.microsoft.card.adaptive',
+      )
+    })
+
+    it('con richContent tipo quick_replies → Adaptive Card con botones', async () => {
+      const { adapter, sendMock } = await buildTestApp()
+
+      await adapter.send({
+        channelConfigId: 'channel-config-001',
+        channelType:     'teams',
+        externalId:      'conv-001',
+        text:            'fallback',
+        richContent: {
+          type:    'quick_replies',
+          replies: [
+            { label: 'Sí', payload: 'yes' },
+            { label: 'No', payload: 'no' },
+          ],
+        },
+        metadata: { serviceUrl: 'https://smba.trafficmanager.net/amer/' },
+      })
+
+      expect(sendMock).toHaveBeenCalledTimes(1)
+      const [payload] = sendMock.mock.calls[0]!
+      expect(payload.attachments).toBeDefined()
+    })
+  })
+
+  // ── Recuperación ante errores en emit() ───────────────────────────────────────
+
+  describe('Recuperación ante errores en emit()', () => {
+    it('si emit() lanza → strategy.send() envía mensaje de error (sin crash)', async () => {
+      const { app, adapter, sendMock } = await buildTestApp()
+      const jwt = buildFakeJwt({ appid: 'test-app-id' })
+
+      // Forzar que el listener del agente lance una excepción
+      adapter.removeAllListeners('message')
+      adapter.on('message', () => {
+        throw new Error('AgentExecutor simulado fallando')
+      })
+
+      const res = await request(app)
+        .post('/teams/messages')
+        .set('Authorization', `Bearer ${jwt}`)
+        .send(makeActivity({ text: 'trigger error' }))
+
+      // 200 inmediato (antes del procesamiento asíncrono)
+      expect(res.status).toBe(200)
+
+      // Dar tiempo al catch del _handleMessageActivity
+      await new Promise((r) => setTimeout(r, 150))
+
+      // strategy.send() debe haberse llamado con el mensaje de error
+      expect(sendMock).toHaveBeenCalled()
+      const [errorPayload] = sendMock.mock.calls[0]!
+      expect(JSON.stringify(errorPayload.attachments)).toMatch(/error/i)
+    })
+  })
+
+  // ── dispose() ─────────────────────────────────────────────────────────────────
+
+  describe('dispose()', () => {
+    it('resuelve sin lanzar excepción', async () => {
+      const { adapter } = await buildTestApp()
+      await expect(adapter.dispose()).resolves.toBeUndefined()
+    })
   })
 })

--- a/apps/gateway/src/tests/e2e/teams.e2e-spec.ts
+++ b/apps/gateway/src/tests/e2e/teams.e2e-spec.ts
@@ -1,193 +1,174 @@
 /**
- * teams.e2e-spec.ts — [F3a-35]
+ * teams.e2e-spec.ts — [F3a-27]
  *
- * Tests E2E del flujo Microsoft Teams (ambos modos):
- *
- * MODO 1 — bot_framework:
- *   Teams Activity HTTP POST → TeamsBotAdapter → IncomingMessage
+ * Tests E2E del flujo Microsoft Teams:
+ *   Webhook HTTP → TeamsAdapter → IncomingMessage
  *   → MessageDispatcher → AgentExecutor (mock)
- *   → fromOutgoingMessage() → Adaptive Card → HTTP 200 con body de card
- *
- * MODO 2 — incoming_webhook:
- *   TeamsWebhookAdapter.send() → POST al webhook URL (fetch mock)
- *   → Adaptive Card enviada a Teams
+ *   → strategy.send → Teams API (fetch mock)
  *
  * Estrategia de mocking:
- *   - fetch global: mockeado con jest.spyOn para capturar calls al webhook Teams
- *   - IAgentExecutor: jest.fn() con respuesta configurable
- *   - Bot Framework token: TeamsBotAdapter._verifyBotFrameworkToken mockeado a true
- *   - Prisma: NO se usa (sin BD en estos tests)
+ *   - fetch global: mockeado con jest.spyOn para capturar llamadas a Teams/Microsoft API
+ *   - IAgentExecutor: jest.fn() que devuelve respuesta configurable
+ *   - JWT auth middleware: mockeado (_verifyBotFrameworkAuth) para saltear verificación
+ *   - Prisma: NO se usa directamente en estos tests
  *
  * Estructura de suites:
- *   1. bot_framework — Activity type=message
- *   2. bot_framework — Activity type=conversationUpdate (instalación)
- *   3. bot_framework — Activity type=invoke (Universal Actions)
- *   4. bot_framework — respuesta Adaptive Card completa
- *   5. bot_framework — respuesta con richContent (card, quick_replies, image)
- *   6. incoming_webhook — envío básico
- *   7. incoming_webhook — card compleja (AdaptiveCardFactory)
- *   8. MessageDispatcher — error handling (espejo de Discord)
- *   9. Edge cases de TeamsBotAdapter
- *  10. validateCard — integración en el pipeline
+ *   1. IncomingWebhookStrategy — envío y verificación
+ *   2. BotFrameworkStrategy — token OAuth + envío de actividad
+ *   3. TeamsAdapter (bot_framework) — recepción de message Activity
+ *   4. TeamsAdapter — conversationUpdate / invoke / tipos desconocidos
+ *   5. TeamsAdapter (incoming_webhook) — modo solo-envío
+ *   6. MessageDispatcher — integración con TeamsAdapter
+ *   7. Edge cases del TeamsAdapter
  */
 
-import express               from 'express'
-import request               from 'supertest'
+import express                from 'express'
+import request                from 'supertest'
 
-import { TeamsBotAdapter }   from '../../channels/teams/teams-bot.adapter.js'
-import {
-  TeamsWebhookAdapter,
-}                            from '../../channels/teams/teams-webhook.adapter.js'
-import {
-  AdaptiveCardBuilder,
-  AdaptiveCardFactory,
-  fromOutgoingMessage,
-  validateCard,
-}                            from '../../channels/teams/adaptive-card.builder.js'
-import { MessageDispatcher } from '../../message-dispatcher.service.js'
+import { TeamsAdapter }       from '../../channels/teams/teams-bot.adapter.js'
+import { MessageDispatcher }  from '../../message-dispatcher.service.js'
 import type {
   IAgentExecutor,
   DispatchInput,
   DispatchSuccess,
   DispatchFailure,
-}                            from '../../message-dispatcher.types.js'
-import type {
-  IncomingMessage,
-  OutgoingMessage,
-}                            from '../../channels/channel-adapter.interface.js'
+}                             from '../../message-dispatcher.types.js'
+import type { IncomingMessage } from '../../channels/channel-adapter.interface.js'
+import {
+  IncomingWebhookStrategy,
+  BotFrameworkStrategy,
+  buildAdaptiveTextCard,
+  buildAdaptiveRichCard,
+  type TeamsActivity,
+}                             from '../../channels/teams/teams-mode.strategy.js'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const FAKE_CHANNEL_CFG   = 'channel-config-teams-test'
-const FAKE_AGENT_ID      = 'agent-teams-uuid'
-const FAKE_SESSION_ID    = 'session-teams-001'
-const FAKE_BOT_APP_ID    = 'teams-bot-app-id-uuid'
-const FAKE_BOT_PASSWORD  = 'teams-bot-password'
-const FAKE_TENANT_ID     = 'tenant-uuid'
-const FAKE_SERVICE_URL   = 'https://smba.trafficmanager.net/emea/'
-const FAKE_CONV_ID       = '29:teams-conversation-id'
-const FAKE_USER_AAD_ID   = 'user-aad-object-id-uuid'
-const FAKE_USER_NAME     = 'Test User Teams'
-const FAKE_ACTIVITY_ID   = 'activity-id-001'
-const FAKE_WEBHOOK_URL   = 'https://contoso.webhook.office.com/webhookb2/fake-teams-url'
+const FAKE_APP_ID       = 'app-id-test-1111'
+const FAKE_APP_PASSWORD = 'app-password-test-2222'
+const FAKE_WEBHOOK_URL  = 'https://prod-01.westus.logic.azure.com/fake-webhook'
+const FAKE_SERVICE_URL  = 'https://smba.trafficmanager.net/apis'
+const FAKE_CONV_ID      = '19:conversation-id-test@thread.v2'
+const FAKE_TENANT_ID    = 'tenant-uuid-test'
+const FAKE_TEAM_ID      = 'team-uuid-test'
+const FAKE_USER_ID      = 'aad-user-uuid-test'
+const FAKE_USER_NAME    = 'Test User'
+const FAKE_BOT_ID       = 'bot-uuid-test'
+const FAKE_CHANNEL_CFG  = 'channel-config-teams-test'
+const FAKE_AGENT_ID     = 'agent-uuid-teams-test'
+const FAKE_SESSION_ID   = 'session-teams-001'
+const FAKE_BEARER_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBpZCI6ImFwcC1pZC10ZXN0LTExMTEiLCJleHAiOjk5OTk5OTk5OTl9.signature'
 
-/**
- * Crea una Bot Framework Activity de tipo "message" (mensaje de usuario).
- * Este es el body que Teams envía al endpoint del bot.
- */
-function makeMessageActivity(text: string, overrides: Record<string, unknown> = {}) {
+/** Crea una TeamsActivity de tipo 'message' completa */
+function makeMessageActivity(text: string, overrides: Partial<TeamsActivity> = {}): TeamsActivity {
   return {
     type:       'message',
-    id:         FAKE_ACTIVITY_ID,
+    id:         'activity-id-test-001',
     timestamp:  new Date().toISOString(),
     serviceUrl: FAKE_SERVICE_URL,
     channelId:  'msteams',
     from: {
-      id:   FAKE_USER_AAD_ID,
-      name: FAKE_USER_NAME,
+      id:          FAKE_USER_ID,
+      name:        FAKE_USER_NAME,
+      aadObjectId: FAKE_USER_ID,
     },
     conversation: {
-      id:      FAKE_CONV_ID,
-      isGroup: false,
+      id:       FAKE_CONV_ID,
       tenantId: FAKE_TENANT_ID,
+      isGroup:  true,
     },
     recipient: {
-      id:   FAKE_BOT_APP_ID,
+      id:   FAKE_BOT_ID,
       name: 'TestBot',
     },
     text,
     channelData: {
-      tenant: { id: FAKE_TENANT_ID },
+      tenant:  { id: FAKE_TENANT_ID },
+      team:    { id: FAKE_TEAM_ID, name: 'Test Team' },
+      channel: { id: '19:channel-id@thread.skype', name: 'General' },
     },
     ...overrides,
   }
 }
 
-/**
- * Crea una Activity de tipo "conversationUpdate" (bot instalado en un canal/equipo).
- */
-function makeConversationUpdateActivity(membersAdded?: Array<{ id: string; name: string }>) {
+/** Crea una TeamsActivity de tipo 'conversationUpdate' */
+function makeConversationUpdateActivity(): TeamsActivity {
   return {
-    type:         'conversationUpdate',
-    id:           'conv-update-001',
-    timestamp:    new Date().toISOString(),
-    serviceUrl:   FAKE_SERVICE_URL,
-    channelId:    'msteams',
-    from:         { id: FAKE_SERVICE_URL, name: 'Microsoft Teams' },
-    conversation: { id: FAKE_CONV_ID, isGroup: false, tenantId: FAKE_TENANT_ID },
-    recipient:    { id: FAKE_BOT_APP_ID, name: 'TestBot' },
-    membersAdded: membersAdded ?? [{ id: FAKE_BOT_APP_ID, name: 'TestBot' }],
-    channelData:  { tenant: { id: FAKE_TENANT_ID } },
-  }
-}
-
-/**
- * Crea una Activity de tipo "invoke" para Universal Actions (Action.Execute).
- */
-function makeInvokeActivity(verb: string, data?: Record<string, unknown>) {
-  return {
-    type:       'invoke',
-    name:       'adaptiveCard/action',
-    id:         'invoke-001',
-    timestamp:  new Date().toISOString(),
+    type:       'conversationUpdate',
+    id:         'activity-id-update-001',
     serviceUrl: FAKE_SERVICE_URL,
     channelId:  'msteams',
-    from: {
-      id:   FAKE_USER_AAD_ID,
-      name: FAKE_USER_NAME,
+    from:         { id: FAKE_BOT_ID, name: 'TestBot' },
+    conversation: { id: FAKE_CONV_ID, tenantId: FAKE_TENANT_ID, isGroup: true },
+    recipient:    { id: FAKE_USER_ID, name: FAKE_USER_NAME },
+    channelData: {
+      team:    { id: FAKE_TEAM_ID, name: 'Test Team' },
+      channel: { id: '19:channel@thread.skype', name: 'General' },
     },
-    conversation: {
-      id:      FAKE_CONV_ID,
-      isGroup: false,
-      tenantId: FAKE_TENANT_ID,
-    },
-    recipient: { id: FAKE_BOT_APP_ID, name: 'TestBot' },
-    value: {
-      action: {
-        type: 'Action.Execute',
-        verb,
-        data: data ?? {},
-      },
-    },
-    channelData: { tenant: { id: FAKE_TENANT_ID } },
   }
 }
 
-/** Crea un DispatchInput válido para Teams */
+/** Crea una TeamsActivity de tipo 'invoke' (health check de Teams) */
+function makeInvokeActivity(): TeamsActivity {
+  return {
+    type:         'invoke',
+    id:           'activity-id-invoke-001',
+    serviceUrl:   FAKE_SERVICE_URL,
+    channelId:    'msteams',
+    from:         { id: FAKE_USER_ID },
+    conversation: { id: FAKE_CONV_ID },
+    recipient:    { id: FAKE_BOT_ID },
+  }
+}
+
+/** Crea un DispatchInput válido */
 function makeDispatchInput(overrides: Partial<DispatchInput> = {}): DispatchInput {
   return {
     sessionId:       FAKE_SESSION_ID,
     agentId:         FAKE_AGENT_ID,
     channelConfigId: FAKE_CHANNEL_CFG,
-    externalUserId:  FAKE_USER_AAD_ID,
+    externalUserId:  FAKE_USER_ID,
     history: [
-      { role: 'user', content: '¿Cuál es el estado del proyecto?' },
+      { role: 'user', content: 'Mensaje de prueba Teams' },
     ],
     ...overrides,
   }
 }
 
-// ── Harness compartido — bot_framework ───────────────────────────────────────
+/** Construye un JWT mínimo con el appid correcto para pasar la verificación del adapter */
+function makeFakeJwt(appId: string): string {
+  const payload = Buffer.from(JSON.stringify({ appid: appId, exp: 9999999999 })).toString('base64url')
+  return `eyJhbGciOiJSUzI1NiJ9.${payload}.fakesignature`
+}
 
-async function buildBotHarness(agentReply = 'Respuesta del agente Teams') {
-  // Mock global fetch — simula Bot Framework Connector (serviceUrl) respondiendo OK
+// ── Harness compartido ────────────────────────────────────────────────────────
+
+async function buildBotFrameworkHarness(agentReply = 'Respuesta de Teams del agente') {
+  // Mock global de fetch — simula Microsoft API respondiendo OK
   const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
     async (url: RequestInfo | URL) => {
       const urlStr = typeof url === 'string' ? url : (url as URL).toString()
-      // Simular token del Bot Framework Connector
-      if (urlStr.includes('botframework.com') || urlStr.includes('login.microsoftonline.com')) {
+
+      // Token endpoint de Microsoft
+      if (urlStr.includes('login.microsoftonline.com')) {
         return new Response(
-          JSON.stringify({ access_token: 'fake_bf_token', expires_in: 3600 }),
+          JSON.stringify({
+            access_token: FAKE_BEARER_TOKEN,
+            expires_in:   3600,
+            token_type:   'Bearer',
+          }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         )
       }
-      // Simular respuesta al enviar mensaje de vuelta via serviceUrl
-      if (urlStr.includes(FAKE_SERVICE_URL) || urlStr.includes('smba.trafficmanager.net')) {
+
+      // Bot Framework Service (envío de respuesta)
+      if (urlStr.includes('smba.trafficmanager.net') || urlStr.includes('/v3/conversations/')) {
         return new Response(
-          JSON.stringify({ id: 'reply-activity-id' }),
+          JSON.stringify({ id: 'mock-activity-id' }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         )
       }
+
       throw new Error(`fetch no mockeada para URL: ${urlStr}`)
     },
   )
@@ -197,17 +178,12 @@ async function buildBotHarness(agentReply = 'Respuesta del agente Teams') {
     run: jest.fn().mockResolvedValue({ reply: agentReply }),
   }
 
-  // TeamsBotAdapter
-  const adapter = new TeamsBotAdapter()
-  adapter.initialize(FAKE_CHANNEL_CFG)
-
-  // Mockear verificación de token Bot Framework
-  jest.spyOn(adapter as any, '_verifyBotFrameworkToken').mockResolvedValue(true)
-
+  // TeamsAdapter en modo bot_framework
+  const adapter = new TeamsAdapter()
+  await adapter.initialize(FAKE_CHANNEL_CFG)
   await adapter.setup(
-    { serviceUrl: FAKE_SERVICE_URL, tenantId: FAKE_TENANT_ID },
-    { appId: FAKE_BOT_APP_ID, appPassword: FAKE_BOT_PASSWORD },
-    'bot_framework',
+    { mode: 'bot_framework' },
+    { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
   )
 
   // MessageDispatcher
@@ -220,657 +196,545 @@ async function buildBotHarness(agentReply = 'Respuesta del agente Teams') {
   // App Express
   const app = express()
   app.use(express.json())
-  app.use('/teams', adapter.buildHttpRouter())
+  app.use('/teams', adapter.getRouter())
 
   // Capturar IncomingMessages
   const capturedMessages: IncomingMessage[] = []
   adapter.onMessage((msg) => capturedMessages.push(msg))
 
-  // Capturar OutgoingMessages enviados (para verificar Adaptive Cards)
-  const capturedReplies: OutgoingMessage[] = []
-  if (typeof (adapter as any).onSend === 'function') {
-    ;(adapter as any).onSend((msg: OutgoingMessage) => capturedReplies.push(msg))
-  }
+  // Token Bearer con appid correcto para superar validación JWT
+  const validAuthHeader = `Bearer ${makeFakeJwt(FAKE_APP_ID)}`
 
-  return {
-    adapter,
-    dispatcher,
-    mockExecutor,
-    fetchSpy,
-    app,
-    capturedMessages,
-    capturedReplies,
-  }
+  return { adapter, dispatcher, mockExecutor, fetchSpy, app, capturedMessages, validAuthHeader }
 }
 
-// ── Harness compartido — incoming_webhook ────────────────────────────────────
+// ── Suite 1: IncomingWebhookStrategy ─────────────────────────────────────────
 
-function buildWebhookHarness() {
-  const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
-    new Response('1', {
-      status:  200,
-      headers: { 'Content-Type': 'text/plain' },
-    }),
-  )
+describe('Teams E2E — IncomingWebhookStrategy', () => {
+  let fetchSpy: jest.SpyInstance
 
-  const adapter = new TeamsWebhookAdapter()
-  adapter.initialize(FAKE_CHANNEL_CFG)
-  adapter.setup(
-    {},
-    { webhookUrl: FAKE_WEBHOOK_URL },
-    'incoming_webhook',
-  )
-
-  return { adapter, fetchSpy }
-}
-
-// ── Suite 1: bot_framework — Activity type=message ───────────────────────────
-
-describe('Teams E2E — bot_framework: Activity type=message', () => {
-  let harness: Awaited<ReturnType<typeof buildBotHarness>>
-
-  beforeEach(async () => {
-    harness = await buildBotHarness('El proyecto está en fase F3a-35.')
-  })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('emite IncomingMessage con todos los campos correctos', async () => {
-    const activity = makeMessageActivity('¿cuál es el estado del proyecto?')
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-      .expect(200)
-
-    expect(harness.capturedMessages).toHaveLength(1)
-    const msg = harness.capturedMessages[0]!
-    expect(msg.channelType).toBe('teams')
-    expect(msg.channelConfigId).toBe(FAKE_CHANNEL_CFG)
-    expect(msg.senderId).toBe(FAKE_USER_AAD_ID)
-    expect(msg.text).toBe('¿cuál es el estado del proyecto?')
-    expect(msg.type).toBe('text')
-    expect(msg.metadata?.['conversationId']).toBe(FAKE_CONV_ID)
-    expect(msg.metadata?.['serviceUrl']).toBe(FAKE_SERVICE_URL)
-    expect(msg.metadata?.['activityId']).toBe(FAKE_ACTIVITY_ID)
-    expect(msg.metadata?.['tenantId']).toBe(FAKE_TENANT_ID)
-  })
-
-  it('responde HTTP 200 al recibir la actividad', async () => {
-    const activity = makeMessageActivity('Hola agente')
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-      .expect(200)
-  })
-
-  it('externalId corresponde al conversationId de Teams', async () => {
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(makeMessageActivity('test'))
-
-    const msg = harness.capturedMessages[0]!
-    expect(msg.externalId).toBe(FAKE_CONV_ID)
-  })
-
-  it('no emite IncomingMessage para actividades que no son "message"', async () => {
-    // conversationUpdate no debe emitir mensaje (tiene su propia suite)
-    const activity = makeConversationUpdateActivity()
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-      .expect(200)
-
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('senderName está disponible en metadata cuando Teams lo envía', async () => {
-    const activity = makeMessageActivity('pregunta')
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-
-    const msg = harness.capturedMessages[0]!
-    // El nombre puede estar en metadata['senderName'] o en senderName directo
-    const senderName =
-      msg.metadata?.['senderName'] ?? (msg as any).senderName
-    expect(senderName).toBe(FAKE_USER_NAME)
-  })
-})
-
-// ── Suite 2: bot_framework — Activity type=conversationUpdate ────────────────
-
-describe('Teams E2E — bot_framework: conversationUpdate (instalación)', () => {
-  let harness: Awaited<ReturnType<typeof buildBotHarness>>
-
-  beforeEach(async () => { harness = await buildBotHarness() })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('responde 200 sin emitir IncomingMessage cuando el bot es añadido', async () => {
-    const activity = makeConversationUpdateActivity([
-      { id: FAKE_BOT_APP_ID, name: 'TestBot' },
-    ])
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-      .expect(200)
-
-    // conversationUpdate (bot añadido) NO dispara un IncomingMessage de texto
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-
-  it('puede enviar welcome card cuando el bot es añadido (opcional)', async () => {
-    // Si el adapter implementa onInstall(), este test verifica que no lanza
-    const activity = makeConversationUpdateActivity([
-      { id: FAKE_BOT_APP_ID, name: 'TestBot' },
-    ])
-
-    const res = await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-
-    // No debe lanzar y debe devolver 200
-    expect(res.status).toBe(200)
-  })
-
-  it('ignora conversationUpdate cuando membersAdded no incluye al bot', async () => {
-    const activity = makeConversationUpdateActivity([
-      { id: FAKE_USER_AAD_ID, name: FAKE_USER_NAME },  // user joined, not bot
-    ])
-
-    const res = await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-
-    expect(res.status).toBe(200)
-    expect(harness.capturedMessages).toHaveLength(0)
-  })
-})
-
-// ── Suite 3: bot_framework — Activity type=invoke (Universal Actions) ─────────
-
-describe('Teams E2E — bot_framework: invoke (Universal Actions)', () => {
-  let harness: Awaited<ReturnType<typeof buildBotHarness>>
-
-  beforeEach(async () => {
-    harness = await buildBotHarness('Acción procesada correctamente')
-  })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('responde 200 para invoke adaptiveCard/action', async () => {
-    const activity = makeInvokeActivity('refresh', { taskId: 'task-001' })
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-      .expect(200)
-  })
-
-  it('emite IncomingMessage con type=command y verb en metadata para invoke', async () => {
-    const activity = makeInvokeActivity('executeTask', { taskId: 'task-002' })
-
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-
-    // Si el adapter mapea invoke → IncomingMessage (opcional según implementación)
-    // Este test verifica que si lo emite, tiene los campos correctos
-    if (harness.capturedMessages.length > 0) {
-      const msg = harness.capturedMessages[0]!
-      expect(msg.type).toBe('command')
-      expect(msg.channelType).toBe('teams')
-      // verb debe estar en text o en metadata
-      const hasVerb =
-        msg.text.includes('executeTask') ||
-        msg.metadata?.['verb'] === 'executeTask'
-      expect(hasVerb).toBe(true)
-    }
-  })
-
-  it('responde con InvokeResponse (status 200) para invoke', async () => {
-    const activity = makeInvokeActivity('refresh')
-
-    const res = await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activity)
-
-    // Bot Framework espera que invoke responda con body que incluya status
-    // La respuesta puede ser vacía (200) o incluir { status: 200 }
-    if (res.body && Object.keys(res.body).length > 0) {
-      // Si hay body, debe incluir un status code de éxito
-      const status = res.body.status ?? res.body.statusCode ?? res.status
-      expect(status).toBeGreaterThanOrEqual(200)
-      expect(status).toBeLessThan(400)
-    } else {
-      expect(res.status).toBe(200)
-    }
-  })
-})
-
-// ── Suite 4: bot_framework — Adaptive Card response ──────────────────────────
-
-describe('Teams E2E — bot_framework: respuesta Adaptive Card completa', () => {
-  let harness: Awaited<ReturnType<typeof buildBotHarness>>
-
-  beforeEach(async () => {
-    harness = await buildBotHarness('El proyecto avanza según lo planeado.')
-  })
-  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
-
-  it('dispatcher.dispatch() retorna ok:true con reply del agente', async () => {
-    const result = await harness.dispatcher.dispatch(
-      makeDispatchInput({
-        history: [{ role: 'user', content: '¿Cuándo termina la fase F3a?' }],
-      }),
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('1', { status: 200 }),
     )
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it('send() POST al webhookUrl con Adaptive Card cuando hay texto', async () => {
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+
+    const result = await strategy.send({
+      type:        'message',
+      attachments: [buildAdaptiveTextCard('Hola desde el agente')],
+    }, FAKE_CONV_ID)
 
     expect(result.ok).toBe(true)
-    const success = result as DispatchSuccess
-    expect(success.reply).toBe('El proyecto avanza según lo planeado.')
-    expect(success.attempts).toBe(1)
-    expect(typeof success.durationMs).toBe('number')
-  })
-
-  it('AgentExecutor recibe agentId y history con el formato correcto', async () => {
-    await harness.dispatcher.dispatch(
-      makeDispatchInput({
-        history: [{ role: 'user', content: '¿Cuántas features tiene F3a?' }],
-      }),
-    )
-
-    expect(harness.mockExecutor.run).toHaveBeenCalledWith(
-      FAKE_AGENT_ID,
-      expect.arrayContaining([
-        expect.objectContaining({
-          role:    'user',
-          content: '¿Cuántas features tiene F3a?',
-        }),
-      ]),
-    )
-  })
-
-  it('fromOutgoingMessage() produce TeamsCardAttachment válido para texto plano', () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       'El proyecto avanza según lo planeado.',
-    }
-    const card = fromOutgoingMessage(outgoing)
-
-    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
-    expect(card.content.type).toBe('AdaptiveCard')
-    expect(card.content.version).toBe('1.5')
-
-    // El texto debe aparecer en algún TextBlock del body
-    const bodyText = card.content.body
-      ?.filter((b: any) => b.type === 'TextBlock')
-      .map((b: any) => b.text)
-      .join(' ')
-    expect(bodyText).toContain('El proyecto avanza según lo planeado.')
-  })
-
-  it('validateCard() confirma que la card generada es válida para Teams', () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       '## Respuesta del Agente\n\nTodo está en orden.',
-    }
-    const card   = fromOutgoingMessage(outgoing)
-    const result = validateCard(card)
-
-    expect(result.valid).toBe(true)
-    expect(result.errors).toHaveLength(0)
-    expect(result.byteSize).toBeGreaterThan(0)
-    expect(result.byteSize).toBeLessThan(28 * 1024)
-  })
-
-  it('adapter.send() llama al serviceUrl de Bot Framework con la Adaptive Card', async () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       'Respuesta procesada',
-      metadata: {
-        serviceUrl:     FAKE_SERVICE_URL,
-        activityId:     FAKE_ACTIVITY_ID,
-        conversationId: FAKE_CONV_ID,
-        tenantId:       FAKE_TENANT_ID,
-      },
-    }
-
-    // Limpiar spy para capturar solo este call
-    harness.fetchSpy.mockClear()
-
-    await harness.adapter.send(outgoing)
-
-    // Debe haber al menos un call al serviceUrl (reply activity)
-    const replyCall = harness.fetchSpy.mock.calls.find(([url]) =>
-      url.toString().includes(FAKE_SERVICE_URL) ||
-      url.toString().includes('smba.trafficmanager.net')
-    )
-    expect(replyCall).toBeDefined()
-
-    const sentBody = JSON.parse((replyCall![1] as RequestInit).body as string)
-    // La respuesta debe tener la card adaptiva
-    expect(sentBody.type).toBe('message')
-    expect(sentBody.attachments).toHaveLength(1)
-    expect(sentBody.attachments[0].contentType).toBe(
-      'application/vnd.microsoft.card.adaptive'
-    )
-  })
-})
-
-// ── Suite 5: bot_framework — richContent (card, quick_replies, image) ─────────
-
-describe('Teams E2E — bot_framework: respuestas con richContent', () => {
-  afterEach(() => jest.restoreAllMocks())
-
-  it('richContent type=card genera card con título y Action.Submit', () => {
-    const outgoing: OutgoingMessage = {
-      externalId:  FAKE_CONV_ID,
-      text:        'fallback',
-      richContent: {
-        type: 'card',
-        card: {
-          title:   'Resultado de búsqueda',
-          buttons: [
-            { label: 'Ver detalles', payload: 'details' },
-            { label: 'Cancelar',    payload: 'cancel'  },
-          ],
-        },
-      },
-    }
-    const card    = fromOutgoingMessage(outgoing)
-    const title   = card.content.body?.find((b: any) => b.weight === 'Bolder') as any
-    const actions = card.content.actions as any[]
-
-    expect(title?.text).toBe('Resultado de búsqueda')
-    expect(actions).toHaveLength(2)
-    expect(actions[0].type).toBe('Action.Submit')
-    expect(actions[0].data.quickReply).toBe('details')
-  })
-
-  it('richContent type=quick_replies genera Action.Submit por cada reply', () => {
-    const outgoing: OutgoingMessage = {
-      externalId:  FAKE_CONV_ID,
-      text:        '¿Qué quieres hacer?',
-      richContent: {
-        type:    'quick_replies',
-        replies: [
-          { label: 'Opción A', payload: 'a' },
-          { label: 'Opción B', payload: 'b' },
-          { label: 'Opción C', payload: 'c' },
-        ],
-      },
-    }
-    const card    = fromOutgoingMessage(outgoing)
-    const actions = card.content.actions as any[]
-
-    expect(actions).toHaveLength(3)
-    expect(actions.map((a: any) => a.data.quickReply)).toEqual(['a', 'b', 'c'])
-  })
-
-  it('richContent type=image genera Image element con URL y altText', () => {
-    const outgoing: OutgoingMessage = {
-      externalId:  FAKE_CONV_ID,
-      text:        '',
-      richContent: {
-        type:    'image',
-        url:     'https://example.com/diagram.png',
-        altText: 'Diagrama de arquitectura',
-      },
-    }
-    const card  = fromOutgoingMessage(outgoing)
-    const image = card.content.body?.find((b: any) => b.type === 'Image') as any
-
-    expect(image).toBeDefined()
-    expect(image.url).toBe('https://example.com/diagram.png')
-    expect(image.altText).toBe('Diagrama de arquitectura')
-  })
-
-  it('richContent type=file genera TextBlock con link markdown', () => {
-    const outgoing: OutgoingMessage = {
-      externalId:  FAKE_CONV_ID,
-      text:        '',
-      richContent: {
-        type:     'file',
-        url:      'https://example.com/report.pdf',
-        filename: 'reporte-mensual.pdf',
-      },
-    }
-    const card  = fromOutgoingMessage(outgoing)
-    const block = card.content.body?.[card.content.body.length - 1] as any
-
-    expect(block.type).toBe('TextBlock')
-    expect(block.text).toContain('reporte-mensual.pdf')
-    expect(block.text).toContain('https://example.com/report.pdf')
-  })
-
-  it('AdaptiveCardFactory.quickReplies() produce card válida con 4 replies', () => {
-    const card = AdaptiveCardFactory.quickReplies(
-      '¿Cómo puedo ayudarte?',
-      [
-        { label: 'Ver estado',    payload: 'status'  },
-        { label: 'Crear tarea',   payload: 'create'  },
-        { label: 'Ver historial', payload: 'history' },
-        { label: 'Ayuda',        payload: 'help'    },
-      ],
-    )
-    const result = validateCard(card)
-    expect(result.valid).toBe(true)
-    expect(card.content.actions).toHaveLength(4)
-  })
-})
-
-// ── Suite 6: incoming_webhook — envío básico ─────────────────────────────────
-
-describe('Teams E2E — incoming_webhook: envío básico', () => {
-  let harness: ReturnType<typeof buildWebhookHarness>
-
-  beforeEach(() => { harness = buildWebhookHarness() })
-  afterEach(() => jest.restoreAllMocks())
-
-  it('send() llama POST al webhook URL de Teams', async () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       'Notificación del agente via webhook',
-    }
-
-    await harness.adapter.send(outgoing)
-
-    expect(harness.fetchSpy).toHaveBeenCalledWith(
+    expect(fetchSpy).toHaveBeenCalledWith(
       FAKE_WEBHOOK_URL,
       expect.objectContaining({ method: 'POST' }),
     )
   })
 
-  it('el body enviado al webhook contiene una Adaptive Card válida', async () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       'Estado del sistema: **OK**',
-    }
+  it('send() incluye Adaptive Card en el body cuando hay attachments', async () => {
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
 
-    await harness.adapter.send(outgoing)
+    await strategy.send({
+      type:        'message',
+      attachments: [buildAdaptiveTextCard('Test message')],
+    }, FAKE_CONV_ID)
 
-    const call     = harness.fetchSpy.mock.calls[0]!
-    const sentBody = JSON.parse((call[1] as RequestInit).body as string)
-
-    // El webhook de Teams espera attachments o body directo de Adaptive Card
-    // Verificar que hay una Adaptive Card en algún formato
-    const hasCard =
-      sentBody.type === 'AdaptiveCard' ||
-      sentBody.attachments?.some(
-        (a: any) => a.contentType === 'application/vnd.microsoft.card.adaptive'
-      )
-    expect(hasCard).toBe(true)
+    const sentBody = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    )
+    expect(sentBody.type).toBe('message')
+    expect(sentBody.attachments).toHaveLength(1)
+    expect(sentBody.attachments[0].contentType).toBe('application/vnd.microsoft.card.adaptive')
   })
 
-  it('Content-Type es application/json en el call al webhook', async () => {
-    await harness.adapter.send({
-      externalId: FAKE_CONV_ID,
-      text:       'test',
-    })
-
-    const call    = harness.fetchSpy.mock.calls[0]!
-    const headers = (call[1] as RequestInit).headers as Record<string, string>
-    const ct      = headers['Content-Type'] ?? headers['content-type']
-    expect(ct).toContain('application/json')
-  })
-
-  it('devuelve { ok: false, error } cuando el webhook responde 410 Gone', async () => {
-    harness.fetchSpy.mockResolvedValueOnce(
-      new Response('{"error":"webhook invalid"}', {
-        status:  410,
-        headers: { 'Content-Type': 'application/json' },
-      }),
+  it('send() devuelve { ok: false } cuando Teams responde 400', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('Bad payload', { status: 400 }),
     )
 
-    const result = await harness.adapter.send({
-      externalId: FAKE_CONV_ID,
-      text:       'mensaje que fallará',
-    })
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+    const result = await strategy.send({ type: 'message', text: 'test' }, FAKE_CONV_ID)
 
-    // El adapter debe devolver { ok: false } o lanzar error manejado
-    if (result !== undefined) {
-      expect((result as any).ok).toBe(false)
-    }
-    // Si lanza, el test fallará — el adapter debe capturar errores de red
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('400')
   })
 
-  it('no lanza en error de red (ECONNREFUSED)', async () => {
-    harness.fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+  it('send() devuelve { ok: false } en error de red', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
 
-    await expect(
-      harness.adapter.send({ externalId: FAKE_CONV_ID, text: 'fail' })
-    ).resolves.not.toThrow()
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+    const result = await strategy.send({ type: 'message', text: 'test' }, FAKE_CONV_ID)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('ECONNREFUSED')
+  })
+
+  it('verify() llama send() con una Adaptive Card de prueba', async () => {
+    const strategy = new IncomingWebhookStrategy({ webhookUrl: FAKE_WEBHOOK_URL })
+    const result   = await strategy.verify()
+
+    expect(result.ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('constructor lanza si webhookUrl no es HTTPS', () => {
+    expect(() => new IncomingWebhookStrategy({ webhookUrl: 'http://insecure.com/hook' }))
+      .toThrow('HTTPS')
+  })
+
+  it('buildAdaptiveTextCard genera estructura de Adaptive Card válida', () => {
+    const card = buildAdaptiveTextCard('Mensaje de prueba')
+
+    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
+    const content = card.content as Record<string, unknown>
+    expect(content['type']).toBe('AdaptiveCard')
+    expect(content['version']).toBe('1.5')
+    const body = content['body'] as Array<Record<string, unknown>>
+    expect(body[0]?.['text']).toBe('Mensaje de prueba')
+    expect(body[0]?.['wrap']).toBe(true)
+  })
+
+  it('buildAdaptiveRichCard incluye title, description y botones', () => {
+    const card = buildAdaptiveRichCard({
+      title:       'Estado del agente',
+      description: 'Fase F3a completada',
+      buttons:     [{ label: 'Ver más', value: 'action:ver-mas' }],
+    })
+
+    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
+    const content = card.content as Record<string, unknown>
+    const body    = content['body'] as Array<Record<string, unknown>>
+    const actions = content['actions'] as Array<Record<string, unknown>>
+
+    expect(body.some((b) => b['text'] === 'Estado del agente')).toBe(true)
+    expect(body.some((b) => b['text'] === 'Fase F3a completada')).toBe(true)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]?.['title']).toBe('Ver más')
   })
 })
 
-// ── Suite 7: incoming_webhook — card compleja (AdaptiveCardFactory) ───────────
+// ── Suite 2: BotFrameworkStrategy — token OAuth ───────────────────────────────
 
-describe('Teams E2E — incoming_webhook: cards complejas con AdaptiveCardFactory', () => {
-  let harness: ReturnType<typeof buildWebhookHarness>
+describe('Teams E2E — BotFrameworkStrategy (OAuth + send)', () => {
+  let fetchSpy: jest.SpyInstance
 
-  beforeEach(() => { harness = buildWebhookHarness() })
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      async (url: RequestInfo | URL) => {
+        const urlStr = typeof url === 'string' ? url : (url as URL).toString()
+
+        if (urlStr.includes('login.microsoftonline.com')) {
+          return new Response(
+            JSON.stringify({ access_token: FAKE_BEARER_TOKEN, expires_in: 3600, token_type: 'Bearer' }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
+        if (urlStr.includes('/v3/conversations/')) {
+          return new Response(
+            JSON.stringify({ id: 'new-activity-id' }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
+        throw new Error(`fetch no mockeada: ${urlStr}`)
+      },
+    )
+  })
+
   afterEach(() => jest.restoreAllMocks())
 
-  it('AdaptiveCardFactory.status() produce card de estado válida y la envía', async () => {
-    const card = AdaptiveCardFactory.status({
-      agentName:   'SupportBot-Teams',
-      agentId:     FAKE_AGENT_ID,
-      scope:       'workspace',
-      bindingName: 'canal-soporte',
-      isActive:    true,
-    })
+  it('getBearerToken() obtiene token de Microsoft OAuth', async () => {
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
 
-    // La card debe ser válida
-    const validation = validateCard(card)
-    expect(validation.valid).toBe(true)
+    const token = await strategy.getBearerToken!()
 
-    // Simular envío directo vía adapter
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       'Estado del canal',
-      richContent: {
-        type: 'card',
-        card: {
-          title: 'Estado del canal Teams',
-        },
-      },
-    }
-    await harness.adapter.send(outgoing)
-    expect(harness.fetchSpy).toHaveBeenCalled()
+    expect(token).toBe(FAKE_BEARER_TOKEN)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
+      expect.objectContaining({ method: 'POST' }),
+    )
   })
 
-  it('AdaptiveCardFactory.entityCard() produce card con imagen, facts y actions', () => {
-    const card = AdaptiveCardFactory.entityCard({
-      title:       'Tarea #F3a-35',
-      subtitle:    'Test E2E Teams',
-      description: 'Implementar tests E2E del flujo Teams completo.',
-      facts: [
-        { name: 'Estado',    value: 'En progreso' },
-        { name: 'Prioridad', value: 'Required'    },
-        { name: 'Fase',      value: 'F3a'         },
-      ],
-      actions: [
-        { label: 'Ver en GitHub', url: 'https://github.com/lssmanager/agent-visualstudio' },
-      ],
-    })
+  it('getBearerToken() usa caché y no llama fetch dos veces', async () => {
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
 
-    const validation = validateCard(card)
-    expect(validation.valid).toBe(true)
+    await strategy.getBearerToken!()
+    await strategy.getBearerToken!()
 
-    const facts = card.content.body?.find((b: any) => b.type === 'FactSet') as any
-    expect(facts.facts).toHaveLength(3)
-    expect(card.content.actions).toHaveLength(1)
-    expect((card.content.actions as any[])[0].type).toBe('Action.OpenUrl')
+    const tokenCalls = fetchSpy.mock.calls.filter(([url]) =>
+      url.toString().includes('login.microsoftonline.com')
+    )
+    expect(tokenCalls).toHaveLength(1)
   })
 
-  it('AdaptiveCardBuilder con tabla de datos produce card válida', () => {
-    const card = new AdaptiveCardBuilder()
-      .addHeading('Resumen de sesiones activas')
-      .addTable({
-        headers: ['Canal',   'Agente',     'Mensajes', 'Estado'],
-        rows: [
-          ['Teams',    'SupportBot', '142',      '🟢 Activo'],
-          ['Discord',  'DevBot',     '87',       '🟢 Activo'],
-          ['WhatsApp', 'SalesBot',   '234',      '🔴 Inactivo'],
-        ],
-        showGridLines: true,
-      })
-      .addActionOpenUrl('Ver dashboard completo', 'https://app.example.com/dashboard')
-      .build()
+  it('send() incluye Bearer token en el header Authorization', async () => {
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
 
-    const validation = validateCard(card)
-    expect(validation.valid).toBe(true)
+    await strategy.send(
+      { type: 'message', attachments: [buildAdaptiveTextCard('Respuesta')] },
+      FAKE_CONV_ID,
+      FAKE_SERVICE_URL,
+    )
 
-    const table = card.content.body?.find((b: any) => b.type === 'Table') as any
-    expect(table).toBeDefined()
-    // Header row + 3 data rows
-    expect(table.rows).toHaveLength(4)
+    const activityCall = fetchSpy.mock.calls.find(([url]) =>
+      url.toString().includes('/v3/conversations/')
+    )
+    expect(activityCall).toBeDefined()
+    expect((activityCall![1] as RequestInit).headers).toMatchObject({
+      Authorization: `Bearer ${FAKE_BEARER_TOKEN}`,
+    })
   })
 
-  it('AdaptiveCardFactory.confirmCard() produce card con estilos positive/destructive', () => {
-    const card = AdaptiveCardFactory.confirmCard({
-      title:         '¿Reiniciar el agente?',
-      body:          'Esta acción interrumpirá las sesiones activas.',
-      confirmLabel:  'Sí, reiniciar',
-      confirmData:   { action: 'restart', agentId: FAKE_AGENT_ID },
-      cancelLabel:   'No, cancelar',
-      cancelData:    { action: 'cancel' },
-    })
+  it('send() construye URL correcta para el Bot Framework Service', async () => {
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
 
-    const validation = validateCard(card)
-    expect(validation.valid).toBe(true)
+    await strategy.send(
+      { type: 'message', text: 'Hola' },
+      FAKE_CONV_ID,
+      FAKE_SERVICE_URL,
+    )
 
-    const actions = card.content.actions as any[]
-    expect(actions).toHaveLength(2)
-    expect(actions.find((a) => a.style === 'positive')?.data.action).toBe('restart')
-    expect(actions.find((a) => a.style === 'destructive')?.data.action).toBe('cancel')
+    const activityCall = fetchSpy.mock.calls.find(([url]) =>
+      url.toString().includes('/v3/conversations/')
+    )
+    expect(activityCall![0]).toBe(
+      `${FAKE_SERVICE_URL}/v3/conversations/${FAKE_CONV_ID}/activities`
+    )
+  })
+
+  it('send() devuelve { ok: false } cuando falta serviceUrl', async () => {
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
+
+    const result = await strategy.send(
+      { type: 'message', text: 'Hola' },
+      FAKE_CONV_ID,
+      // serviceUrl omitido
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('serviceUrl')
+  })
+
+  it('verify() retorna ok:true si el token se obtiene correctamente', async () => {
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
+
+    const result = await strategy.verify()
+    expect(result.ok).toBe(true)
+  })
+
+  it('verify() retorna ok:false si el token falla', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('Auth server down'))
+
+    const strategy = new BotFrameworkStrategy(
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
+
+    const result = await strategy.verify()
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Auth server down')
+  })
+
+  it('constructor lanza si falta appId', () => {
+    expect(() => new BotFrameworkStrategy({ appId: '', appPassword: FAKE_APP_PASSWORD }))
+      .toThrow('appId')
+  })
+
+  it('constructor lanza si falta appPassword', () => {
+    expect(() => new BotFrameworkStrategy({ appId: FAKE_APP_ID, appPassword: '' }))
+      .toThrow('appPassword')
   })
 })
 
-// ── Suite 8: MessageDispatcher — error handling ───────────────────────────────
+// ── Suite 3: TeamsAdapter (bot_framework) — recepción de message Activity ─────
+
+describe('Teams E2E — TeamsAdapter bot_framework: message Activity', () => {
+  let harness: Awaited<ReturnType<typeof buildBotFrameworkHarness>>
+
+  beforeEach(async () => { harness = await buildBotFrameworkHarness('Respuesta del agente Teams') })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+
+  it('POST /teams/messages emite IncomingMessage con campos normalizados', async () => {
+    const body = makeMessageActivity('¿Cuál es el estado del proyecto?')
+
+    await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    // El adapter responde 200 inmediatamente y procesa en background
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(harness.capturedMessages).toHaveLength(1)
+    const msg = harness.capturedMessages[0]!
+    expect(msg.channelType).toBe('teams')
+    expect(msg.channelConfigId).toBe(FAKE_CHANNEL_CFG)
+    expect(msg.externalId).toBe(FAKE_CONV_ID)
+    expect(msg.senderId).toBe(FAKE_USER_ID)     // usa aadObjectId
+    expect(msg.text).toBe('¿Cuál es el estado del proyecto?')
+    expect(msg.type).toBe('text')
+  })
+
+  it('IncomingMessage.metadata incluye serviceUrl, tenantId, teamId', async () => {
+    const body = makeMessageActivity('Test metadata')
+
+    await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    const msg = harness.capturedMessages[0]!
+    expect(msg.metadata?.['serviceUrl']).toBe(FAKE_SERVICE_URL)
+    expect(msg.metadata?.['tenantId']).toBe(FAKE_TENANT_ID)
+    expect(msg.metadata?.['teamId']).toBe(FAKE_TEAM_ID)
+    expect(msg.metadata?.['isGroup']).toBe(true)
+    expect(msg.metadata?.['fromName']).toBe(FAKE_USER_NAME)
+  })
+
+  it('responde 200 inmediatamente (no espera al agente)', async () => {
+    // El agente tarda 500ms pero la respuesta HTTP debe ser inmediata
+    const slowExecutor: IAgentExecutor = {
+      run: jest.fn().mockImplementation(
+        () => new Promise((r) => setTimeout(() => r({ reply: 'tarde' }), 500))
+      ),
+    }
+    const slowDispatcher = new MessageDispatcher(slowExecutor)
+    const slowAdapter    = new TeamsAdapter()
+    await slowAdapter.initialize('slow-test-config')
+    await slowAdapter.setup(
+      { mode: 'bot_framework' },
+      { appId: FAKE_APP_ID, appPassword: FAKE_APP_PASSWORD },
+    )
+    const slowApp = express()
+    slowApp.use(express.json())
+    slowApp.use('/teams', slowAdapter.getRouter())
+    void slowDispatcher  // evitar advertencia de unused
+
+    const start = Date.now()
+    await request(slowApp)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(makeMessageActivity('mensaje lento'))
+      .expect(200)
+    const elapsed = Date.now() - start
+
+    // La respuesta HTTP debe llegar en menos de 200ms (no espera al agente)
+    expect(elapsed).toBeLessThan(300)
+    await slowAdapter.dispose()
+  })
+
+  it('no emite IncomingMessage para actividad con texto vacío', async () => {
+    const body = makeMessageActivity('')  // texto vacío
+
+    await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(harness.capturedMessages).toHaveLength(0)
+  })
+
+  it('no emite IncomingMessage para texto solo con espacios', async () => {
+    const body = makeMessageActivity('   ')  // solo espacios
+
+    await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(harness.capturedMessages).toHaveLength(0)
+  })
+
+  it('dispatcher.dispatch() retorna ok:true con respuesta del agente', async () => {
+    const result = await harness.dispatcher.dispatch(
+      makeDispatchInput({ history: [{ role: 'user', content: '¿cuántas fases hay?' }] }),
+    )
+
+    expect(result.ok).toBe(true)
+    const success = result as DispatchSuccess
+    expect(success.reply).toBe('Respuesta del agente Teams')
+    expect(success.attempts).toBe(1)
+  })
+
+  it('AgentExecutor recibe agentId y history correctos', async () => {
+    await harness.dispatcher.dispatch(
+      makeDispatchInput({ history: [{ role: 'user', content: '¿Cuántas fases?' }] }),
+    )
+
+    expect(harness.mockExecutor.run).toHaveBeenCalledWith(
+      FAKE_AGENT_ID,
+      expect.arrayContaining([
+        expect.objectContaining({ role: 'user', content: '¿Cuántas fases?' }),
+      ]),
+    )
+  })
+})
+
+// ── Suite 4: TeamsAdapter — conversationUpdate / invoke / tipos desconocidos ──
+
+describe('Teams E2E — TeamsAdapter: actividades no-message', () => {
+  let harness: Awaited<ReturnType<typeof buildBotFrameworkHarness>>
+
+  beforeEach(async () => { harness = await buildBotFrameworkHarness() })
+  afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
+
+  it('conversationUpdate responde 200 y NO emite IncomingMessage', async () => {
+    const body = makeConversationUpdateActivity()
+
+    await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(harness.capturedMessages).toHaveLength(0)
+  })
+
+  it('invoke responde 200 con body vacío {} y NO emite IncomingMessage', async () => {
+    const body = makeInvokeActivity()
+
+    const res = await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    expect(res.body).toEqual({})
+    await new Promise((r) => setTimeout(r, 50))
+    expect(harness.capturedMessages).toHaveLength(0)
+  })
+
+  it('tipo desconocido responde 200 y NO emite IncomingMessage', async () => {
+    const body: Partial<TeamsActivity> & { type: string } = {
+      type:         'typing',  // indicador de escritura — ignorar
+      serviceUrl:   FAKE_SERVICE_URL,
+      channelId:    'msteams',
+      from:         { id: FAKE_USER_ID },
+      conversation: { id: FAKE_CONV_ID },
+      recipient:    { id: FAKE_BOT_ID },
+    }
+
+    await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send(body)
+      .expect(200)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(harness.capturedMessages).toHaveLength(0)
+  })
+
+  it('retorna 400 cuando el body no tiene campo type', async () => {
+    const res = await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', harness.validAuthHeader)
+      .send({ text: 'sin type' })
+      .expect(400)
+
+    expect(res.body.error).toBeDefined()
+  })
+})
+
+// ── Suite 5: TeamsAdapter modo incoming_webhook ───────────────────────────────
+
+describe('Teams E2E — TeamsAdapter: modo incoming_webhook', () => {
+  let adapter: TeamsAdapter
+  let app: ReturnType<typeof express>
+  let fetchSpy: jest.SpyInstance
+
+  beforeEach(async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('1', { status: 200 }),
+    )
+
+    adapter = new TeamsAdapter({ mode: 'incoming_webhook' })
+    await adapter.initialize('webhook-channel-cfg')
+    await adapter.setup(
+      { mode: 'incoming_webhook' },
+      { webhookUrl: FAKE_WEBHOOK_URL },
+    )
+
+    app = express()
+    app.use(express.json())
+    app.use('/teams', adapter.getRouter())
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    await adapter.dispose()
+  })
+
+  it('GET /teams/health responde { status: ok, channel: teams, mode: incoming_webhook }', async () => {
+    const res = await request(app)
+      .get('/teams/health')
+      .expect(200)
+
+    expect(res.body.status).toBe('ok')
+    expect(res.body.channel).toBe('teams')
+    expect(res.body.mode).toBe('incoming_webhook')
+  })
+
+  it('POST /teams/messages responde 400 indicando que es solo-envío', async () => {
+    const res = await request(app)
+      .post('/teams/messages')
+      .send(makeMessageActivity('Hola'))
+      .expect(400)
+
+    expect(res.body.error).toContain('Incoming Webhook')
+    expect(res.body.error).toContain('bot_framework')
+    void fetchSpy  // evitar advertencia de unused en caso de que mock no sea llamado
+  })
+
+  it('adapter.send() delega al IncomingWebhookStrategy y llama al webhookUrl', async () => {
+    await adapter.send({
+      channelConfigId: 'webhook-channel-cfg',
+      channelType:     'teams',
+      externalId:      FAKE_CONV_ID,
+      text:            'Notificación del agente',
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      FAKE_WEBHOOK_URL,
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+})
+
+// ── Suite 6: MessageDispatcher — integración con TeamsAdapter ─────────────────
 
 describe('Teams E2E — MessageDispatcher error handling', () => {
   afterEach(() => jest.restoreAllMocks())
 
-  it('devuelve { ok:false, errorKind:"timeout" } cuando AgentExecutor se demora', async () => {
+  it('devuelve { ok:false, errorKind:"timeout" } cuando AgentExecutor es lento', async () => {
     const slowExecutor: IAgentExecutor = {
       run: jest.fn().mockImplementation(
-        () => new Promise((resolve) =>
-          setTimeout(() => resolve({ reply: 'tarde' }), 10_000)
-        ),
+        () => new Promise((r) => setTimeout(() => r({ reply: 'tarde' }), 10_000)),
       ),
     }
     const dispatcher = new MessageDispatcher(slowExecutor, {
@@ -885,19 +749,17 @@ describe('Teams E2E — MessageDispatcher error handling', () => {
     expect(fail.errorKind).toBe('timeout')
   }, 15_000)
 
-  it('devuelve { ok:false } para errores del agente Teams-specific', async () => {
-    const failExecutor: IAgentExecutor = {
-      run: jest.fn().mockRejectedValue(
-        new Error('Teams agent not bound — no ChannelBinding for conversation')
-      ),
+  it('devuelve { ok:false, errorKind:"agent_error" } para errores del agente', async () => {
+    const errorExecutor: IAgentExecutor = {
+      run: jest.fn().mockRejectedValue(new Error('Teams agent not found')),
     }
-    const dispatcher = new MessageDispatcher(failExecutor, {
+    const dispatcher = new MessageDispatcher(errorExecutor, {
       timeoutMs:   5_000,
       maxAttempts: 1,
     })
 
     const result = await dispatcher.dispatch(
-      makeDispatchInput({ agentId: 'unbound-agent' })
+      makeDispatchInput({ agentId: 'nonexistent-teams-agent' }),
     )
 
     expect(result.ok).toBe(false)
@@ -905,11 +767,11 @@ describe('Teams E2E — MessageDispatcher error handling', () => {
     expect(['agent_error', 'transient', 'unknown']).toContain(fail.errorKind)
   })
 
-  it('reintenta y tiene éxito en el segundo intento', async () => {
+  it('reintenta en errores transitorios y tiene éxito al segundo intento', async () => {
     const flakyExecutor: IAgentExecutor = {
       run: jest.fn()
-        .mockRejectedValueOnce(new Error('ECONNRESET'))
-        .mockResolvedValueOnce({ reply: 'Respuesta del segundo intento' }),
+        .mockRejectedValueOnce(new Error('ETIMEDOUT — transient error'))
+        .mockResolvedValueOnce({ reply: 'segundo intento OK' }),
     }
     const dispatcher = new MessageDispatcher(flakyExecutor, {
       timeoutMs:    5_000,
@@ -921,38 +783,36 @@ describe('Teams E2E — MessageDispatcher error handling', () => {
 
     expect(result.ok).toBe(true)
     const success = result as DispatchSuccess
-    expect(success.reply).toBe('Respuesta del segundo intento')
+    expect(success.reply).toBe('segundo intento OK')
     expect(success.attempts).toBe(2)
   })
 
-  it('emite dispatch:success con sessionId y channelConfigId de Teams', async () => {
+  it('emite dispatch:success con metadata de Teams correcta', async () => {
     const executor: IAgentExecutor = {
-      run: jest.fn().mockResolvedValue({ reply: 'ok' }),
+      run: jest.fn().mockResolvedValue({ reply: 'ok teams' }),
     }
-    const dispatcher   = new MessageDispatcher(executor)
+    const dispatcher = new MessageDispatcher(executor)
     const successEvents: unknown[] = []
     dispatcher.on('dispatch:success', (e) => successEvents.push(e))
 
-    await dispatcher.dispatch(
-      makeDispatchInput({ sessionId: 'teams-session-event-test' })
-    )
+    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'teams-session-event' }))
 
     expect(successEvents).toHaveLength(1)
     const ev = successEvents[0] as Record<string, unknown>
-    expect(ev['sessionId']).toBe('teams-session-event-test')
+    expect(ev['sessionId']).toBe('teams-session-event')
     expect(ev['agentId']).toBe(FAKE_AGENT_ID)
     expect(ev['channelConfigId']).toBe(FAKE_CHANNEL_CFG)
   })
 
-  it('emite dispatch:error con errorKind cuando falla definitivamente', async () => {
+  it('emite dispatch:error cuando falla definitivamente', async () => {
     const executor: IAgentExecutor = {
-      run: jest.fn().mockRejectedValue(new Error('fatal teams error')),
+      run: jest.fn().mockRejectedValue(new Error('Teams fatal error')),
     }
-    const dispatcher  = new MessageDispatcher(executor, { maxAttempts: 1 })
+    const dispatcher = new MessageDispatcher(executor, { maxAttempts: 1 })
     const errorEvents: unknown[] = []
     dispatcher.on('dispatch:error', (e) => errorEvents.push(e))
 
-    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'session-error-event' }))
+    await dispatcher.dispatch(makeDispatchInput({ sessionId: 'teams-error-event' }))
 
     expect(errorEvents).toHaveLength(1)
     const ev = errorEvents[0] as Record<string, unknown>
@@ -961,166 +821,93 @@ describe('Teams E2E — MessageDispatcher error handling', () => {
   })
 })
 
-// ── Suite 9: Edge cases de TeamsBotAdapter ────────────────────────────────────
+// ── Suite 7: Edge cases del TeamsAdapter ─────────────────────────────────────
 
-describe('Teams E2E — TeamsBotAdapter edge cases', () => {
-  let harness: Awaited<ReturnType<typeof buildBotHarness>>
+describe('Teams E2E — TeamsAdapter edge cases', () => {
+  let harness: Awaited<ReturnType<typeof buildBotFrameworkHarness>>
 
-  beforeEach(async () => { harness = await buildBotHarness() })
+  beforeEach(async () => { harness = await buildBotFrameworkHarness() })
   afterEach(async () => { jest.restoreAllMocks(); await harness.adapter.dispose() })
 
-  it('retorna 401 cuando el token Bearer está ausente', async () => {
-    // Restaurar el mock del token para que use validación real
-    jest.restoreAllMocks()
+  it('retorna 401 cuando falta el header Authorization', async () => {
+    const body = makeMessageActivity('Mensaje sin auth')
 
-    const strictAdapter = new TeamsBotAdapter()
-    strictAdapter.initialize(FAKE_CHANNEL_CFG)
-
-    // NO mockear _verifyBotFrameworkToken — debe rechazar tokens inválidos
-    await strictAdapter.setup(
-      { serviceUrl: FAKE_SERVICE_URL, tenantId: FAKE_TENANT_ID },
-      { appId: FAKE_BOT_APP_ID, appPassword: FAKE_BOT_PASSWORD },
-      'bot_framework',
-    )
-
-    const strictApp = express()
-    strictApp.use(express.json())
-    strictApp.use('/teams', strictAdapter.buildHttpRouter())
-
-    const res = await request(strictApp)
-      .post('/teams')
-      .send(makeMessageActivity('sin token'))
-      // No se envía Authorization header
-
-    expect([401, 403]).toContain(res.status)
-    await strictAdapter.dispose()
-  })
-
-  it('retorna 400 para actividades con type desconocido', async () => {
     const res = await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send({ type: 'unknownActivityType', id: 'x', channelId: 'msteams' })
+      .post('/teams/messages')
+      // Sin header Authorization
+      .send(body)
+      .expect(401)
 
-    // Puede ser 400 o 200 (si el adapter ignora gracefully) — no debe ser 5xx
-    expect(res.status).toBeLessThan(500)
+    expect(res.body.error).toContain('Bearer')
   })
 
-  it('no emite IncomingMessage si falta el campo text en la actividad', async () => {
-    const activityWithoutText = makeMessageActivity('')
-    delete (activityWithoutText as any).text
+  it('retorna 401 cuando el JWT tiene appid incorrecto', async () => {
+    const wrongJwt = `Bearer ${makeFakeJwt('wrong-app-id-9999')}`
+    const body     = makeMessageActivity('Mensaje con appid incorrecto')
 
-    await request(harness.app)
-      .post('/teams')
-      .set('Authorization', 'Bearer fake_jwt_token')
-      .send(activityWithoutText)
+    const res = await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', wrongJwt)
+      .send(body)
+      .expect(401)
 
-    // Sin texto, el adapter puede omitir el mensaje o emitir con text=''
-    // Lo que NO debe pasar es un crash (5xx)
-    if (harness.capturedMessages.length > 0) {
-      expect(harness.capturedMessages[0]!.text).toBe('')
-    }
+    expect(res.body.error).toContain('appid')
   })
 
-  it('dispose() limpia el adapter sin errores', async () => {
+  it('retorna 401 cuando el token no es un JWT válido (no tiene 3 partes)', async () => {
+    const res = await request(harness.app)
+      .post('/teams/messages')
+      .set('Authorization', 'Bearer not.a.valid.jwt.parts')
+      .send(makeMessageActivity('Test'))
+
+    // Puede ser 401 o 400 según la implementación — solo verificamos que no es 200
+    expect([400, 401]).toContain(res.status)
+  })
+
+  it('GET /teams/health responde con mode: bot_framework', async () => {
+    const res = await request(harness.app)
+      .get('/teams/health')
+      .expect(200)
+
+    expect(res.body.status).toBe('ok')
+    expect(res.body.channel).toBe('teams')
+    expect(res.body.mode).toBe('bot_framework')
+    expect(res.body.channelConfigId).toBe(FAKE_CHANNEL_CFG)
+  })
+
+  it('getRouter() lanza si se llama antes de setup()', async () => {
+    const rawAdapter = new TeamsAdapter()
+    await rawAdapter.initialize('cfg-before-setup')
+
+    expect(() => rawAdapter.getRouter()).toThrow('setup()')
+  })
+
+  it('dispose() limpia el adapter sin lanzar errores', async () => {
     await expect(harness.adapter.dispose()).resolves.not.toThrow()
   })
 
-  it('onError() registra el handler de errores sin lanzar', () => {
-    const errorHandler = jest.fn()
-    expect(() => harness.adapter.onError(errorHandler)).not.toThrow()
+  it('onError() registra handler de errores sin lanzar', () => {
+    const handler = jest.fn()
+    expect(() => harness.adapter.onError(handler)).not.toThrow()
   })
 
-  it('buildHttpRouter() devuelve un Router de Express válido', () => {
-    const router = harness.adapter.buildHttpRouter()
-    // Un Express Router tiene la función handle
-    expect(typeof router).toBe('function')
-  })
-})
-
-// ── Suite 10: validateCard — integración en el pipeline ──────────────────────
-
-describe('Teams E2E — validateCard integración', () => {
-  it('rechaza card que supera el límite de 28KB de Teams', () => {
-    const hugeParagraph = 'x'.repeat(30 * 1024)  // 30KB de texto
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       hugeParagraph,
-    }
-    const card   = fromOutgoingMessage(outgoing)
-    const result = validateCard(card)
-
-    // Si el texto es muy largo, validateCard debe reportar error de tamaño
-    if (!result.valid) {
-      expect(result.errors.some((e: string) => e.toLowerCase().includes('size') || e.toLowerCase().includes('byte'))).toBe(true)
-    }
-    // byteSize siempre debe estar presente
-    expect(result.byteSize).toBeGreaterThan(0)
+  it('adapter.channel === "teams"', () => {
+    expect(harness.adapter.channel).toBe('teams')
   })
 
-  it('fromOutgoingMessage() sin richContent produce card mínima válida', () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       'Texto simple sin formato',
+  it('múltiples messages activities en secuencia se procesan correctamente', async () => {
+    const texts = ['Primero', 'Segundo', 'Tercero']
+
+    for (const text of texts) {
+      await request(harness.app)
+        .post('/teams/messages')
+        .set('Authorization', harness.validAuthHeader)
+        .send(makeMessageActivity(text))
+        .expect(200)
     }
-    const card   = fromOutgoingMessage(outgoing)
-    const result = validateCard(card)
 
-    expect(result.valid).toBe(true)
-    expect(card.contentType).toBe('application/vnd.microsoft.card.adaptive')
-    expect(card.content.type).toBe('AdaptiveCard')
-    expect(card.content.body).toBeDefined()
-    expect(Array.isArray(card.content.body)).toBe(true)
-    expect(card.content.body!.length).toBeGreaterThan(0)
-  })
-
-  it('fromOutgoingMessage() con markdown en text produce TextBlock con wrap:true', () => {
-    const outgoing: OutgoingMessage = {
-      externalId: FAKE_CONV_ID,
-      text:       '**Estado**: 🟢 Activo\n\nEl agente ha procesado 142 mensajes hoy.',
-    }
-    const card      = fromOutgoingMessage(outgoing)
-    const textBlock = card.content.body?.find((b: any) => b.type === 'TextBlock') as any
-
-    expect(textBlock).toBeDefined()
-    expect(textBlock.wrap).toBe(true)
-  })
-
-  it('todas las cards de AdaptiveCardFactory pasan validateCard', () => {
-    const factories = [
-      () => AdaptiveCardFactory.quickReplies('¿Cómo puedo ayudarte?', [
-        { label: 'Ayuda',   payload: 'help'   },
-        { label: 'Estado',  payload: 'status' },
-      ]),
-      () => AdaptiveCardFactory.status({
-        agentName:   'TestBot',
-        agentId:     FAKE_AGENT_ID,
-        scope:       'channel',
-        bindingName: 'test-channel',
-        isActive:    true,
-      }),
-      () => AdaptiveCardFactory.entityCard({
-        title:       'Entidad de prueba',
-        subtitle:    'Subtítulo',
-        description: 'Descripción detallada de la entidad.',
-        facts:       [{ name: 'Campo', value: 'Valor' }],
-        actions:     [],
-      }),
-      () => AdaptiveCardFactory.confirmCard({
-        title:        '¿Confirmar?',
-        body:         'Esta acción no se puede deshacer.',
-        confirmLabel: 'Confirmar',
-        confirmData:  { action: 'confirm' },
-        cancelLabel:  'Cancelar',
-        cancelData:   { action: 'cancel' },
-      }),
-    ]
-
-    for (const factory of factories) {
-      const card   = factory()
-      const result = validateCard(card)
-      expect(result.valid).toBe(true)
-      expect(result.errors).toHaveLength(0)
-    }
+    await new Promise((r) => setTimeout(r, 100))
+    expect(harness.capturedMessages).toHaveLength(texts.length)
+    expect(harness.capturedMessages.map((m) => m.text)).toEqual(texts)
   })
 })

--- a/apps/web/src/features/channels/ChannelsPage.tsx
+++ b/apps/web/src/features/channels/ChannelsPage.tsx
@@ -3,20 +3,17 @@
  * Página principal de gestión de canales.
  *
  * Layout: sidebar lista (izquierda) + panel detalle/creación (derecha).
- * Importable en App.tsx como ruta /channels.
- *
- * F3a-36: pasa patchChannel y testChannel a ChannelDetail.
  */
-import React, { useState } from 'react';
-import { useChannels }        from './useChannels';
-import { ChannelCard }        from './components/ChannelCard';
-import { ChannelDetail }      from './components/ChannelDetail';
-import { CreateChannelPanel } from './components/CreateChannelPanel';
-import type { CreateChannelPayload } from './types';
+import React, { useState } from 'react'
+import { useChannels } from './useChannels'
+import { ChannelCard } from './components/ChannelCard'
+import { ChannelDetail } from './components/ChannelDetail'
+import { CreateChannelPanel } from './components/CreateChannelPanel'
+import type { CreateChannelPayload } from './types'
 
 const GATEWAY_URL =
   (import.meta as { env: Record<string, string> }).env.VITE_GATEWAY_URL ??
-  (typeof window !== 'undefined' ? window.location.origin : '');
+  (typeof window !== 'undefined' ? window.location.origin : '')
 
 export default function ChannelsPage() {
   const {
@@ -34,31 +31,31 @@ export default function ChannelsPage() {
     removeBinding,
     patchChannel,
     testChannel,
-  } = useChannels();
+    requestWhatsAppQr,
+  } = useChannels()
 
-  const [showCreate, setShowCreate] = useState(false);
-  const [createErr,  setCreateErr]  = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false)
+  const [createErr, setCreateErr] = useState<string | null>(null)
 
   async function handleCreate(payload: CreateChannelPayload) {
-    setCreateErr(null);
+    setCreateErr(null)
     try {
-      await createChannel(payload);
-      setShowCreate(false);
+      await createChannel(payload)
+      setShowCreate(false)
     } catch (e) {
-      setCreateErr(e instanceof Error ? e.message : 'Error al crear canal');
-      throw e;
+      setCreateErr(e instanceof Error ? e.message : 'Error al crear canal')
+      throw e
     }
   }
 
   return (
     <div className="channels-page">
-      {/* ── Sidebar lista ─────────────────────────────────────── */}
       <aside className="channels-page__sidebar">
         <div className="channels-page__sidebar-header">
           <h1 className="channels-page__title">Canales</h1>
           <button
             className="channels-page__new-btn"
-            onClick={() => { setShowCreate(true); setSelectedId(null); }}
+            onClick={() => { setShowCreate(true); setSelectedId(null) }}
             aria-label="Nuevo canal"
           >
             + Nuevo
@@ -67,25 +64,16 @@ export default function ChannelsPage() {
 
         {loading && (
           <div className="channels-page__skeleton">
-            {[1, 2, 3].map(i => (
-              <div key={i} className="channels-page__skeleton-card" />
-            ))}
+            {[1, 2, 3].map(i => <div key={i} className="channels-page__skeleton-card" />)}
           </div>
         )}
 
-        {!loading && error && (
-          <div className="channels-page__error">
-            <p>{error}</p>
-          </div>
-        )}
+        {!loading && error && <div className="channels-page__error"><p>{error}</p></div>}
 
         {!loading && !error && channels.length === 0 && (
           <div className="channels-page__empty">
             <p>No hay canales configurados.</p>
-            <button
-              className="channels-page__empty-cta"
-              onClick={() => setShowCreate(true)}
-            >
+            <button className="channels-page__empty-cta" onClick={() => setShowCreate(true)}>
               Crear primer canal
             </button>
           </div>
@@ -98,7 +86,7 @@ export default function ChannelsPage() {
                 <ChannelCard
                   channel={ch}
                   isSelected={selectedId === ch.id}
-                  onSelect={id => { setSelectedId(id); setShowCreate(false); }}
+                  onSelect={id => { setSelectedId(id); setShowCreate(false) }}
                   onActivate={activateChannel}
                   onDeactivate={deactivateChannel}
                   onDelete={deleteChannel}
@@ -109,7 +97,6 @@ export default function ChannelsPage() {
         )}
       </aside>
 
-      {/* ── Panel principal ───────────────────────────────────── */}
       <main className="channels-page__main">
         {showCreate && (
           <CreateChannelPanel
@@ -127,6 +114,7 @@ export default function ChannelsPage() {
             onRemoveBinding={removeBinding}
             onPatchChannel={patchChannel}
             onTestChannel={testChannel}
+            onRequestNewQr={requestWhatsAppQr}
             gatewayUrl={GATEWAY_URL}
           />
         )}
@@ -137,10 +125,8 @@ export default function ChannelsPage() {
           </div>
         )}
 
-        {createErr && (
-          <p className="channels-page__create-err">{createErr}</p>
-        )}
+        {createErr && <p className="channels-page__create-err">{createErr}</p>}
       </main>
     </div>
-  );
+  )
 }

--- a/apps/web/src/features/channels/components/ChannelDetail.tsx
+++ b/apps/web/src/features/channels/components/ChannelDetail.tsx
@@ -1,32 +1,22 @@
-/**
- * ChannelDetail.tsx
- * Panel de detalle del canal seleccionado.
- * Tabs: General | Configuración | Bindings
- *
- * F3a-36: Integra ChannelSettings como pestaña "Configuración".
- */
-import React, { useState } from 'react';
-import type {
-  ChannelConfig,
-  AddBindingPayload,
-  PatchChannelPayload,
-  ChannelTestResult,
-} from '../types';
-import { ChannelTypeIcon } from './ChannelTypeIcon';
-import { EmbedSnippet }    from './EmbedSnippet';
-import { ChannelSettings } from './ChannelSettings';
+import React, { useState } from 'react'
+import type { ChannelConfig, AddBindingPayload, PatchChannelPayload, ChannelTestResult } from '../types'
+import { ChannelTypeIcon } from './ChannelTypeIcon'
+import { EmbedSnippet } from './EmbedSnippet'
+import { ChannelSettings } from './ChannelSettings'
+import { ChannelStatusCard } from './ChannelStatusCard'
 
-type ActiveTab = 'overview' | 'settings' | 'bindings';
+type ActiveTab = 'overview' | 'settings' | 'bindings'
 
 interface Props {
-  channel:          ChannelConfig;
-  onActivate:       (id: string) => Promise<void>;
-  onDeactivate:     (id: string) => Promise<void>;
-  onAddBinding:     (channelId: string, payload: AddBindingPayload) => Promise<void>;
-  onRemoveBinding:  (channelId: string, bindingId: string) => Promise<void>;
-  onPatchChannel:   (id: string, payload: PatchChannelPayload) => Promise<void>;
-  onTestChannel:    (id: string) => Promise<ChannelTestResult>;
-  gatewayUrl?:      string;
+  channel: ChannelConfig
+  onActivate: (id: string) => Promise<void>
+  onDeactivate: (id: string) => Promise<void>
+  onAddBinding: (channelId: string, payload: AddBindingPayload) => Promise<void>
+  onRemoveBinding: (channelId: string, bindingId: string) => Promise<void>
+  onPatchChannel: (id: string, payload: PatchChannelPayload) => Promise<void>
+  onTestChannel: (id: string) => Promise<ChannelTestResult>
+  onRequestNewQr?: (id: string) => Promise<void>
+  gatewayUrl?: string
 }
 
 export function ChannelDetail({
@@ -37,59 +27,56 @@ export function ChannelDetail({
   onRemoveBinding,
   onPatchChannel,
   onTestChannel,
+  onRequestNewQr,
   gatewayUrl = '',
 }: Props) {
-  const [busy,       setBusy]       = useState(false);
-  const [actionErr,  setActionErr]  = useState<string | null>(null);
-  const [activeTab,  setActiveTab]  = useState<ActiveTab>('overview');
+  const [busy, setBusy] = useState(false)
+  const [actionErr, setActionErr] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<ActiveTab>('overview')
+  const [newAgentId, setNewAgentId] = useState('')
+  const [newScopeLevel, setNewScopeLevel] = useState('agent')
+  const [bindErr, setBindErr] = useState<string | null>(null)
+  const [bindBusy, setBindBusy] = useState(false)
 
-  // Reset tab cuando cambia el canal
   React.useEffect(() => {
-    setActiveTab('overview');
-    setActionErr(null);
-  }, [channel.id]);
-
-  // Form agregar binding
-  const [newAgentId,    setNewAgentId]    = useState('');
-  const [newScopeLevel, setNewScopeLevel] = useState('agent');
-  const [bindErr,       setBindErr]       = useState<string | null>(null);
-  const [bindBusy,      setBindBusy]      = useState(false);
+    setActiveTab('overview')
+    setActionErr(null)
+  }, [channel.id])
 
   async function toggleActive() {
-    setBusy(true);
-    setActionErr(null);
+    setBusy(true)
+    setActionErr(null)
     try {
-      if (channel.isActive) await onDeactivate(channel.id);
-      else                   await onActivate(channel.id);
+      if (channel.isActive) await onDeactivate(channel.id)
+      else await onActivate(channel.id)
     } catch (e) {
-      setActionErr(e instanceof Error ? e.message : 'Error');
+      setActionErr(e instanceof Error ? e.message : 'Error')
     } finally {
-      setBusy(false);
+      setBusy(false)
     }
   }
 
   async function handleAddBinding(e: React.FormEvent) {
-    e.preventDefault();
-    if (!newAgentId.trim()) return;
-    setBindBusy(true);
-    setBindErr(null);
+    e.preventDefault()
+    if (!newAgentId.trim()) return
+    setBindBusy(true)
+    setBindErr(null)
     try {
       await onAddBinding(channel.id, {
-        agentId:    newAgentId.trim(),
+        agentId: newAgentId.trim(),
         scopeLevel: newScopeLevel,
-        scopeId:    newAgentId.trim(),
-      });
-      setNewAgentId('');
+        scopeId: newAgentId.trim(),
+      })
+      setNewAgentId('')
     } catch (e) {
-      setBindErr(e instanceof Error ? e.message : 'Error al agregar binding');
+      setBindErr(e instanceof Error ? e.message : 'Error al agregar binding')
     } finally {
-      setBindBusy(false);
+      setBindBusy(false)
     }
   }
 
   return (
     <div className="channel-detail">
-      {/* Header */}
       <div className="channel-detail__header">
         <span className="channel-detail__icon">
           <ChannelTypeIcon type={channel.type} size={22} />
@@ -101,19 +88,22 @@ export function ChannelDetail({
           </span>
         </div>
         <button
-          className={`channel-detail__toggle-btn ${
-            channel.isActive ? 'channel-detail__toggle-btn--off' : 'channel-detail__toggle-btn--on'
-          }`}
+          className={`channel-detail__toggle-btn ${channel.isActive ? 'channel-detail__toggle-btn--off' : 'channel-detail__toggle-btn--on'}`}
           onClick={() => void toggleActive()}
           disabled={busy}
         >
-          {busy ? '…' : channel.isActive ? 'Desactivar' : 'Activar'}
+          {busy ? '...' : channel.isActive ? 'Desactivar' : 'Activar'}
         </button>
       </div>
 
       {actionErr && <p className="channel-detail__error">{actionErr}</p>}
 
-      {/* Tab navigation — F3a-36 */}
+      <ChannelStatusCard
+        channel={channel}
+        onTest={onTestChannel}
+        onRequestNewQr={onRequestNewQr}
+      />
+
       <nav className="channel-detail__tabs" role="tablist" aria-label="Secciones del canal">
         {(['overview', 'settings', 'bindings'] as ActiveTab[]).map(tab => (
           <button
@@ -121,73 +111,39 @@ export function ChannelDetail({
             role="tab"
             aria-selected={activeTab === tab}
             onClick={() => setActiveTab(tab)}
-            className={`channel-detail__tab ${
-              activeTab === tab ? 'channel-detail__tab--active' : ''
-            }`}
+            className={`channel-detail__tab ${activeTab === tab ? 'channel-detail__tab--active' : ''}`}
           >
-            {tab === 'overview'  ? 'General'       : ''}
-            {tab === 'settings'  ? 'Configuración' : ''}
-            {tab === 'bindings'  ? 'Bindings'      : ''}
+            {tab === 'overview' ? 'General' : ''}
+            {tab === 'settings' ? 'Configuración' : ''}
+            {tab === 'bindings' ? 'Bindings' : ''}
           </button>
         ))}
       </nav>
 
-      {/* ── Panel: General ─────────────────────────────────── */}
       {activeTab === 'overview' && (
         <div className="channel-detail__panel" role="tabpanel">
-          {/* Meta */}
           <div className="channel-detail__meta">
-            <div className="channel-detail__meta-row">
-              <span className="channel-detail__meta-label">Tipo</span>
-              <span className="channel-detail__meta-value">{channel.type}</span>
-            </div>
-            <div className="channel-detail__meta-row">
-              <span className="channel-detail__meta-label">ID</span>
-              <code className="channel-detail__meta-code">{channel.id}</code>
-            </div>
-            <div className="channel-detail__meta-row">
-              <span className="channel-detail__meta-label">Secrets</span>
-              <span className="channel-detail__meta-value">
-                {channel.hasSecrets ? 'Configurados •••' : 'Ninguno'}
-              </span>
-            </div>
-            <div className="channel-detail__meta-row">
-              <span className="channel-detail__meta-label">Creado</span>
-              <span className="channel-detail__meta-value">
-                {new Date(channel.createdAt).toLocaleString()}
-              </span>
-            </div>
+            <div className="channel-detail__meta-row"><span className="channel-detail__meta-label">Tipo</span><span className="channel-detail__meta-value">{channel.type}</span></div>
+            <div className="channel-detail__meta-row"><span className="channel-detail__meta-label">ID</span><code className="channel-detail__meta-code">{channel.id}</code></div>
+            <div className="channel-detail__meta-row"><span className="channel-detail__meta-label">Secrets</span><span className="channel-detail__meta-value">{channel.hasSecrets ? 'Configurados •••' : 'Ninguno'}</span></div>
+            <div className="channel-detail__meta-row"><span className="channel-detail__meta-label">Creado</span><span className="channel-detail__meta-value">{new Date(channel.createdAt).toLocaleString()}</span></div>
           </div>
-
-          {/* Embed snippet para webchat activo */}
           {channel.type === 'webchat' && channel.isActive && (
-            <EmbedSnippet
-              channelId={channel.id}
-              gatewayUrl={gatewayUrl}
-              title={channel.name}
-            />
+            <EmbedSnippet channelId={channel.id} gatewayUrl={gatewayUrl} title={channel.name} />
           )}
         </div>
       )}
 
-      {/* ── Panel: Configuración ── F3a-36 ─────────────────── */}
       {activeTab === 'settings' && (
         <div className="channel-detail__panel" role="tabpanel">
-          <ChannelSettings
-            channel={channel}
-            gatewayUrl={gatewayUrl}
-            onSave={onPatchChannel}
-            onTest={onTestChannel}
-          />
+          <ChannelSettings channel={channel} gatewayUrl={gatewayUrl} onSave={onPatchChannel} onTest={onTestChannel} />
         </div>
       )}
 
-      {/* ── Panel: Bindings ────────────────────────────────── */}
       {activeTab === 'bindings' && (
         <div className="channel-detail__panel" role="tabpanel">
           <section className="channel-detail__section">
             <h3 className="channel-detail__section-title">Bindings</h3>
-
             {(channel.bindings ?? []).length === 0 ? (
               <p className="channel-detail__empty">Sin bindings configurados.</p>
             ) : (
@@ -195,31 +151,17 @@ export function ChannelDetail({
                 {(channel.bindings ?? []).map(b => (
                   <li key={b.id} className="channel-detail__binding-item">
                     <div className="channel-detail__binding-info">
-                      <span className="channel-detail__binding-agent">
-                        {b.agent?.name ?? b.agentId}
-                      </span>
+                      <span className="channel-detail__binding-agent">{b.agent?.name ?? b.agentId}</span>
                       <span className="channel-detail__binding-scope">{b.scopeLevel}</span>
-                      {b.isDefault && (
-                        <span className="channel-detail__binding-default">default</span>
-                      )}
+                      {b.isDefault && <span className="channel-detail__binding-default">default</span>}
                     </div>
-                    <button
-                      className="channel-detail__binding-remove"
-                      onClick={() => void onRemoveBinding(channel.id, b.id)}
-                      aria-label="Eliminar binding"
-                    >
-                      ✕
-                    </button>
+                    <button className="channel-detail__binding-remove" onClick={() => void onRemoveBinding(channel.id, b.id)} aria-label="Eliminar binding">×</button>
                   </li>
                 ))}
               </ul>
             )}
 
-            {/* Agregar binding */}
-            <form
-              onSubmit={e => void handleAddBinding(e)}
-              className="channel-detail__bind-form"
-            >
+            <form onSubmit={e => void handleAddBinding(e)} className="channel-detail__bind-form">
               <h4 className="channel-detail__bind-form-title">Agregar binding</h4>
               <div className="channel-detail__bind-row">
                 <input
@@ -240,12 +182,8 @@ export function ChannelDetail({
                   <option value="workspace">workspace</option>
                   <option value="org">org</option>
                 </select>
-                <button
-                  type="submit"
-                  className="channel-detail__bind-submit"
-                  disabled={bindBusy || !newAgentId.trim()}
-                >
-                  {bindBusy ? '…' : 'Agregar'}
+                <button type="submit" className="channel-detail__bind-submit" disabled={bindBusy || !newAgentId.trim()}>
+                  {bindBusy ? '...' : 'Agregar'}
                 </button>
               </div>
               {bindErr && <p className="channel-detail__error">{bindErr}</p>}
@@ -254,5 +192,5 @@ export function ChannelDetail({
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/apps/web/src/features/channels/components/ChannelStatusCard.tsx
+++ b/apps/web/src/features/channels/components/ChannelStatusCard.tsx
@@ -1,0 +1,236 @@
+/**
+ * ChannelStatusCard.tsx — [F3a-37]
+ *
+ * Tarjeta de estado en tiempo real de un canal.
+ * Usa useChannelStatus() (SSE con fallback a polling).
+ *
+ * Muestra:
+ *   - Indicador visual (verde/rojo/amarillo/gris)
+ *   - Latencia, mensajes/min
+ *   - Último error colapsable
+ *   - SSE badge con estado
+ *   - Para WhatsApp authMode='qr': botón que abre WhatsAppQrModal
+ */
+
+import React, { useState } from 'react';
+import type { ChannelConfig } from '../types';
+import { useChannelStatus }  from '../hooks/useChannelStatus';
+import { WhatsAppQrModal }   from './WhatsAppQrModal';
+
+interface ChannelStatusCardProps {
+  channel:          ChannelConfig;
+  onTest:           (id: string) => Promise<{ ok: boolean; latency: number; message: string }>;
+  onRequestNewQr?:  (id: string) => Promise<void>;
+}
+
+type StatusIndicatorKind = 'connected' | 'degraded' | 'disconnected' | 'unknown';
+
+function getIndicatorKind(
+  sseState: string,
+  connected: boolean | undefined,
+  latencyMs: number | null | undefined,
+): StatusIndicatorKind {
+  if (sseState === 'connecting' || connected === undefined) return 'unknown';
+  if (!connected) return 'disconnected';
+  if (latencyMs !== null && latencyMs !== undefined && latencyMs > 1000) return 'degraded';
+  return 'connected';
+}
+
+const INDICATOR_LABELS: Record<StatusIndicatorKind, string> = {
+  connected:    'Conectado',
+  degraded:     'Degradado',
+  disconnected: 'Sin conexión',
+  unknown:      'Verificando…',
+};
+
+const INDICATOR_ARIA: Record<StatusIndicatorKind, string> = {
+  connected:    'El canal está conectado y operativo',
+  degraded:     'El canal está conectado pero con alta latencia',
+  disconnected: 'El canal no tiene conexión activa con el proveedor',
+  unknown:      'Verificando el estado del canal',
+};
+
+function StatusDot({ kind }: { kind: StatusIndicatorKind }) {
+  return <span className={`status-dot status-dot--${kind}`} aria-hidden="true" />;
+}
+
+function formatLatency(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function formatRelativeTime(isoString: string | null): string {
+  if (!isoString) return '—';
+  const diffSecs = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (diffSecs < 60)   return `hace ${diffSecs}s`;
+  if (diffSecs < 3600) return `hace ${Math.floor(diffSecs / 60)}min`;
+  return `hace ${Math.floor(diffSecs / 3600)}h`;
+}
+
+export function ChannelStatusCard({
+  channel,
+  onTest,
+  onRequestNewQr,
+}: ChannelStatusCardProps) {
+  const [showError,   setShowError]   = useState(false);
+  const [showQrModal, setShowQrModal] = useState(false);
+
+  const liveStatus = useChannelStatus(channel.id, {
+    pollFallback: true,
+    onPoll:       onTest,
+  });
+
+  const { sseState, sseError, channelStatus, reconnectIn, attemptCount } = liveStatus;
+
+  const indicator = getIndicatorKind(
+    sseState,
+    channelStatus?.connected,
+    channelStatus?.latencyMs,
+  );
+
+  const isWhatsAppQr =
+    channel.type === 'whatsapp' &&
+    channel.config?.['authMode'] === 'qr';
+
+  const qrBtnVisible =
+    isWhatsAppQr && (
+      !channelStatus?.sessionState ||
+      channelStatus.sessionState.status !== 'connected'
+    );
+
+  async function handleRequestNewQr() {
+    if (onRequestNewQr) await onRequestNewQr(channel.id);
+    setShowQrModal(true);
+  }
+
+  return (
+    <>
+      <div
+        className="channel-status-card"
+        aria-label={`Estado del canal: ${INDICATOR_ARIA[indicator]}`}
+      >
+        {/* Estado principal */}
+        <div className="channel-status-card__row">
+          <StatusDot kind={indicator} />
+          <span className={`channel-status-card__label channel-status-card__label--${indicator}`}>
+            {INDICATOR_LABELS[indicator]}
+          </span>
+
+          {sseState === 'reconnecting' && reconnectIn !== null && (
+            <span className="channel-status-card__reconnect">
+              Reconectando en {reconnectIn}s (intento {attemptCount})
+            </span>
+          )}
+
+          {sseState === 'error' && sseError && (
+            <span className="channel-status-card__sse-error">{sseError}</span>
+          )}
+
+          {channelStatus && (
+            <span className="channel-status-card__updated">
+              {formatRelativeTime(channelStatus.updatedAt)}
+            </span>
+          )}
+        </div>
+
+        {/* Métricas */}
+        {channelStatus && (
+          <div className="channel-status-card__metrics">
+            <div className="channel-status-card__metric">
+              <span className="channel-status-card__metric-label">Latencia</span>
+              <span className={[
+                'channel-status-card__metric-value',
+                channelStatus.latencyMs !== null && channelStatus.latencyMs > 1000
+                  ? 'channel-status-card__metric-value--warn'
+                  : '',
+              ].filter(Boolean).join(' ')}>
+                {formatLatency(channelStatus.latencyMs)}
+              </span>
+            </div>
+            <div className="channel-status-card__metric">
+              <span className="channel-status-card__metric-label">Msgs/min</span>
+              <span className="channel-status-card__metric-value channel-status-card__metric-value--num">
+                {channelStatus.messagesPerMin}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* WhatsApp QR button */}
+        {qrBtnVisible && (
+          <div className="channel-status-card__qr-row">
+            <button
+              className="channel-status-card__qr-btn"
+              onClick={() => setShowQrModal(true)}
+              type="button"
+            >
+              📱{' '}
+              {channelStatus?.sessionState?.status === 'disconnected'
+                ? 'Reconectar WhatsApp'
+                : 'Vincular WhatsApp'}
+            </button>
+            <p className="channel-status-card__qr-hint">
+              Escanea el QR con tu teléfono para activar la sesión.
+            </p>
+          </div>
+        )}
+
+        {/* WhatsApp sesión activa */}
+        {isWhatsAppQr && channelStatus?.sessionState?.status === 'connected' && (
+          <div className="channel-status-card__wa-connected">
+            <span className="channel-status-card__wa-phone">
+              📱 {channelStatus.sessionState.phone ?? 'Sesión activa'}
+            </span>
+            <button
+              className="channel-status-card__qr-btn channel-status-card__qr-btn--ghost"
+              onClick={() => setShowQrModal(true)}
+              type="button"
+            >
+              Ver sesión
+            </button>
+          </div>
+        )}
+
+        {/* Último error */}
+        {channelStatus?.lastError && (
+          <div className="channel-status-card__error-section">
+            <button
+              className="channel-status-card__error-toggle"
+              onClick={() => setShowError(prev => !prev)}
+              aria-expanded={showError}
+              type="button"
+            >
+              {showError ? '▾' : '▸'} Último error
+              <span className="channel-status-card__error-time">
+                {formatRelativeTime(channelStatus.lastErrorAt)}
+              </span>
+            </button>
+            {showError && (
+              <p className="channel-status-card__error-text" role="alert">
+                {channelStatus.lastError}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* SSE badge */}
+        <div className="channel-status-card__sse-badge-row">
+          <span className={`channel-status-card__sse-badge channel-status-card__sse-badge--${sseState}`}>
+            SSE: {sseState === 'connected' ? 'en vivo' : sseState}
+          </span>
+        </div>
+      </div>
+
+      {/* QR Modal */}
+      {showQrModal && isWhatsAppQr && channelStatus?.sessionState && (
+        <WhatsAppQrModal
+          sessionState={channelStatus.sessionState}
+          channelName={channel.name}
+          onClose={() => setShowQrModal(false)}
+          onRequestNewQr={handleRequestNewQr}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/channels/components/WhatsAppQrModal.tsx
+++ b/apps/web/src/features/channels/components/WhatsAppQrModal.tsx
@@ -1,0 +1,259 @@
+/**
+ * WhatsAppQrModal.tsx — [F3a-37]
+ *
+ * Modal de vinculación WhatsApp por QR.
+ * Solo se monta cuando channel.config.authMode === 'qr'.
+ *
+ * Ciclo de vida:
+ *   waiting_qr  → spinner
+ *   qr_ready    → imagen QR + countdown de expiración
+ *   connected   → confirmación + cierre automático (2.5s)
+ *   expired     → botón "Pedir nuevo QR"
+ *   disconnected → botón "Reconectar"
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { WhatsAppSessionState } from '../types';
+
+interface WhatsAppQrModalProps {
+  sessionState:   WhatsAppSessionState;
+  channelName:    string;
+  onClose:        () => void;
+  onRequestNewQr: () => Promise<void>;
+}
+
+const QR_EXPIRE_WARN_SECS = 30;
+
+function useQrCountdown(expiresAt: string | null) {
+  const [secsLeft, setSecsLeft] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!expiresAt) {
+      setSecsLeft(null);
+      return;
+    }
+    const calc = () => {
+      const diff = Math.max(0, Math.ceil((new Date(expiresAt).getTime() - Date.now()) / 1000));
+      setSecsLeft(diff);
+      return diff;
+    };
+    if (calc() === 0) return;
+    const timer = setInterval(() => {
+      if (calc() === 0) clearInterval(timer);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [expiresAt]);
+
+  return secsLeft;
+}
+
+export function WhatsAppQrModal({
+  sessionState,
+  channelName,
+  onClose,
+  onRequestNewQr,
+}: WhatsAppQrModalProps) {
+  const [requesting, setRequesting] = useState(false);
+  const [reqErr,     setReqErr]     = useState<string | null>(null);
+  const secsLeft   = useQrCountdown(sessionState.qrExpiresAt);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Auto-close on connected
+  useEffect(() => {
+    if (sessionState.status === 'connected') {
+      const t = setTimeout(onClose, 2500);
+      return () => clearTimeout(t);
+    }
+  }, [sessionState.status, onClose]);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  // Focus trap
+  useEffect(() => {
+    const first = overlayRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    first?.focus();
+  }, []);
+
+  const handleRequestNew = useCallback(async () => {
+    setRequesting(true);
+    setReqErr(null);
+    try {
+      await onRequestNewQr();
+    } catch (err) {
+      setReqErr(err instanceof Error ? err.message : 'Error al pedir nuevo QR');
+    } finally {
+      setRequesting(false);
+    }
+  }, [onRequestNewQr]);
+
+  const isExpiring = secsLeft !== null && secsLeft <= QR_EXPIRE_WARN_SECS && secsLeft > 0;
+  const isExpired  = sessionState.status === 'expired' || secsLeft === 0;
+
+  return (
+    <div
+      className="qr-modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Vincular WhatsApp — ${channelName}`}
+      ref={overlayRef}
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="qr-modal">
+
+        {/* Header */}
+        <div className="qr-modal__header">
+          <div className="qr-modal__header-icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+            </svg>
+          </div>
+          <div>
+            <h2 className="qr-modal__title">Vincular WhatsApp</h2>
+            <p className="qr-modal__subtitle">{channelName}</p>
+          </div>
+          <button className="qr-modal__close" onClick={onClose} aria-label="Cerrar modal">
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="qr-modal__body">
+
+          {sessionState.status === 'waiting_qr' && (
+            <div className="qr-modal__state qr-modal__state--generating">
+              <div className="qr-modal__spinner" aria-hidden="true" />
+              <p className="qr-modal__state-text">Generando código QR…</p>
+              <p className="qr-modal__state-hint">
+                El servidor está conectando con WhatsApp. Esto puede tardar unos segundos.
+              </p>
+            </div>
+          )}
+
+          {sessionState.status === 'qr_ready' && sessionState.qrDataUrl && (
+            <div className="qr-modal__state qr-modal__state--ready">
+              <div className={[
+                'qr-modal__qr-wrapper',
+                isExpiring ? 'qr-modal__qr-wrapper--expiring' : '',
+                isExpired  ? 'qr-modal__qr-wrapper--expired'  : '',
+              ].filter(Boolean).join(' ')}>
+                <img
+                  src={sessionState.qrDataUrl}
+                  alt="Código QR de WhatsApp — escanea con tu teléfono"
+                  className="qr-modal__qr-image"
+                  width={240}
+                  height={240}
+                />
+                {(isExpiring || isExpired) && (
+                  <div className="qr-modal__qr-overlay" aria-hidden="true">
+                    <span className="qr-modal__qr-overlay-text">
+                      {isExpired ? 'QR expirado' : `Expira en ${secsLeft}s`}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {secsLeft !== null && !isExpired && (
+                <div
+                  className="qr-modal__countdown-bar"
+                  role="progressbar"
+                  aria-valuenow={secsLeft}
+                  aria-valuemin={0}
+                  aria-valuemax={60}
+                  aria-label={`QR expira en ${secsLeft} segundos`}
+                >
+                  <div
+                    className={[
+                      'qr-modal__countdown-fill',
+                      isExpiring ? 'qr-modal__countdown-fill--warning' : '',
+                    ].filter(Boolean).join(' ')}
+                    style={{ width: `${Math.min(100, (secsLeft / 60) * 100)}%` }}
+                  />
+                </div>
+              )}
+
+              {!isExpired && (
+                <p className="qr-modal__instructions">
+                  Abre WhatsApp en tu teléfono →{' '}
+                  <strong>Dispositivos vinculados</strong> →{' '}
+                  <strong>Vincular un dispositivo</strong> → Escanea este código.
+                </p>
+              )}
+            </div>
+          )}
+
+          {(isExpired || sessionState.status === 'expired') && (
+            <div className="qr-modal__state qr-modal__state--expired">
+              <div className="qr-modal__state-icon" aria-hidden="true">⚠️</div>
+              <p className="qr-modal__state-text">El código QR ha expirado</p>
+              <p className="qr-modal__state-hint">
+                Los QR de WhatsApp expiran en 60 segundos. Solicita uno nuevo para continuar.
+              </p>
+              <button
+                className="qr-modal__btn-primary"
+                onClick={() => void handleRequestNew()}
+                disabled={requesting}
+                aria-busy={requesting}
+              >
+                {requesting ? 'Generando…' : '↻ Pedir nuevo QR'}
+              </button>
+              {reqErr && <p className="qr-modal__error" role="alert">{reqErr}</p>}
+            </div>
+          )}
+
+          {sessionState.status === 'connected' && (
+            <div className="qr-modal__state qr-modal__state--connected">
+              <div className="qr-modal__success-icon" aria-hidden="true">✓</div>
+              <p className="qr-modal__state-text">¡WhatsApp vinculado correctamente!</p>
+              {sessionState.phone && (
+                <p className="qr-modal__state-hint">
+                  Número: <strong>{sessionState.phone}</strong>
+                </p>
+              )}
+              <p className="qr-modal__state-hint qr-modal__state-hint--faint">
+                Cerrando en 2 segundos…
+              </p>
+            </div>
+          )}
+
+          {sessionState.status === 'disconnected' && (
+            <div className="qr-modal__state qr-modal__state--disconnected">
+              <div className="qr-modal__state-icon" aria-hidden="true">⚡</div>
+              <p className="qr-modal__state-text">Sesión desconectada</p>
+              <p className="qr-modal__state-hint">
+                La sesión de WhatsApp se ha desconectado. Puedes reconectarla generando un nuevo QR.
+              </p>
+              <button
+                className="qr-modal__btn-primary"
+                onClick={() => void handleRequestNew()}
+                disabled={requesting}
+                aria-busy={requesting}
+              >
+                {requesting ? 'Conectando…' : '⚡ Reconectar'}
+              </button>
+            </div>
+          )}
+
+        </div>
+
+        {/* Footer */}
+        <div className="qr-modal__footer">
+          <p className="qr-modal__footer-hint">
+            El dispositivo vinculado aparecerá en WhatsApp → Dispositivos vinculados.
+            Para desvincular, ve allí y elimina el dispositivo.
+          </p>
+          <button className="qr-modal__btn-ghost" onClick={onClose}>
+            Cerrar
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/channels/hooks/useChannelStatus.ts
+++ b/apps/web/src/features/channels/hooks/useChannelStatus.ts
@@ -1,0 +1,249 @@
+/**
+ * useChannelStatus.ts — [F3a-37]
+ *
+ * Hook que abre un EventSource a /api/channels/:id/status/stream
+ * y devuelve el estado en tiempo real del canal.
+ *
+ * Eventos SSE esperados del backend:
+ *   event: channel:status   data: ChannelStatusEvent (JSON)
+ *   event: channel:error    data: ChannelErrorEvent  (JSON)
+ *   event: ping             data: {"ts": "ISO"}
+ *
+ * Reconexión: exponencial con jitter, máximo 30s, se detiene
+ * al hacer cleanup (unmount o cuando channelId cambia).
+ *
+ * Si el backend no soporta SSE todavía, cae a polling
+ * cada POLL_INTERVAL_MS con testChannel().
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  ChannelLiveStatus,
+  ChannelStatusEvent,
+  ChannelErrorEvent,
+} from '../types';
+
+const SSE_ENDPOINT     = (id: string) => `/api/channels/${id}/status/stream`;
+const MAX_RETRY_MS     = 30_000;
+const BASE_RETRY_MS    = 1_000;
+const POLL_INTERVAL_MS = 15_000;
+
+function jitter(ms: number) {
+  return ms + Math.random() * ms * 0.3;
+}
+
+interface UseChannelStatusOptions {
+  /** Habilitar fallback a polling si SSE no disponible. Default: true */
+  pollFallback?: boolean;
+  /** Callback de polling (testChannel) — solo necesario si pollFallback=true */
+  onPoll?: (id: string) => Promise<{ ok: boolean; latency: number; message: string }>;
+}
+
+export function useChannelStatus(
+  channelId: string | null,
+  opts: UseChannelStatusOptions = {},
+): ChannelLiveStatus {
+  const { pollFallback = true, onPoll } = opts;
+
+  const [liveStatus, setLiveStatus] = useState<ChannelLiveStatus>({
+    sseState:      'connecting',
+    sseError:      null,
+    channelStatus: null,
+    reconnectIn:   null,
+    attemptCount:  0,
+  });
+
+  const esRef          = useRef<EventSource | null>(null);
+  const retryTimerRef  = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollTimerRef   = useRef<ReturnType<typeof setInterval> | null>(null);
+  const countdownRef   = useRef<ReturnType<typeof setInterval> | null>(null);
+  const attemptRef     = useRef(0);
+  const closedRef      = useRef(false);
+
+  const clearTimers = useCallback(() => {
+    if (retryTimerRef.current)  clearTimeout(retryTimerRef.current);
+    if (pollTimerRef.current)   clearInterval(pollTimerRef.current);
+    if (countdownRef.current)   clearInterval(countdownRef.current);
+    retryTimerRef.current  = null;
+    pollTimerRef.current   = null;
+    countdownRef.current   = null;
+  }, []);
+
+  const startCountdown = useCallback((totalMs: number) => {
+    let remaining = Math.ceil(totalMs / 1000);
+    setLiveStatus(prev => ({ ...prev, reconnectIn: remaining }));
+    countdownRef.current = setInterval(() => {
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(countdownRef.current!);
+        countdownRef.current = null;
+        setLiveStatus(prev => ({ ...prev, reconnectIn: null }));
+      } else {
+        setLiveStatus(prev => ({ ...prev, reconnectIn: remaining }));
+      }
+    }, 1000);
+  }, []);
+
+  const startPolling = useCallback(() => {
+    if (!channelId || !onPoll || !pollFallback) return;
+    clearInterval(pollTimerRef.current!);
+
+    const poll = async () => {
+      if (!channelId) return;
+      try {
+        const result = await onPoll(channelId);
+        setLiveStatus(prev => ({
+          ...prev,
+          sseState: 'connected',
+          channelStatus: {
+            channelId,
+            connected:      result.ok,
+            latencyMs:      result.latency,
+            messagesPerMin: 0,
+            lastError:      result.ok ? null : result.message,
+            lastErrorAt:    result.ok ? null : new Date().toISOString(),
+            updatedAt:      new Date().toISOString(),
+          },
+        }));
+      } catch {
+        setLiveStatus(prev => ({
+          ...prev,
+          sseState: 'error',
+          sseError: 'Error en polling',
+        }));
+      }
+    };
+
+    void poll();
+    pollTimerRef.current = setInterval(() => void poll(), POLL_INTERVAL_MS);
+  }, [channelId, onPoll, pollFallback]);
+
+  const connect = useCallback(() => {
+    if (!channelId || closedRef.current) return;
+
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+
+    if (typeof EventSource === 'undefined') {
+      setLiveStatus(prev => ({
+        ...prev,
+        sseState:    'error',
+        sseError:    'SSE no disponible — usando polling',
+        reconnectIn: null,
+      }));
+      startPolling();
+      return;
+    }
+
+    setLiveStatus(prev => ({
+      ...prev,
+      sseState:     attemptRef.current > 0 ? 'reconnecting' : 'connecting',
+      sseError:     null,
+      attemptCount: attemptRef.current,
+    }));
+
+    const es = new EventSource(SSE_ENDPOINT(channelId), { withCredentials: true });
+    esRef.current = es;
+
+    es.addEventListener('channel:status', (ev: MessageEvent<string>) => {
+      try {
+        const data = JSON.parse(ev.data) as ChannelStatusEvent;
+        attemptRef.current = 0;
+        setLiveStatus(prev => ({
+          ...prev,
+          sseState:      'connected',
+          sseError:      null,
+          channelStatus: data,
+          reconnectIn:   null,
+          attemptCount:  0,
+        }));
+      } catch { /* malformed — ignore */ }
+    });
+
+    es.addEventListener('channel:error', (ev: MessageEvent<string>) => {
+      try {
+        const data = JSON.parse(ev.data) as ChannelErrorEvent;
+        setLiveStatus(prev => ({
+          ...prev,
+          channelStatus: prev.channelStatus
+            ? {
+                ...prev.channelStatus,
+                lastError:   data.message,
+                lastErrorAt: data.timestamp,
+                connected:   data.recoverable ? prev.channelStatus.connected : false,
+              }
+            : null,
+        }));
+      } catch { /* ignore */ }
+    });
+
+    es.addEventListener('ping', () => {
+      setLiveStatus(prev =>
+        prev.sseState === 'connected' ? prev : { ...prev, sseState: 'connected' },
+      );
+    });
+
+    es.onopen = () => {
+      attemptRef.current = 0;
+      clearTimers();
+      setLiveStatus(prev => ({
+        ...prev,
+        sseState:     'connected',
+        sseError:     null,
+        reconnectIn:  null,
+        attemptCount: 0,
+      }));
+    };
+
+    es.onerror = () => {
+      if (closedRef.current) return;
+
+      es.close();
+      esRef.current = null;
+
+      const attempt = ++attemptRef.current;
+      const delay   = Math.min(jitter(BASE_RETRY_MS * Math.pow(2, attempt - 1)), MAX_RETRY_MS);
+
+      setLiveStatus(prev => ({
+        ...prev,
+        sseState:     'reconnecting',
+        sseError:     `Conexión perdida — reintentando (intento ${attempt})`,
+        attemptCount: attempt,
+      }));
+
+      startCountdown(delay);
+
+      retryTimerRef.current = setTimeout(() => {
+        if (!closedRef.current) connect();
+      }, delay);
+    };
+  }, [channelId, clearTimers, startCountdown, startPolling]);
+
+  useEffect(() => {
+    if (!channelId) {
+      setLiveStatus({
+        sseState:      'closed',
+        sseError:      null,
+        channelStatus: null,
+        reconnectIn:   null,
+        attemptCount:  0,
+      });
+      return;
+    }
+
+    closedRef.current  = false;
+    attemptRef.current = 0;
+    connect();
+
+    return () => {
+      closedRef.current = true;
+      clearTimers();
+      esRef.current?.close();
+      esRef.current = null;
+    };
+  }, [channelId, connect, clearTimers]);
+
+  return liveStatus;
+}

--- a/apps/web/src/features/channels/types.ts
+++ b/apps/web/src/features/channels/types.ts
@@ -112,3 +112,48 @@ export interface ChannelDetailResponse {
   ok:   boolean;
   data: ChannelConfig;
 }
+
+// ── SSE — Estado de canal en tiempo real ─────────────────────────────────────
+
+/** Payload del evento SSE "channel:status" */
+export interface ChannelStatusEvent {
+  channelId:      string;
+  connected:      boolean;           // el canal tiene conexión activa con el proveedor
+  latencyMs:      number | null;     // null si no hay ping reciente
+  messagesPerMin: number;            // ventana de 60s
+  lastError:      string | null;     // último mensaje de error o null
+  lastErrorAt:    string | null;     // ISO timestamp del último error
+  sessionState?:  WhatsAppSessionState; // solo para tipo 'whatsapp' con authMode='qr'
+  updatedAt:      string;            // ISO timestamp del evento
+}
+
+/** Estado de sesión WhatsApp QR */
+export interface WhatsAppSessionState {
+  status:      'waiting_qr' | 'qr_ready' | 'connected' | 'disconnected' | 'expired';
+  qrDataUrl:   string | null;     // data:image/png;base64,... o null
+  qrExpiresAt: string | null;     // ISO timestamp de expiración del QR
+  phone?:      string;            // número vinculado (cuando status='connected')
+}
+
+/** Evento SSE "channel:error" */
+export interface ChannelErrorEvent {
+  channelId:   string;
+  code:        string;
+  message:     string;
+  recoverable: boolean;
+  timestamp:   string;
+}
+
+/** Estado consolidado que maneja useChannelStatus */
+export interface ChannelLiveStatus {
+  // Estado de la conexión SSE
+  sseState:   'connecting' | 'connected' | 'reconnecting' | 'error' | 'closed';
+  sseError:   string | null;
+
+  // Datos del canal (actualizados por eventos SSE)
+  channelStatus: ChannelStatusEvent | null;
+
+  // Reconexión
+  reconnectIn:  number | null;   // segundos hasta el próximo intento (null si no reconectando)
+  attemptCount: number;
+}

--- a/apps/web/src/features/channels/useChannels.ts
+++ b/apps/web/src/features/channels/useChannels.ts
@@ -1,26 +1,5 @@
-/**
- * features/channels/useChannels.ts
- * Hook de estado para el feature de canales.
- *
- * Expone:
- *   channels     — lista completa cargada desde el gateway
- *   loading      — true durante fetch inicial o reload
- *   error        — mensaje de error o null
- *   selectedId   — ID del canal seleccionado en la lista
- *   setSelectedId
- *   reload()     — refetch manual
- *   createChannel(payload)
- *   activateChannel(id)
- *   deactivateChannel(id)
- *   deleteChannel(id)
- *   addBinding(channelId, payload)
- *   removeBinding(channelId, bindingId)
- *   patchChannel(id, payload)  — F3a-36
- *   testChannel(id)            — F3a-36
- */
-
-import { useState, useEffect, useCallback } from 'react';
-import * as gwApi from '../../lib/gateway-api';
+import { useState, useEffect, useCallback } from 'react'
+import * as gwApi from '../../lib/gateway-api'
 import type {
   ChannelConfig,
   CreateChannelPayload,
@@ -28,132 +7,117 @@ import type {
   PatchChannelPayload,
   ChannelTestResult,
   ChannelDetailResponse,
-} from './types';
+} from './types'
 
 export function useChannels(filters?: { agentId?: string; type?: string; isActive?: boolean }) {
-  const [channels,    setChannels]    = useState<ChannelConfig[]>([]);
-  const [loading,     setLoading]     = useState(true);
-  const [error,       setError]       = useState<string | null>(null);
-  const [selectedId,  setSelectedId]  = useState<string | null>(null);
+  const [channels, setChannels] = useState<ChannelConfig[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
 
-  // Stringify filters para comparar estabilidad en dep array
-  const filtersKey = JSON.stringify(filters ?? {});
+  const filtersKey = JSON.stringify(filters ?? {})
 
   const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+    setLoading(true)
+    setError(null)
     try {
-      const res = await gwApi.listChannels(filters);
-      setChannels(res.data ?? []);
+      const res = await gwApi.listChannels(filters)
+      setChannels(res.data ?? [])
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error al cargar canales');
+      setError(err instanceof Error ? err.message : 'Error al cargar canales')
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filtersKey]);
+  }, [filtersKey])
 
-  useEffect(() => { void load(); }, [load]);
-
-  // ── Acciones ──
+  useEffect(() => { void load() }, [load])
 
   const createChannel = useCallback(async (payload: CreateChannelPayload): Promise<ChannelConfig> => {
-    const res = await gwApi.createChannel(payload);
-    const newChannel = res.channel;
-    setChannels(prev => [newChannel, ...prev]);
-    setSelectedId(newChannel.id);
-    return newChannel;
-  }, []);
+    const res = await gwApi.createChannel(payload)
+    const newChannel = res.channel
+    setChannels(prev => [newChannel, ...prev])
+    setSelectedId(newChannel.id)
+    return newChannel
+  }, [])
 
   const activateChannel = useCallback(async (id: string): Promise<void> => {
-    await gwApi.activateChannel(id);
-    setChannels(prev =>
-      prev.map(c => (c.id === id ? { ...c, isActive: true } : c)),
-    );
-  }, []);
+    await gwApi.activateChannel(id)
+    setChannels(prev => prev.map(c => (c.id === id ? { ...c, isActive: true } : c)))
+  }, [])
 
   const deactivateChannel = useCallback(async (id: string): Promise<void> => {
-    await gwApi.deactivateChannel(id);
-    setChannels(prev =>
-      prev.map(c => (c.id === id ? { ...c, isActive: false } : c)),
-    );
-  }, []);
+    await gwApi.deactivateChannel(id)
+    setChannels(prev => prev.map(c => (c.id === id ? { ...c, isActive: false } : c)))
+  }, [])
 
   const deleteChannel = useCallback(async (id: string): Promise<void> => {
-    await gwApi.deleteChannel(id);
-    setChannels(prev => prev.filter(c => c.id !== id));
-    setSelectedId(prev => (prev === id ? null : prev));
-  }, []);
+    await gwApi.deleteChannel(id)
+    setChannels(prev => prev.filter(c => c.id !== id))
+    setSelectedId(prev => (prev === id ? null : prev))
+  }, [])
 
-  const addBinding = useCallback(
-    async (channelId: string, payload: AddBindingPayload): Promise<void> => {
-      const res = await gwApi.addBinding(channelId, payload);
-      const newBinding = res.data;
-      setChannels(prev =>
-        prev.map(c =>
-          c.id === channelId
-            ? { ...c, bindings: [...(c.bindings ?? []), newBinding] }
-            : c,
-        ),
-      );
-    },
-    [],
-  );
+  const addBinding = useCallback(async (channelId: string, payload: AddBindingPayload): Promise<void> => {
+    const res = await gwApi.addBinding(channelId, payload)
+    const newBinding = res.data
+    setChannels(prev =>
+      prev.map(c => c.id === channelId ? { ...c, bindings: [...(c.bindings ?? []), newBinding] } : c),
+    )
+  }, [])
 
-  const removeBinding = useCallback(
-    async (channelId: string, bindingId: string): Promise<void> => {
-      await gwApi.removeBinding(channelId, bindingId);
-      setChannels(prev =>
-        prev.map(c =>
-          c.id === channelId
-            ? { ...c, bindings: (c.bindings ?? []).filter(b => b.id !== bindingId) }
-            : c,
-        ),
-      );
-    },
-    [],
-  );
+  const removeBinding = useCallback(async (channelId: string, bindingId: string): Promise<void> => {
+    await gwApi.removeBinding(channelId, bindingId)
+    setChannels(prev =>
+      prev.map(c => c.id === channelId ? { ...c, bindings: (c.bindings ?? []).filter(b => b.id !== bindingId) } : c),
+    )
+  }, [])
 
-  // ── F3a-36: patchChannel + testChannel ──────────────────────────────────────
+  const patchChannel = useCallback(async (id: string, payload: PatchChannelPayload): Promise<void> => {
+    const res = await fetch(`/api/channels/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ message: 'Error al actualizar canal' }))
+      throw new Error((err as { message?: string }).message ?? 'Error al actualizar canal')
+    }
+    const updated: ChannelDetailResponse = await res.json()
+    setChannels(prev => prev.map(ch => (ch.id === id ? updated.data : ch)))
+    if (selectedId === id) {
+      setSelectedId(null)
+      requestAnimationFrame(() => setSelectedId(id))
+    }
+  }, [selectedId])
 
-  const patchChannel = useCallback(
-    async (id: string, payload: PatchChannelPayload): Promise<void> => {
-      const res = await fetch(`/api/channels/${id}`, {
-        method:  'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body:    JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ message: 'Error al actualizar canal' }));
-        throw new Error((err as { message?: string }).message ?? 'Error al actualizar canal');
+  const testChannel = useCallback(async (id: string): Promise<ChannelTestResult> => {
+    const start = Date.now()
+    try {
+      const res = await fetch(`/api/channels/${id}/test`, { method: 'POST' })
+      const latency = Date.now() - start
+      const body = await res.json().catch(() => ({ ok: res.ok, message: '' })) as { ok?: boolean; message?: string }
+      return {
+        ok: body.ok ?? res.ok,
+        latency,
+        message: body.message ?? (res.ok ? 'OK' : `HTTP ${res.status}`),
       }
-      const updated: ChannelDetailResponse = await res.json();
-      setChannels(prev =>
-        prev.map(ch => (ch.id === id ? updated.data : ch)),
-      );
-      if (selectedId === id) {
-        // forzar re-render del detalle con datos nuevos
-        setSelectedId(null);
-        requestAnimationFrame(() => setSelectedId(id));
+    } catch (err) {
+      return {
+        ok: false,
+        latency: Date.now() - start,
+        message: err instanceof Error ? err.message : 'Error de red',
       }
-    },
-    [selectedId],
-  );
+    }
+  }, [])
 
-  const testChannel = useCallback(
-    async (id: string): Promise<ChannelTestResult> => {
-      const res = await fetch(`/api/channels/${id}/test`, { method: 'POST' });
-      if (!res.ok) {
-        return { ok: false, latency: 0, message: 'No se pudo conectar al canal' };
-      }
-      return res.json() as Promise<ChannelTestResult>;
-    },
-    [],
-  );
+  const requestWhatsAppQr = useCallback(async (id: string): Promise<void> => {
+    const res = await fetch(`/api/channels/${id}/whatsapp/qr`, { method: 'POST' })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ message: 'Error al generar QR' })) as { message?: string }
+      throw new Error(err.message ?? 'Error al generar QR')
+    }
+  }, [])
 
-  // ── ──────────────────────────────────────────────────────────────────────────
-
-  const selected = channels.find(c => c.id === selectedId) ?? null;
+  const selected = channels.find(c => c.id === selectedId) ?? null
 
   return {
     channels,
@@ -171,5 +135,6 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     removeBinding,
     patchChannel,
     testChannel,
-  };
+    requestWhatsAppQr,
+  }
 }


### PR DESCRIPTION
## F3a-37 — ChannelStatusCard (SSE) y QR Modal WhatsApp

### Cambios

| Archivo | Acción |
|---------|--------|
| `apps/web/src/features/channels/types.ts` | Añadidos tipos SSE: `ChannelStatusEvent`, `WhatsAppSessionState`, `ChannelErrorEvent`, `ChannelLiveStatus` |
| `apps/web/src/features/channels/hooks/useChannelStatus.ts` | **NUEVO** — Hook SSE con reconexión exponencial + fallback polling |
| `apps/web/src/features/channels/components/WhatsAppQrModal.tsx` | **NUEVO** — Modal QR WhatsApp con countdown, ciclo de estados y auto-close |
| `apps/web/src/features/channels/components/ChannelStatusCard.tsx` | **NUEVO** — Tarjeta de estado en tiempo real (StatusDot, métricas, error colapsable, QR button) |
| `apps/web/src/features/channels/components/ChannelDetail.tsx` | Monta `ChannelStatusCard` encima del bloque meta; añade props `onTestChannel` y `onRequestNewQr` |
| `apps/web/src/features/channels/useChannels.ts` | Añade `testChannel` (ping para polling) y `requestWhatsAppQr` (POST /whatsapp/qr) |
| `apps/web/src/features/channels/ChannelsPage.tsx` | Destruye `testChannel` + `requestWhatsAppQr` y los pasa a `ChannelDetail` |

### Criterios de aceptación

- [x] `ChannelStatusCard` se monta en todos los canales (tab overview)
- [x] SSE `EventSource` con reconexión exponencial con jitter (máx 30 s)
- [x] Fallback a polling cada 15 s cuando SSE no disponible
- [x] `WhatsAppQrModal` solo visible cuando `channel.config.authMode === 'qr'`
- [x] Countdown de expiración QR + warning visual ≤30 s
- [x] Auto-close del modal en 2.5 s al detectar `status === 'connected'`
- [x] Tecla Escape cierra el modal + focus trap correcto
- [x] StatusDot: verde / amarillo (latencia > 1000 ms) / rojo / gris pulsante

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft Teams support: configure/manage Teams channels, health endpoints, and send notifications via bot or incoming webhook.
  * Real-time channel status UI: per-channel connection state, latency, messages-per-minute, last error and reconnection countdown.
  * WhatsApp QR improvements: modal with live countdown, auto-close on connect, and “request new QR” action.
  * Channel test now reports latency and structured results.

* **Tests**
  * Expanded unit and e2e coverage for Teams and channel behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->