### PR TITLE
fix(F2/F3-blockers): AUDIT-01+05+07+08+09+06+03+04+10+11+12 — Sprint completo F2/F3

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,7 @@ module.exports = {
       // uses vi.fn/vi.mock and must be excluded to avoid runtime errors with Jest)
       testMatch: [
         '<rootDir>/src/__tests__/**/*-sequential.test.ts',
+        '<rootDir>/src/__tests__/**/*-e2e.test.ts',
       ],
       transform: {
         '^.+\\.tsx?$': ['ts-jest', {


### PR DESCRIPTION
## Sprint F2/F3 — 12 AUDITs en rama `fix/phase-F2-blockers`

---

### AUDIT-07 (#167) — jest.config: hierarchy-e2e invisible en CI
Closes #167

### AUDIT-09 (#164) — Import .js en profile-engine test
Closes #164

### AUDIT-06 (#166) — RunStep.orderBy createdAt → startedAt
Closes #166

### AUDIT-03 (#174) — registry.getChannelConfig/getAdapter → registry.get
Closes #174

### AUDIT-04 (#172) — externalId vs externalUserId
Closes #172

### AUDIT-10 (#175) — WebhookAdapter._isCallbackAllowed() — test unitario
**Commit:** `1f039d3` — 9 casos: fail-secure sin env, origins permitidos, subdominios, URLs malformadas, comparación por origin+puerto
Closes #175

### AUDIT-11 (#178) — SlackAdapter.initialize() signingSecret — test unitario
**Commit:** `1f039d3` — 6 casos: lanza si falta/vacío, no usa env global, mensaje incluye channelConfigId
Closes #178

### AUDIT-12 (#177) — WhatsAppSessionStore TOCTOU lock — test unitario
**Commit:** `1f039d3` — 8 casos: 2 y 10 llamadas concurrentes = 1 entrada, _creationLocks se limpia
Closes #177

### AUDIT-05 (#173) — CI BLOCKER — channel-lifecycle vs ChannelConfig schema
**Commit:** `c89d334` — eliminados status/errorMessage/lastStartedAt/lastStoppedAt de provision/start/stop
Closes #173

### AUDIT-05b (#173) — ChannelStatusDto — campos opcionales/null
**Commit:** `b40e242` — status/errorMessage/lastStartedAt/lastStoppedAt marcados `string | null` con comentario AUDIT-25
Closes #173

### AUDIT-01 (#163) — ProfilePropagator — orchestratorId → isLevelOrchestrator
**Commit:** `3d462f2` — propagateUp() reescrito: agent.findFirst({ workspaceId/departmentId/agencyId, isLevelOrchestrator: true }) en lugar de workspace/department/agency.orchestratorId (campo inexistente)
Closes #163

### AUDIT-08 (#165) — Mock Prisma en tests profile-engine
**Commit:** `2bdb011` — buildPrismaMock actualizado: wsOrchAgent/depOrchAgent/agcOrchAgent via agent.findFirst; workspace/department/agency sin orchestratorId; 8 casos de test
Closes #165

---

## Issues cerrados
Closes #167 | Closes #164 | Closes #166 | Closes #174 | Closes #172 | Closes #175 | Closes #178 | Closes #177 | Closes #173 | Closes #163 | Closes #165