### PR TITLE
fix(F3a-02): update WebChatAdapter + all channel adapters to IncomingMessage contract

### DIFF
--- a/apps/gateway/src/channels/webchat.adapter.ts
+++ b/apps/gateway/src/channels/webchat.adapter.ts
@@ -20,14 +20,13 @@
 
 import { WebSocketServer, WebSocket, type RawData } from 'ws'
 import type { IncomingMessage as HttpIncomingMessage, Server } from 'http'
+import type { PrismaClient } from '@prisma/client'
 import { PrismaService } from '../prisma/prisma.service.js'
 import {
   BaseChannelAdapter,
   type IncomingMessage,
   type OutgoingMessage,
 } from './channel-adapter.interface.js'
-
-const db = new PrismaService()
 
 // ── Tipos de frame ──────────────────────────────────────────────────────
 
@@ -64,11 +63,25 @@ interface ActiveConnection {
 export class WebChatAdapter extends BaseChannelAdapter {
   readonly channel = 'webchat'
 
+  // Instancia de PrismaClient — inyectada por constructor o lazy-init
+  private readonly db: PrismaClient
+
   // WebSocketServer — se adjunta al httpServer en initialize()
   private wss: WebSocketServer | null = null
 
   // sessionId → lista de conexiones activas (multi-tab support)
   private readonly connections = new Map<string, ActiveConnection[]>()
+
+  /**
+   * @param prisma — instancia compartida de PrismaClient.
+   *   Si no se pasa, se crea una instancia local via PrismaService (fallback
+   *   para compatibilidad con código antiguo). En producción siempre pasar
+   *   la instancia compartida del servidor para evitar pool exhaustion.
+   */
+  constructor(prisma?: PrismaClient) {
+    super()
+    this.db = prisma ?? (new PrismaService() as unknown as PrismaClient)
+  }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────
 
@@ -87,7 +100,7 @@ export class WebChatAdapter extends BaseChannelAdapter {
   ): Promise<void> {
     this.channelConfigId = channelConfigId
 
-    const config = await db.channelConfig.findUnique({
+    const config = await this.db.channelConfig.findUnique({
       where: { id: channelConfigId },
     })
     if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`)
@@ -352,7 +365,7 @@ export class WebChatAdapter extends BaseChannelAdapter {
 
   private async sendHistory(conn: ActiveConnection): Promise<void> {
     try {
-      const session = await db.gatewaySession.findFirst({
+      const session = await this.db.gatewaySession.findFirst({
         where: {
           channelConfigId: this.channelConfigId,
           externalUserId:   conn.sessionId,
@@ -382,7 +395,7 @@ export class WebChatAdapter extends BaseChannelAdapter {
         throw new Error(`Missing agentId for WebChat session ${sessionId}`)
       }
 
-      await db.gatewaySession.upsert({
+      await this.db.gatewaySession.upsert({
         where: {
           channelConfigId_externalUserId: {
             channelConfigId: this.channelConfigId,
@@ -428,7 +441,7 @@ export class WebChatAdapter extends BaseChannelAdapter {
   }
 
   private async resolveAgentId(sessionId: string): Promise<string | null> {
-    const session = await db.gatewaySession.findFirst({
+    const session = await this.db.gatewaySession.findFirst({
       where: {
         channelConfigId: this.channelConfigId,
         externalUserId:  sessionId,

--- a/apps/gateway/src/routes/webchat.ts
+++ b/apps/gateway/src/routes/webchat.ts
@@ -40,20 +40,23 @@
 
 import { createHash }               from 'crypto';
 import { Router, type Request, type Response } from 'express';
-import { WebChatAdapter }           from '@agent-vs/gateway-sdk';
+import { registry, WebChatAdapter } from '@agent-vs/gateway-sdk';
 import type { GatewayService }      from '../gateway.service';
 
 // ---------------------------------------------------------------------------
-// Adapter cache: one WebChatAdapter per ChannelConfig row
+// Adapter lookup: always use the shared instance registered in server.ts
+// so that the same PrismaClient pool is reused (no per-channel leaks).
 // ---------------------------------------------------------------------------
 
-const adapterCache = new Map<string, WebChatAdapter>();
-
-function getAdapter(channelId: string): WebChatAdapter {
-  if (!adapterCache.has(channelId)) {
-    adapterCache.set(channelId, new WebChatAdapter());
+function getAdapter(_channelId: string): WebChatAdapter {
+  const adapter = registry.get('webchat');
+  if (!adapter || !(adapter instanceof WebChatAdapter)) {
+    throw new Error(
+      '[webchat] WebChatAdapter not found in registry. ' +
+      'Make sure registry.register(new WebChatAdapter(db)) is called in server.ts before mounting routes.',
+    );
   }
-  return adapterCache.get(channelId)!;
+  return adapter;
 }
 
 // ---------------------------------------------------------------------------
@@ -64,13 +67,13 @@ export function webchatGatewayRouter(gatewayService: GatewayService): Router {
   const router = Router();
   const timeoutMs = Number(process.env.WEBCHAT_QUEUE_TIMEOUT_MS ?? 60_000);
 
-  // ── SSE stream ─────────────────────────────────────────────────────────
+  // ── SSE stream ──────────────────────────────────────────────────────
   router.get('/:channelId/stream', (req: Request, res: Response): void => {
     const adapter = getAdapter(req.params.channelId);
     adapter.createSseHandler()(req, res);
   });
 
-  // ── Inbound message from browser ───────────────────────────────────────
+  // ── Inbound message from browser ─────────────────────────────────────
   //
   // FIXED race condition from previous version:
   //   Before: handler() resolved the queue immediately, then dispatch ran
@@ -145,7 +148,7 @@ export function webchatGatewayRouter(gatewayService: GatewayService): Router {
     }
   });
 
-  // ── Session bootstrap ───────────────────────────────────────────────────
+  // ── Session bootstrap ────────────────────────────────────────────────────
   //
   // Called by the web widget on first load to get a stable sessionId.
   // Derives a deterministic UUID from the fingerprint so the same browser

--- a/apps/gateway/src/server.ts
+++ b/apps/gateway/src/server.ts
@@ -29,7 +29,8 @@ export function createApp(opts: AppOptions = {}): Application {
   const db = opts.db ?? new PrismaClient();
 
   if (!registry.has('telegram')) registry.register(new TelegramAdapter());
-  if (!registry.has('webchat')) registry.register(new WebChatAdapter());
+  // Pass shared db to WebChatAdapter so it reuses the same PrismaClient pool
+  if (!registry.has('webchat')) registry.register(new WebChatAdapter(db));
 
   applySecurityMiddleware(app, {
     corsOrigins: opts.corsOrigins,


### PR DESCRIPTION
## Resumen

Corrige los dos issues de contrato del gateway:

### #134 — WebChatAdapter sin PrismaClient compartido

**Problema:** `webchat.adapter.ts` creaba `const db = new PrismaService()` a nivel módulo (singleton hardcodeado), y `routes/webchat.ts` creaba instancias adicionales de `WebChatAdapter` por canal — cada una con su propio pool de conexiones Prisma.

**Fix:**
- `WebChatAdapter` acepta ahora un `PrismaClient` opcional en el constructor. Si no se pasa, hace fallback a `new PrismaService()` para retro-compatibilidad.
- `server.ts`: `registry.register(new WebChatAdapter(db))` — pasa la instancia compartida.
- `routes/webchat.ts`: eliminado el `adapterCache` local con `new WebChatAdapter()`. Ahora usa `registry.get('webchat')` para reutilizar el adapter ya registrado en `server.ts`.

### #133 — IncomingMessage sin channelConfigId + channelType

Verificado post-F2: todos los adapters (telegram, whatsapp, discord, slack, webchat) ya emiten `IncomingMessage` con `channelConfigId`, `channelType` y `senderId` correctos. El contrato está completamente cumplido. Issue cerrado con comentario explicativo.

## Commits

- `fix(F3a-02): pass shared PrismaClient to WebChatAdapter` (webchat.adapter.ts)
- `fix(F3a-02): pass shared PrismaClient to WebChatAdapter` (server.ts)
- `fix(F3a-02): remove local WebChatAdapter instantiation in webchat routes`

Closes #133 #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database connection handling in the webchat adapter for more efficient resource management and shared connection pooling across the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->