### PR TITLE
fix(AUDIT-30): type Run.channelKind String? → ChannelKind?; add slack…

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -156,11 +156,15 @@ model Hook {
 }
 
 // ── Channel ───────────────────────────────────────────────────────────────────
+// AUDIT-30: añadidos slack y teams al enum ChannelKind para que Run.channelKind
+// sea tipado con el enum real en lugar de String? libre.
 enum ChannelKind {
   telegram
   whatsapp
   discord
   webchat
+  slack
+  teams
 }
 
 enum ChannelStatus {
@@ -401,7 +405,8 @@ model Run {
   agent       Agent?    @relation(fields: [agentId], references: [id])
 
   sessionId   String?
-  channelKind String?
+  // AUDIT-30: tipado con enum ChannelKind en lugar de String? libre
+  channelKind ChannelKind?
 
   status      RunStatus @default(pending)
   inputData   Json      @default("{}")   // payload inicial

--- a/packages/flow-engine/src/agent-runner.ts
+++ b/packages/flow-engine/src/agent-runner.ts
@@ -9,7 +9,7 @@
  * Integrado con ModelPolicyResolver via LLMStepExecutor.
  * Para runs sin Flow (conversación directa), usa un nodo sintético.
  */
-import type { PrismaClient } from '@prisma/client'
+import type { PrismaClient, ChannelKind } from '@prisma/client'
 import type { ILLMProvider } from './llm-provider.js'
 import { LLMStepExecutor } from './llm-step-executor.js'
 import type { StepExecutionContext } from './llm-step-executor.js'
@@ -34,7 +34,8 @@ export interface RunInput {
   agentId?:    string
   flowId?:     string
   sessionId?:  string
-  channelKind?: string
+  /** AUDIT-30: tipado con enum ChannelKind de Prisma en lugar de string libre */
+  channelKind?: ChannelKind
   inputData:   Record<string, unknown>
   availableSkills?: SkillSpec[]
   extraTools?:      McpToolDefinition[]

--- a/packages/run-engine/src/repositories/run.repository.ts
+++ b/packages/run-engine/src/repositories/run.repository.ts
@@ -15,7 +15,7 @@
  *   (FlowExecutor, HierarchyOrchestrator). Nuevo código debe usar esta clase.
  */
 
-import type { PrismaClient, RunStatus } from '@prisma/client'
+import type { PrismaClient, RunStatus, ChannelKind } from '@prisma/client'
 
 // ── DTOs ──────────────────────────────────────────────────────────────────────
 
@@ -24,7 +24,8 @@ export interface CreateRunInput {
   agentId?:     string
   flowId?:      string
   sessionId?:   string
-  channelKind?: string
+  /** AUDIT-30: tipado con enum ChannelKind generado por Prisma */
+  channelKind?: ChannelKind
   inputData?:   Record<string, unknown>
   metadata?:    Record<string, unknown>
 }


### PR DESCRIPTION
…/teams to enum

- prisma/schema.prisma: añade slack, teams a enum ChannelKind
- prisma/schema.prisma: Run.channelKind String? → ChannelKind?
- run.repository.ts: CreateRunInput.channelKind string → ChannelKind
- agent-runner.ts: RunInput.channelKind string → ChannelKind

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Slack and Teams as communication channels.

* **Refactor**
  * Enhanced channel type validation system to ensure data consistency and prevent invalid channel kinds across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->