### PR TITLE
feat(AUDIT-37..40): Tech debt — list() registry, Run hierarchy columns, AuditEvent F4 marker

### DIFF
--- a/packages/gateway-sdk/src/channel-adapter.ts
+++ b/packages/gateway-sdk/src/channel-adapter.ts
@@ -182,6 +182,41 @@ export class ChannelAdapterRegistry {
   registeredTypes(): string[] {
     return [...this.adapters.keys()];
   }
+
+  /**
+   * Devuelve todos los adaptadores registrados con sus tipos.
+   *
+   * Útil para:
+   * - Health-check global: iterar sobre todos los adapters activos
+   * - Restart en cascada: `registry.list().forEach(({ adapter }) => adapter.teardown(...))`
+   * - Endpoint `GET /gateway/health`: exponer qué canales están conectados
+   *
+   * @returns Array de { type, adapter } en orden de registro.
+   *
+   * @example
+   * ```ts
+   * const active = registry.list().map(({ type }) => ({ type, status: 'active' }));
+   * res.json({ adapters: active });
+   * ```
+   */
+  list(): Array<{ type: string; adapter: IChannelAdapter }> {
+    return Array.from(this.adapters.entries()).map(([type, adapter]) => ({
+      type,
+      adapter,
+    }));
+  }
+
+  /**
+   * Variante conveniente de `list()` que solo devuelve los adaptadores.
+   *
+   * Útil cuando solo necesitas iterar sobre los adapters sin el tipo:
+   * ```ts
+   * await Promise.all(registry.listAdapters().map(a => a.teardown({}, {})));
+   * ```
+   */
+  listAdapters(): IChannelAdapter[] {
+    return Array.from(this.adapters.values());
+  }
 }
 
 /** Module-level singleton — import and use directly */

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,4 @@
-// ─────────────────────────────────────────────────────────────────────────────────
+// ───────────────────────────────────────────────────────────────────────────────────
 // prisma/schema.prisma
 // Agent Visual Studio — Full Platform Schema — Versión F0 (canónica)
 //
@@ -11,12 +11,12 @@
 // Audit:        AuditEvent
 // Settings:     SystemConfig  (single-tenant admin keys — plaintext, same trust as .env)
 //
-// ── D-15 ───────────────────────────────────────────────────────────────────────────────
+// ── D-15 ─────────────────────────────────────────────────────────────────────────────────────
 // GatewaySession.messageHistory ELIMINADO.
 // Reemplazado por activeContextJson Json? (contexto activo de la sesión)
 // + modelo ConversationMessage (historial append-only, indexado).
 //
-// ── D-24d ──────────────────────────────────────────────────────────────────────────
+// ── D-24d ───────────────────────────────────────────────────────────────────────────────
 // isLevelOrchestrator Boolean @default(false) en Agent, Workspace, Department.
 // Solo UN agente/workspace/department por scope puede tener isLevelOrchestrator=true.
 // Prisma no puede expresar "​​@@unique donde el valor sea true";
@@ -25,29 +25,48 @@
 //     ON "Agent" ("workspaceId") WHERE "isLevelOrchestrator" = true;
 //   (ídem para Workspace y Department — ver C-20 en Plan Maestro)
 //
-// ── D-07 ─────────────────────────────────────────────────────────────────────────────────
+// ── D-07 ─────────────────────────────────────────────────────────────────────────────────────
 // Flow.agentId: el ownership real es Flow → Agent → Workspace → Department → Agency.
 //
-// ── Exactly-one-FK invariant on Policy tables ────────────────────────────────────────
+// ── Exactly-one-FK invariant on Policy tables ────────────────────────────────────────────
 // BudgetPolicy and ModelPolicy each belong to exactly ONE scope level.
 // Enforced at two layers:
 //   1. DB layer — raw CHECK constraint added via a manual migration.
 //   2. App layer — PolicyScopeGuard in apps/api validates before upsert.
 //
-// ── AUDIT-23 ─────────────────────────────────────────────────────────────────────────
+// ── AUDIT-23 ────────────────────────────────────────────────────────────────────────────
 // enum ChannelType ya es el nombre canónico (no ChannelKind).
 // Valores exactos: telegram, whatsapp, webchat, discord, teams, slack, webhook.
 //
-// ── AUDIT-24 ─────────────────────────────────────────────────────────────────────────
+// ── AUDIT-24 ────────────────────────────────────────────────────────────────────────────
 // ChannelConfig.secretsEncrypted es String? (nullable).
 // AES-256-GCM se aplica en F3b-05; hasta entonces puede estar vacío.
 // Los adapters deben leer secretsEncrypted (NO tokenEnc ni credentials).
 //
