### PR TITLE
Feat/audit 27 28 29 30 31 quality batch

### DIFF
--- a/packages/hierarchy/src/__tests__/capability-matching.test.ts
+++ b/packages/hierarchy/src/__tests__/capability-matching.test.ts
@@ -6,17 +6,20 @@
  *   - jaccardScore(): retorna 0..1, caso vacío retorna 0
  *   - findSpecialistWithCapability() con profiles mock en BD
  *   - findSpecialistWithCapability() sin profiles en BD (profileFound: false)
+ *   - isFallback semántico: true cuando ningún agente supera el threshold
  *
  * Estos tests usan mocks de PrismaClient y no requieren BD real.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   tokenize,
   jaccardScore,
   HierarchyOrchestrator,
   type HierarchyNode,
   type AgentExecutorFn,
+  type SpecialistMatch,
+  type HierarchyTask,
 } from '../hierarchy-orchestrator.js'
 import type { PrismaClient } from '@prisma/client'
 
@@ -121,6 +124,19 @@ function makeAgent(id: string, name: string): HierarchyNode {
 /** AgentExecutorFn stub — nunca debería llamarse en estos tests */
 const stubExecutor: AgentExecutorFn = vi.fn().mockResolvedValue({ response: 'ok' })
 
+/**
+ * Helper para acceder a findSpecialistWithCapability() (privado) vía cast.
+ * Permite testing unitario puro sin invocar orchestrate() completo.
+ */
+function getFindSpecialist(orchestrator: HierarchyOrchestrator) {
+  return (orchestrator as unknown as {
+    findSpecialistWithCapability: (
+      taskDescription: string,
+      candidates?: HierarchyNode[],
+    ) => Promise<SpecialistMatch>
+  }).findSpecialistWithCapability.bind(orchestrator)
+}
+
 describe('findSpecialistWithCapability() — via decomposeTasks() fallback', () => {
   it('asigna el task al agente con mayor afinidad semántica (con profiles en BD)', async () => {
     const agentA = makeAgent('agent-a', 'Legal Agent')
@@ -159,7 +175,7 @@ describe('findSpecialistWithCapability() — via decomposeTasks() fallback', () 
     // Llamar decomposeTasks indirectamente vía orchestrate() mocked
     // Accedemos al método privado via cast para testing unitario
     const decomposeTasksFn = (orchestrator as never as {
-      decomposeTasks: (task: string, input?: Record<string, unknown>) => Promise<import('../hierarchy-orchestrator.js').HierarchyTask[]>
+      decomposeTasks: (task: string, input?: Record<string, unknown>) => Promise<HierarchyTask[]>
     }).decomposeTasks.bind(orchestrator)
 
     const subtasks = await decomposeTasksFn('draft legal contract for the acquisition')
@@ -189,7 +205,7 @@ describe('findSpecialistWithCapability() — via decomposeTasks() fallback', () 
     )
 
     const decomposeTasksFn = (orchestrator as never as {
-      decomposeTasks: (task: string) => Promise<import('../hierarchy-orchestrator.js').HierarchyTask[]>
+      decomposeTasks: (task: string) => Promise<HierarchyTask[]>
     }).decomposeTasks.bind(orchestrator)
 
     // No debe lanzar — debe devolver un subtask válido
@@ -215,7 +231,7 @@ describe('findSpecialistWithCapability() — via decomposeTasks() fallback', () 
     const orchestrator = new HierarchyOrchestrator(hierarchy, stubExecutor, prisma)
 
     const decomposeTasksFn = (orchestrator as never as {
-      decomposeTasks: (task: string) => Promise<import('../hierarchy-orchestrator.js').HierarchyTask[]>
+      decomposeTasks: (task: string) => Promise<HierarchyTask[]>
     }).decomposeTasks.bind(orchestrator)
 
     await decomposeTasksFn('any task')
@@ -227,5 +243,95 @@ describe('findSpecialistWithCapability() — via decomposeTasks() fallback', () 
     expect(callArg.where.agentId.in).toEqual(
       expect.arrayContaining(['agent-1', 'agent-2', 'agent-3'])
     )
+  })
+})
+
+// ── isFallback behavior ───────────────────────────────────────────────────────
+
+describe('isFallback behavior', () => {
+  it('returns isFallback=true when no agent meets the score threshold', async () => {
+    // Arrange: agentes con capabilities completamente distintos a la query
+    const agentBilling  = makeAgent('agent-billing',  'Billing Agent')
+    const agentDefault  = makeAgent('agent-default',  'Default Agent')
+
+    const prisma = buildPrismaMock([
+      {
+        agentId:       'agent-billing',
+        systemPrompt:  'billing invoices payments receipts accounts',
+        persona:       {},
+        knowledgeBase: [],
+      },
+      {
+        agentId:       'agent-default',
+        systemPrompt:  '',
+        persona:       {},
+        knowledgeBase: [],
+      },
+    ])
+
+    const hierarchy: HierarchyNode = {
+      id:       'ws-fallback',
+      name:     'Test Workspace',
+      level:    'workspace',
+      children: [agentBilling, agentDefault],
+    }
+
+    const orchestrator = new HierarchyOrchestrator(hierarchy, stubExecutor, prisma)
+    const findSpecialist = getFindSpecialist(orchestrator)
+
+    // Act: query completamente dispar — nada debería superar el threshold MIN_SCORE=0.05
+    const result = await findSpecialist(
+      'quantum physics research neutron star astrophysics',
+      [agentBilling, agentDefault],
+    )
+
+    // Assert — criterio de calidad AUDIT-29:
+    expect(result).toBeDefined()
+    expect(result.isFallback).toBe(true)
+    // El nodo devuelto debe ser uno de los candidatos (el de mayor score, aunque sea 0)
+    expect(['agent-billing', 'agent-default']).toContain(result.node.id)
+  })
+
+  it('returns isFallback=false when a qualified agent is found', async () => {
+    // Arrange: agente con alta afinidad semántica para la query
+    const agentBilling  = makeAgent('agent-billing',  'Billing Agent')
+    const agentDefault  = makeAgent('agent-default',  'Default Agent')
+
+    const prisma = buildPrismaMock([
+      {
+        agentId:       'agent-billing',
+        // systemPrompt con tokens que coinciden directamente con la query
+        systemPrompt:  'billing invoices payments invoice help assistance support',
+        persona:       {},
+        knowledgeBase: [],
+      },
+      {
+        agentId:       'agent-default',
+        systemPrompt:  '',
+        persona:       {},
+        knowledgeBase: [],
+      },
+    ])
+
+    const hierarchy: HierarchyNode = {
+      id:       'ws-match',
+      name:     'Test Workspace',
+      level:    'workspace',
+      children: [agentBilling, agentDefault],
+    }
+
+    const orchestrator = new HierarchyOrchestrator(hierarchy, stubExecutor, prisma)
+    const findSpecialist = getFindSpecialist(orchestrator)
+
+    // Act: query con tokens que coinciden directamente con el systemPrompt del billing agent
+    const result = await findSpecialist(
+      'help with my invoice billing payments',
+      [agentBilling, agentDefault],
+    )
+
+    // Assert — criterio de calidad AUDIT-29:
+    expect(result).toBeDefined()
+    expect(result.isFallback).toBe(false)
+    expect(result.node.id).toBe('agent-billing')
   })
 })

--- a/packages/hierarchy/src/hierarchy-orchestrator.ts
+++ b/packages/hierarchy/src/hierarchy-orchestrator.ts
@@ -24,6 +24,31 @@ import {
   buildStatusChangeEvent,
 } from '../../run-engine/src/events/index.js'
 
+// ── Constantes de módulo — se instancian UNA SOLA VEZ al importar ───────────
+
+/**
+ * Palabras vacías filtradas antes del cálculo de score de capacidades.
+ * Definida a nivel de módulo para evitar recronstrucción en cada llamada
+ * a tokenize() — crítico en flows de alta frecuencia con múltiples candidatos.
+ */
+const STOPWORDS_SET = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to',
+  'for', 'of', 'with', 'by', 'from', 'as', 'is', 'are', 'was',
+  'be', 'been', 'have', 'has', 'had', 'do', 'does', 'did',
+  'will', 'would', 'could', 'should', 'may', 'might', 'must',
+  'this', 'that', 'these', 'those', 'it', 'its', 'you', 'your',
+  'we', 'our', 'they', 'their', 'he', 'she', 'his', 'her',
+  'el', 'la', 'los', 'las', 'un', 'una', 'de', 'en', 'con', 'por',
+  'para', 'que', 'es', 'son', 'tiene', 'este', 'esta',
+])
+
+/**
+ * Regex de tokenización — extrae tokens alfanuméricos (incluyendo chars
+ * acentuados en español). Definida a nivel de módulo para evitar
+ * recompilación en cada invocación de tokenize().
+ */
+const TOKEN_SPLIT_RE = /[^a-záéíóúüñ\w]+/gi
+
 // ── Tipos públicos ───────────────────────────────────────────────────────────────────────────────
 
 export type HierarchyLevel = 'agency' | 'department' | 'workspace' | 'agent' | 'subagent'
@@ -260,24 +285,16 @@ const DEFAULT_OPTIONS: Required<OrchestratorOptions> = {
 
 /**
  * Tokeniza texto en un Set de palabras lowercase sin stopwords.
+ *
+ * Usa STOPWORDS_SET y TOKEN_SPLIT_RE definidas a nivel de módulo
+ * para evitar re-instanciación en flows de alta frecuencia (AUDIT-27).
  */
 export function tokenize(text: string): Set<string> {
-  const STOPWORDS = new Set([
-    'the','a','an','and','or','but','in','on','at','to',
-    'for','of','with','by','from','as','is','are','was',
-    'be','been','have','has','had','do','does','did',
-    'will','would','could','should','may','might','must',
-    'this','that','these','those','it','its','you','your',
-    'we','our','they','their','he','she','his','her',
-    'el','la','los','las','un','una','de','en','con','por',
-    'para','que','es','son','tiene','este','esta',
-  ])
   return new Set(
     text
       .toLowerCase()
-      .replace(/[^a-záéíóúüñ\w\s]/gi, ' ')
-      .split(/\s+/)
-      .filter((w) => w.length >= 3 && !STOPWORDS.has(w)),
+      .split(TOKEN_SPLIT_RE)
+      .filter((w) => w.length >= 3 && !STOPWORDS_SET.has(w)),
   )
 }
 


### PR DESCRIPTION
✅ Rama creada
feat/audit-27-28-29-30-31-quality-batch — creada desde main → SHA base: 1965dd3

✅ COMMIT 1 — AUDIT-27
SHA: [0da33a8](https://github.com/lssmanager/agent-visualstudio/commit/0da33a87032758bd086b1e549273f14804250aae)

perf(AUDIT-27): extraer STOPWORDS_SET y TOKEN_REGEX a constantes de módulo

STOPWORDS_SET = new Set([...]) movida a top-level del módulo — se instancia una sola vez al importar

TOKEN_SPLIT_RE = /[^a-záéíóúüñ\w]+/gi también a nivel de módulo

tokenize() refactorizada para reusarlas — sin cambio de API pública

Ningún new Set(...) ni literal regex dentro del cuerpo de funciones

✅ COMMIT 2 — AUDIT-28 + AUDIT-29
SHA: [09eedfe](https://github.com/lssmanager/agent-visualstudio/commit/09eedfe238e6656e58b2916dccb3feac0f0fc3d3)

test(AUDIT-28/29): eliminar imports sin uso y añadir asserts explícitos de isFallback

AUDIT-28: eliminado beforeEach del import (no estaba en uso)

AUDIT-29: añadido describe('isFallback behavior') con 2 casos:

isFallback === true cuando la query es "quantum physics research" y los agentes tienen capabilities de billing/invoices → ninguno supera MIN_SCORE=0.05

isFallback === false cuando la query coincide semánticamente con el systemPrompt del agente billing

Helper getFindSpecialist() para acceder al método privado sin invocar orchestrate() completo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for capability matching behavior validation.

* **Chores**
  * Optimized internal tokenization logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->