-// ── AUDIT-25 ─────────────────────────────────────────────────────────────────────────
-// ChannelConfig.isActive Boolean @default(false) es el ÚNICO campo de estado persistido.
+// ── AUDIT-25 ────────────────────────────────────────────────────────────────────────────
+// ChannelConfig.isActive Boolean @default(false) es el Único campo de estado persistido.
 // Los campos fantasma status/errorMessage/lastStartedAt/lastStoppedAt han sido ELIMINADOS.
 // El estado en memoria se maneja con RuntimeChannelStatus en channel-lifecycle.service.ts.
-// ─────────────────────────────────────────────────────────────────────────────────
+//
+// ── AUDIT-37 ────────────────────────────────────────────────────────────────────────────
+// BudgetPolicy ya implementa el patrón exactly-one-FK con agentId String? @unique
+// y FK directa a Agent con onDelete: Cascade. AUDIT-37 está RESUELTO en el schema actual.
+// No requiere migración adicional.
+//
+// ── AUDIT-39 ────────────────────────────────────────────────────────────────────────────
+// Run.parentRunId, Run.parentStepId, Run.hierarchyRoot promovidos de
+// Run.metadata (JSON) a columnas explícitas con índices.
+// HierarchyStatusService debe migrar:
+//   ANTES: where: { metadata: { path: ['parentRunId'], equals: id } }
+//   DESPUÉS: where: { parentRunId: id }
+// Ejecutar scripts/migrate-run-hierarchy.ts para backfill de datos existentes.
+//
+// ── AUDIT-38 ────────────────────────────────────────────────────────────────────────────
+// AuditEvent.workspaceId: planificado para migración F4-observabilidad.
+// El modelo actual usa scopeType/scopeId genéricos. Hacer workspaceId NOT NULL
+// requiere rellenar todos los call sites de AuditEvent (20-50 ubicaciones).
+// Ver issue de seguimiento: [F4-OBS] AuditEvent.workspaceId obligatorio.
+// ───────────────────────────────────────────────────────────────────────────────────
 
 generator client {
   provider = "prisma-client-js"
@@ -58,7 +77,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// ─── Hierarchy ──────────────────────────────────────────────────────────────────────────────
+// ─── Hierarchy ────────────────────────────────────────────────────────────────────────────────────
 
 model Agency {
   id           String       @id @default(uuid())
@@ -170,7 +189,7 @@ model Subagent {
   @@unique([agentId, slug])
 }
 
-// ─── Skills / Tools ────────────────────────────────────────────────────────────────────────────
+// ─── Skills / Tools ────────────────────────────────────────────────────────────────────────────────────────
 
 model Skill {
   id          String   @id @default(uuid())
@@ -210,7 +229,7 @@ model SubagentSkill {
   @@id([subagentId, skillId])
 }
 
-// ─── Flows ──────────────────────────────────────────────────────────────────────────────────
+// ─── Flows ───────────────────────────────────────────────────────────────────────────────────────
 
 model Flow {
   id          String   @id @default(uuid())
@@ -229,7 +248,7 @@ model Flow {
   runs Run[]
 }
 
-// ─── Runs ────────────────────────────────────────────────────────────────────────────────────
+// ─── Runs ──────────────────────────────────────────────────────────────────────────────────────
 
 model Run {
   id           String    @id @default(uuid())
@@ -251,11 +270,40 @@ model Run {
   metadata     Json?
   createdAt    DateTime  @default(now())
 
+  // ─── AUDIT-39: jerarquía explícita (promovida de metadata) ─────────────────────────
+  // Antes estos valores vivían en Run.metadata como keys JSON, lo que
+  // obligaba a HierarchyStatusService a usar path operators de Postgres o
+  // filtros en memoria — costoso y no indexable.
+  //
+  // MIGRACIÓN: ejecutar scripts/migrate-run-hierarchy.ts para backfill.
+  // HierarchyStatusService debe usar estos campos directamente:
+  //   ANTES: where: { metadata: { path: ['parentRunId'], equals: id } }
+  //   DESPUÉS: where: { parentRunId: id }
+
+  /// ID del Run padre que lanzó este Run (null = run raíz).
+  /// Self-relation "RunHierarchy" — indexado para queries de hijos.
+  parentRunId    String?
+  parentRun      Run?    @relation("RunHierarchy", fields: [parentRunId], references: [id], onDelete: SetNull)
+  childRuns      Run[]   @relation("RunHierarchy")
+
+  /// ID del RunStep padre que lanzó este Run (null si fue lanzado directamente).
+  /// Permite reconstruir el árbol completo Runs ↔ RunSteps.
+  parentStepId   String?
+  parentStep     RunStep? @relation("StepChildRuns", fields: [parentStepId], references: [id], onDelete: SetNull)
+
+  /// ID del Run raíz del árbol de ejecución — desnormalizado para queries rápidas.
+  /// Null si este Run es el raíz. Permite obtener todos los Runs de un árbol
+  /// con un único WHERE hierarchyRoot = :rootId sin joins recursivos.
+  hierarchyRoot  String?
+
   steps RunStep[]
 
   @@index([flowId, status])
   /// D-10: índice corregido — agrega status al compuesto
   @@index([agencyId, status, createdAt])
+  /// AUDIT-39: índices para HierarchyStatusService
+  @@index([parentRunId])
+  @@index([hierarchyRoot])
 }
 
 model RunStep {
@@ -279,6 +327,9 @@ model RunStep {
   retryCount  Int       @default(0)
   startedAt   DateTime  @default(now())
   completedAt DateTime?
+
+  /// AUDIT-39: Runs hijos lanzados desde este RunStep.
+  childRuns   Run[]     @relation("StepChildRuns")
 
   /// D-10: índices de performance obligatorios
   @@index([runId, status])
@@ -308,9 +359,9 @@ enum BotStatus {
   webhook_error
 }
 
-// ─── Gateway / Channels ─────────────────────────────────────────────────────────────────────
+// ─── Gateway / Channels ───────────────────────────────────────────────────────────────────────────────────
 
-/// AUDIT-25: isActive es el ÚNICO campo de estado persistido en ChannelConfig.
+/// AUDIT-25: isActive es el Único campo de estado persistido en ChannelConfig.
 /// Los campos status/errorMessage/lastStartedAt/lastStoppedAt han sido ELIMINADOS.
 /// El estado en memoria (RuntimeChannelStatus) vive en channel-lifecycle.service.ts.
 ///
@@ -417,7 +468,7 @@ model ConversationMessage {
   @@index([scopeId, createdAt])
 }
 
-// ─── n8n Integration ─────────────────────────────────────────────────────────────────────────────
+// ─── n8n Integration ──────────────────────────────────────────────────────────────────────────────────────
 
 model N8nConnection {
   id              String   @id @default(uuid())
@@ -450,7 +501,7 @@ model N8nWorkflow {
   @@unique([connectionId, n8nWorkflowId])
 }
 
-// ─── Provider Credentials ────────────────────────────────────────────────────────────────────────────
+// ─── Provider Credentials ────────────────────────────────────────────────────────────────────────────────────
 
 model ProviderCredential {
   id               String    @id @default(uuid())
@@ -472,7 +523,7 @@ model ProviderCredential {
   @@index([agencyId, type, isActive])
 }
 
-// ─── Model Catalog ─────────────────────────────────────────────────────────────────────────────
+// ─── Model Catalog ───────────────────────────────────────────────────────────────────────────────────────
 
 model ModelCatalogEntry {
   id           String             @id @default(uuid())
@@ -492,7 +543,7 @@ model ModelCatalogEntry {
   @@index([modelId])
 }
 
-// ─── Budget / Model Policies ──────────────────────────────────────────────────────────────────────
+// ─── Budget / Model Policies ──────────────────────────────────────────────────────────────────────────────────
 
 model BudgetPolicy {
   id         String   @id @default(uuid())
@@ -533,8 +584,18 @@ model ModelPolicy {
   agent      Agent?      @relation("AgentModel",      fields: [agentId],      references: [id], onDelete: Cascade)
 }
 
-// ─── Audit ────────────────────────────────────────────────────────────────────────────────────
+// ─── Audit ───────────────────────────────────────────────────────────────────────────────────────
 
+/// TODO(AUDIT-38): Planificado para migración F4-observabilidad.
+/// El modelo actual usa scopeType/scopeId genéricos (string libre).
+/// Para trazabilidad completa por workspace se necesita:
+///   workspaceId  String  (NOT NULL con FK a Workspace)
+///   agencyId     String? (opcional, para filtros de dashboard)
+///   departmentId String? (opcional)
+///   agentId      String? (opcional, para logs de agente específico)
+/// Hacer workspaceId NOT NULL requiere rellenar todos los call sites de AuditEvent
+/// (estimado 20–50 ubicaciones en gateway, API y run-engine).
+/// Coordinación con F4-observabilidad para hacerlo en una sola migración.
 model AuditEvent {
   id        String   @id @default(uuid())
   eventType String
@@ -549,7 +610,7 @@ model AuditEvent {
   @@index([userId, createdAt])
 }
 
-// ─── System Config (single-tenant settings) ──────────────────────────────────────────────
+// ─── System Config (single-tenant settings) ───────────────────────────────────────────────────
 //
 // Almacena API keys y URLs configuradas desde Settings UI.
 // Sin cifrado — mismo nivel de confianza que process.env / .env en disco.

--- a/scripts/migrate-run-hierarchy.ts
+++ b/scripts/migrate-run-hierarchy.ts
@@ -1,0 +1,125 @@
+/**
+ * scripts/migrate-run-hierarchy.ts — AUDIT-39
+ *
+ * Backfill migration: promueve parentRunId, parentStepId y hierarchyRoot
+ * desde Run.metadata (JSON) a las nuevas columnas explícitas.
+ *
+ * Ejecutar UNA VEZ después de aplicar la migración de schema AUDIT-39:
+ *   pnpm prisma migrate deploy  # aplica la migración de schema
+ *   pnpm tsx scripts/migrate-run-hierarchy.ts
+ *
+ * Flags:
+ *   --dry-run   Imprime qué se actualizaría sin escribir en BD
+ *
+ * Idempotencia:
+ *   El script solo procesa Runs donde alguna columna explícita está null
+ *   y metadata tiene el valor correspondiente. Seguro relanzar.
+ *
+ * @module migrate-run-hierarchy
+ */
+
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+const DRY_RUN = process.argv.includes('--dry-run')
+
+async function main(): Promise<void> {
+  console.log(
+    `[migrate-run-hierarchy] Starting backfill${DRY_RUN ? ' (DRY RUN — no writes)' : ''}...`,
+  )
+
+  // Encuentra Runs que tienen datos en metadata pero columnas explícitas null.
+  // Carga en batches de 500 para no saturar memoria en tablas grandes.
+  const BATCH_SIZE = 500
+  let offset = 0
+  let totalProcessed = 0
+  let totalUpdated = 0
+
+  while (true) {
+    const batch = await prisma.run.findMany({
+      where: {
+        metadata: { not: null },
+        // Solo Runs que aún no tienen las columnas rellenadas
+        AND: [
+          {
+            OR: [
+              { parentRunId: null },
+              { parentStepId: null },
+              { hierarchyRoot: null },
+            ],
+          },
+        ],
+      },
+      select: {
+        id:            true,
+        metadata:      true,
+        parentRunId:   true,
+        parentStepId:  true,
+        hierarchyRoot: true,
+      },
+      skip:  offset,
+      take:  BATCH_SIZE,
+    })
+
+    if (batch.length === 0) break
+    offset += batch.length
+    totalProcessed += batch.length
+
+    for (const run of batch) {
+      const meta = (run.metadata ?? {}) as Record<string, unknown>
+
+      const newParentRunId   = (meta['parentRunId']   as string | undefined) ?? null
+      const newParentStepId  = (meta['parentStepId']  as string | undefined) ?? null
+      const newHierarchyRoot = (meta['hierarchyRoot'] as string | undefined) ?? null
+
+      // Solo actualiza si hay algo que cambiar
+      const hasChanges =
+        (newParentRunId   !== null && run.parentRunId   === null) ||
+        (newParentStepId  !== null && run.parentStepId  === null) ||
+        (newHierarchyRoot !== null && run.hierarchyRoot === null)
+
+      if (!hasChanges) continue
+
+      if (DRY_RUN) {
+        console.log(
+          `[dry-run] Run ${run.id}:`,
+          {
+            parentRunId:   newParentRunId,
+            parentStepId:  newParentStepId,
+            hierarchyRoot: newHierarchyRoot,
+          },
+        )
+      } else {
+        await prisma.run.update({
+          where: { id: run.id },
+          data: {
+            ...(newParentRunId   !== null ? { parentRunId:   newParentRunId   } : {}),
+            ...(newParentStepId  !== null ? { parentStepId:  newParentStepId  } : {}),
+            ...(newHierarchyRoot !== null ? { hierarchyRoot: newHierarchyRoot } : {}),
+          },
+        })
+      }
+
+      totalUpdated++
+    }
+
+    if (totalProcessed % 100 === 0 || batch.length < BATCH_SIZE) {
+      console.log(
+        `[migrate-run-hierarchy] Processed ${totalProcessed} rows, updated ${totalUpdated}...`,
+      )
+    }
+  }
+
+  console.log(
+    `[migrate-run-hierarchy] Done. Processed: ${totalProcessed}, Updated: ${totalUpdated}${
+      DRY_RUN ? ' (DRY RUN — nothing written)' : ''
+    }`,
+  )
+}
+
+main()
+  .catch((err: unknown) => {
+    console.error('[migrate-run-hierarchy] Fatal error:', err)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())


### PR DESCRIPTION
## Resumen

Implementa los 4 puntos de deuda técnica AUDIT-37 a AUDIT-40 identificados en el Plan Maestro. Ninguno bloquea CI.

---

## AUDIT-40 — `list()` + `listAdapters()` en `ChannelAdapterRegistry` ✅

**Archivo:** `packages/gateway-sdk/src/channel-adapter.ts`

El registry exponía `register`, `deregister`, `get`, `has`, `registeredTypes` pero sin forma de enumerar todos los adapters activos. Añadidos dos métodos:

```typescript
// Inventario completo con tipo
registry.list()         // Array<{ type: string; adapter: IChannelAdapter }>

// Solo los adapters (conveniente para iteración)
registry.listAdapters() // IChannelAdapter[]
```

Usos inmediatos:
- `GET /gateway/health` puede listar `registry.list().map(({ type }) => ({ type, status: 'active' }))`
- Restart en cascada: `await Promise.all(registry.listAdapters().map(a => a.teardown({}, {})))`

---

## AUDIT-37 — BudgetPolicy FK a Agent — **YA ESTABA IMPLEMENTADO** ✅

El schema ya usa el patrón exactly-one-FK con `agentId String? @unique` + `onDelete: Cascade`. No requería cambio. Documentado en el schema y cerrado con issue #215.

---

## AUDIT-39 — `Run` jerarquía explícita (columnas + índices) ✅

**Archivo:** `prisma/schema.prisma`

Promovidos 3 campos de `Run.metadata` (JSON opaco) a columnas explícitas indexadas:

| Campo | Tipo | Propósito |
|---|---|---|
| `parentRunId` | `String?` | Self-FK con relación `RunHierarchy` |
| `parentStepId` | `String?` | FK a `RunStep` que lanzó este Run |
| `hierarchyRoot` | `String?` | ID del Run raíz (desnormalizado) |

Índices añadidos: `@@index([parentRunId])` + `@@index([hierarchyRoot])`

**`HierarchyStatusService` debe migrar:**
```typescript
// ANTES (full-scan, lento)
where: { metadata: { path: ['parentRunId'], equals: runId } }
// DESPUÉS (Index Scan, rápido)
where: { parentRunId: runId }
```

**Backfill:** `scripts/migrate-run-hierarchy.ts` — idempotente, soporta `--dry-run`.

```bash
pnpm prisma migrate dev --name "run-hierarchy-columns"
pnpm tsx scripts/migrate-run-hierarchy.ts --dry-run  # verificar
pnpm tsx scripts/migrate-run-hierarchy.ts            # aplicar
```

---

## AUDIT-38 — `AuditEvent.workspaceId` — Planificado para F4 📋

Añadido `TODO(AUDIT-38)` en `prisma/schema.prisma` sobre el modelo `AuditEvent`. El campo requiere rellenar 20-50 call sites distribuidos en todo el monorepo — se coordina con la migración de observabilidad de F4.

Issue de seguimiento creado: #214

---

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `packages/gateway-sdk/src/channel-adapter.ts` | +`list()` +`listAdapters()` |
| `prisma/schema.prisma` | +`parentRunId`, `parentStepId`, `hierarchyRoot`, `@@index` en `Run`; TODO en `AuditEvent`; nota AUDIT-37 |
| `scripts/migrate-run-hierarchy.ts` | Nuevo — backfill AUDIT-39 |

## Issues

- Closes #AUDIT-40 (via commit `6b2dbd8`)
- Closes #AUDIT-39 (via commit `38e02a2`)
- Refs #214 (AUDIT-38 — pospuesto a F4)
- Refs #215 (AUDIT-37 — ya implementado, cerrado)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session context management with improved data structure.
  * Added adapter registry listing capabilities for improved system management.

* **Improvements**
  * Better execution hierarchy tracking providing enhanced visibility into operation workflows.

* **Chores**
  * Infrastructure updates including data migration for system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->