### PR TITLE
fix(channels-ui): sync CHANNEL_KINDS + SSE guard + Slack/Teams form fields

### DIFF
--- a/apps/web/src/features/settings/components/ChannelsSettingsTab.tsx
+++ b/apps/web/src/features/settings/components/ChannelsSettingsTab.tsx
@@ -8,13 +8,15 @@ import {
   deleteChannel, subscribeChannelStatus,
 } from '../../../lib/channels-api';
 
-// AUDIT-23: añadidos slack y webhook alineados con enum ChannelKind del schema Prisma
+// FIX-1: 7 entries — added 'teams' and 'webhook' to match ChannelKind enum
 const CHANNEL_KINDS: { kind: ChannelKind; label: string; needsToken: boolean }[] = [
-  { kind: 'telegram',  label: 'Telegram',  needsToken: true },
-  { kind: 'whatsapp',  label: 'WhatsApp',  needsToken: true },
-  { kind: 'discord',   label: 'Discord',   needsToken: true },
-  { kind: 'webchat',   label: 'Web Chat',  needsToken: false },
-  { kind: 'slack',     label: 'Slack',     needsToken: true },
+  { kind: 'telegram',  label: 'Telegram',        needsToken: true  },
+  { kind: 'whatsapp',  label: 'WhatsApp',         needsToken: true  },
+  { kind: 'discord',   label: 'Discord',          needsToken: true  },
+  { kind: 'webchat',   label: 'Web Chat',         needsToken: false },
+  { kind: 'slack',     label: 'Slack',            needsToken: true  },
+  { kind: 'teams',     label: 'Microsoft Teams',  needsToken: true  },
+  { kind: 'webhook',   label: 'Webhook',          needsToken: false },
 ];
 
 // AUDIT-25: STATUS_ICON alineado con enum ChannelStatus del schema Prisma
@@ -35,15 +37,22 @@ const STATUS_LABEL: Record<ChannelRecord['status'], string> = {
   error:       'Error',
 };
 
+// FIX-2: valid statuses set — guard against unexpected SSE values
+// Placed here alongside STATUS_LABEL so all status-related constants are grouped.
+const VALID_STATUSES = new Set<string>(['provisioned', 'bound', 'error', 'offline']);
+
 interface Props {
   workspaceId: string;
   agents: { id: string; name: string }[];
 }
 
+// FIX-3: AddForm extended with appId + appSecret for Slack / Teams
 interface AddForm {
-  kind: ChannelKind;
-  name: string;
-  token: string;
+  kind:      ChannelKind;
+  name:      string;
+  token:     string;   // Telegram, WhatsApp, Discord
+  appId:     string;   // Slack, Teams
+  appSecret: string;   // Slack, Teams
 }
 
 export function ChannelsSettingsTab({ workspaceId, agents }: Props) {
@@ -55,9 +64,13 @@ export function ChannelsSettingsTab({ workspaceId, agents }: Props) {
   const sseCleanups             = useRef<Map<string, () => void>>(new Map());
 
   const { register, handleSubmit, watch, reset, formState: { errors } } =
-    useForm<AddForm>({ defaultValues: { kind: 'telegram', name: '', token: '' } });
-  const selectedKind = watch('kind');
-  const needsToken = CHANNEL_KINDS.find((c) => c.kind === selectedKind)?.needsToken ?? false;
+    useForm<AddForm>({
+      defaultValues: { kind: 'telegram', name: '', token: '', appId: '', appSecret: '' },
+    });
+  const selectedKind       = watch('kind');
+  const needsToken         = CHANNEL_KINDS.find((c) => c.kind === selectedKind)?.needsToken ?? false;
+  // FIX-3: helper — Slack and Teams need appId + appSecret instead of a plain bot token
+  const needsAppCredentials = selectedKind === 'slack' || selectedKind === 'teams';
 
   const load = useCallback(async () => {
     setLoading(true); setErr(null);
@@ -79,8 +92,12 @@ export function ChannelsSettingsTab({ workspaceId, agents }: Props) {
     channels.forEach((ch) => {
       if (!map.has(ch.id)) {
         const unsub = subscribeChannelStatus(workspaceId, ch.id, (data) => {
+          // FIX-2: guard — discard unexpected status values before casting
+          if (!VALID_STATUSES.has(data.status)) return;
           setChannels((prev) =>
-            prev.map((c) => c.id === ch.id ? { ...c, status: data.status as ChannelRecord['status'] } : c),
+            prev.map((c) =>
+              c.id === ch.id ? { ...c, status: data.status as ChannelRecord['status'] } : c,
+            ),
           );
         });
         map.set(ch.id, unsub);
@@ -96,10 +113,13 @@ export function ChannelsSettingsTab({ workspaceId, agents }: Props) {
   async function handleAdd(values: AddForm) {
     setBusy('new'); setErr(null);
     try {
+      // FIX-3: route credentials correctly based on kind
       await provisionChannel(workspaceId, {
-        kind: values.kind,
-        name: values.name,
-        token: values.token || undefined,
+        kind:      values.kind,
+        name:      values.name,
+        token:     needsAppCredentials ? undefined              : (values.token     || undefined),
+        appId:     needsAppCredentials ? (values.appId     || undefined) : undefined,
+        appSecret: needsAppCredentials ? (values.appSecret || undefined) : undefined,
       });
       reset();
       setShowAdd(false);
@@ -142,8 +162,9 @@ export function ChannelsSettingsTab({ workspaceId, agents }: Props) {
       <div className="flex items-center justify-between">
         <div>
           <h3 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>Channels</h3>
+          {/* FIX-1: header text updated to include Teams and Webhook */}
           <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-            Connect Telegram, WhatsApp, Discord, Slack, or Web Chat. Tokens are encrypted at rest.
+            Connect Telegram, WhatsApp, Discord, Slack, Web Chat, Teams, or Webhook. Tokens are encrypted at rest.
           </p>
         </div>
         <button
@@ -191,17 +212,44 @@ export function ChannelsSettingsTab({ workspaceId, agents }: Props) {
             </div>
           </div>
 
-          {needsToken && (
+          {/* FIX-3: simple bot token for telegram/whatsapp/discord */}
+          {needsToken && !needsAppCredentials && (
             <div>
-              <label className="block text-xs text-[var(--text-muted)] mb-1">Bot Token / Credential</label>
+              <label className="block text-xs text-[var(--text-muted)] mb-1">Bot Token</label>
               <input
-                {...register('token', { required: needsToken ? 'Token required' : false })}
+                {...register('token', { required: 'Token required' })}
                 type="password"
                 autoComplete="off"
-                placeholder="Paste token…"
+                placeholder="Paste bot token…"
                 className="w-full rounded-lg border border-[var(--input-border)] bg-[var(--input-bg)] px-3 py-2 text-sm text-[var(--input-text)] focus:outline-none"
               />
               {errors.token && <p className="text-xs text-red-500 mt-0.5">{errors.token.message}</p>}
+            </div>
+          )}
+
+          {/* FIX-3: appId + appSecret grid for slack/teams */}
+          {needsAppCredentials && (
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-[var(--text-muted)] mb-1">App ID</label>
+                <input
+                  {...register('appId', { required: 'App ID required' })}
+                  placeholder="App ID…"
+                  className="w-full rounded-lg border border-[var(--input-border)] bg-[var(--input-bg)] px-3 py-2 text-sm text-[var(--input-text)] focus:outline-none"
+                />
+                {errors.appId && <p className="text-xs text-red-500 mt-0.5">{errors.appId.message}</p>}
+              </div>
+              <div>
+                <label className="block text-xs text-[var(--text-muted)] mb-1">App Secret</label>
+                <input
+                  {...register('appSecret', { required: 'App Secret required' })}
+                  type="password"
+                  autoComplete="off"
+                  placeholder="App Secret…"
+                  className="w-full rounded-lg border border-[var(--input-border)] bg-[var(--input-bg)] px-3 py-2 text-sm text-[var(--input-text)] focus:outline-none"
+                />
+                {errors.appSecret && <p className="text-xs text-red-500 mt-0.5">{errors.appSecret.message}</p>}
+              </div>
             </div>
           )}
 

--- a/apps/web/src/lib/channels-api.ts
+++ b/apps/web/src/lib/channels-api.ts
@@ -14,14 +14,20 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-// ─── Channels ────────────────────────────────────────────────────────────────
+// ─── Channels ───────────────────────────────────────────────────────────────────────────────
 export function listChannels(workspaceId: string) {
   return request<ChannelRecord[]>(`/workspaces/${workspaceId}/channels`);
 }
 
 export function provisionChannel(
   workspaceId: string,
-  payload: { kind: ChannelKind; name: string; token?: string; appId?: string; secret?: string },
+  payload: {
+    kind:       ChannelKind;
+    name:       string;
+    token?:     string;   // Telegram, WhatsApp, Discord
+    appId?:     string;   // Slack, Teams
+    appSecret?: string;   // Slack, Teams (renamed from 'secret' for clarity)
+  },
 ) {
   return request<ChannelRecord>(`/workspaces/${workspaceId}/channels/provision`, {
     method: 'POST',
@@ -59,7 +65,7 @@ export function subscribeChannelStatus(
   return () => es.close();
 }
 
-// ─── LLM Providers ───────────────────────────────────────────────────────────
+// ─── LLM Providers ───────────────────────────────────────────────────────────────────────
 export function listLlmProviders(workspaceId: string) {
   return request<LlmProviderRecord[]>(`/workspaces/${workspaceId}/llm-providers`);
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,1 +1,65 @@
-aW1wb3J0IHR5cGUgewogIENhbm9uaWNhbFN0dWRpb1N0YXRlLAogIENvcmVGaWxlRGlmZiwKICBXb3Jrc3BhY2VTcGVjQ2Fub25pY2FsLAp9IGZyb20gJy4uLy4uLy4uLy4uL3BhY2thZ2VzL2NvcmUtdHlwZXMvc3JjL3N0dWRpby1jYW5vbmljYWwnOwppbXBvcnQgdHlwZSB7IEFnZW50U3BlYywgRmxvd1NwZWMsIFByb2ZpbGVTcGVjLCBTa2lsbFNwZWMsIFdvcmtzcGFjZVNwZWMgfSBmcm9tICcuL3R5cGVzLWJhc2UnOwoKLy8gQVVESVQtMzE6IHNpbmNyb25pemFkbyBjb24gZW51bSBDaGFubmVsS2luZCBkZWwgc2NoZW1hIFByaXNtYQovLyAgICAgICAgICAgKEFVRElULTMwIGHDsWFkaW8gc2xhY2sgeSB0ZWFtcyBhbCBlbnVtKQpleHBvcnQgdHlwZSBDaGFubmVsS2luZCA9CiAgfCAndGVsZWdyYW0nCiAgfCAnd2hhdHNhcHAnCiAgfCAnZGlzY29yZCcKICB8ICd3ZWJjaGF0JwogIHwgJ3NsYWNrJwogIHwgJ3RlYW1zJzsKCi8vIEFVRElULTMxOiBzdGF0dXMgYWxpbmVhZG8gY29uIGVudW0gQ2hhbm5lbFN0YXR1cyBkZWwgc2NoZW1hIFByaXNtYToKLy8gICBBTlRFUzogJ2lkbGUnIHwgJ3Byb3Zpc2lvbmluZycgfCAnYWN0aXZlJyB8ICdlcnJvcicgICAgIChpbmNvcnJlY3RvKQovLyAgIERFU1BVw4lTOiAncHJvdmlzaW9uZWQnIHwgJ2JvdW5kJyB8ICdlcnJvcicgfCAnb2ZmbGluZScgIChvcmFjbGUgZGUgREIpCmV4cG9ydCBpbnRlcmZhY2UgQ2hhbm5lbFJlY29yZCB7CiAgaWQ6IHN0cmluZzsKICB3b3Jrc3BhY2VJZDogc3RyaW5nOwogIGtpbmQ6IENoYW5uZWxLaW5kOwogIG5hbWU6IHN0cmluZzsKICBzdGF0dXM6ICdwcm92aXNpb25lZCcgfCAnYm91bmQnIHwgJ2Vycm9yJyB8ICdvZmZsaW5lJzsKICBhZ2VudElkOiBzdHJpbmcgfCBudWxsOwogIGNyZWF0ZWRBdDogc3RyaW5nOwogIHVwZGF0ZWRBdDogc3RyaW5nOwp9CgpleHBvcnQgaW50ZXJmYWNlIExsbVByb3ZpZGVyUmVjb3JkIHsKICBpZDogc3RyaW5nOwogIHdvcmtzcGFjZUlkOiBzdHJpbmc7CiAgcHJvdmlkZXI6IHN0cmluZzsKICBsYWJlbDogc3RyaW5nOwogIG1hc2tlZEtleTogc3RyaW5nOwogIGlzRGVmYXVsdDogYm9vbGVhbjsKICBjcmVhdGVkQXQ6IHN0cmluZzsKfQoKZXhwb3J0IGludGVyZmFjZSBTdHVkaW9TdGF0ZVJlc3BvbnNlIHsKICB3b3Jrc3BhY2U6IFdvcmtzcGFjZVNwZWMgfCBudWxsOwogIGFnZW50czogQWdlbnRTcGVjW107CiAgc2tpbGxzOiBTa2lsbFNwZWNbXTsKICBmbG93czogRmxvd1NwZWNbXTsKICBwb2xpY2llczogQXJyYXk8eyBpZDogc3RyaW5nOyBuYW1lOiBzdHJpbmcgfT47CiAgcHJvZmlsZXM6IFByb2ZpbGVTcGVjW107CiAgY29tcGlsZTogeyBhcnRpZmFjdHM6IHVua25vd25bXTsgZGlhZ25vc3RpY3M6IHN0cmluZ1tdIH07CiAgcnVudGltZTogewogICAgaGVhbHRoOiB7IG9rOiBib29sZWFuOyBba2V5OiBzdHJpbmddOiB1bmtub3duIH07CiAgICBkaWFnbm9zdGljczogUmVjb3JkPHN0cmluZywgdW5rbm93bj47CiAgICBzZXNzaW9uczogeyBvazogYm9vbGVhbjsgcGF5bG9hZD86IHVua25vd25bXSB9OwogIH07CiAgZ2VuZXJhdGVkQXQ6IHN0cmluZzsKfQoKZXhwb3J0IHR5cGUgQ2Fub25pY2FsU3R1ZGlvU3RhdGVSZXNwb25zZSA9IENhbm9uaWNhbFN0dWRpb1N0YXRlOwpleHBvcnQgdHlwZSBDb3JlRmlsZXNEaWZmUmVzcG9uc2UgPSB7IHNuYXBzaG90SWQ/OiBzdHJpbmc7IGRpZmZzOiBDb3JlRmlsZURpZmZbXTsgZ2VuZXJhdGVkQXQ/OiBzdHJpbmcgfTsKZXhwb3J0IHR5cGUgQ29yZUZpbGVzUHJldmlld1Jlc3BvbnNlID0geyBzbmFwc2hvdElkPzogc3RyaW5nOyBhcnRpZmFjdHM6IHVua25vd25bXTsgZGlhZ25vc3RpY3M6IHN0cmluZ1tdOyBnZW5lcmF0ZWRBdD86IHN0cmluZyB9OwoKZXhwb3J0ICogZnJvbSAnLi90eXBlcy1iYXNlJzsKZXhwb3J0IHR5cGUgKiBmcm9tICcuLi8uLi8uLi8uLi9wYWNrYWdlcy9jb3JlLXR5cGVzL3NyYy9zdHVkaW8tY2Fub25pY2FsJzsK
+import type {
+  CanonicalStudioState,
+  CoreFileDiff,
+  WorkspaceSpecCanonical,
+} from '../../../../packages/core-types/src/studio-canonical';
+import type { AgentSpec, FlowSpec, ProfileSpec, SkillSpec, WorkspaceSpec } from './types-base';
+
+// AUDIT-31: sincronizado con enum ChannelKind del schema Prisma
+//           (AUDIT-30 añadió slack y teams al enum)
+//           fix(channels-ui): añadido 'webhook' para completar el enum
+export type ChannelKind =
+  | 'telegram'
+  | 'whatsapp'
+  | 'discord'
+  | 'webchat'
+  | 'slack'
+  | 'teams'
+  | 'webhook';
+
+// AUDIT-31: status alineado con enum ChannelStatus del schema Prisma:
+//   ANTES: 'idle' | 'provisioning' | 'active' | 'error'    (incorrecto)
+//   DESPUÉS: 'provisioned' | 'bound' | 'error' | 'offline'  (oracle de DB)
+export interface ChannelRecord {
+  id: string;
+  workspaceId: string;
+  kind: ChannelKind;
+  name: string;
+  status: 'provisioned' | 'bound' | 'error' | 'offline';
+  agentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LlmProviderRecord {
+  id: string;
+  workspaceId: string;
+  provider: string;
+  label: string;
+  maskedKey: string;
+  isDefault: boolean;
+  createdAt: string;
+}
+
+export interface StudioStateResponse {
+  workspace: WorkspaceSpec | null;
+  agents: AgentSpec[];
+  skills: SkillSpec[];
+  flows: FlowSpec[];
+  policies: Array<{ id: string; name: string }>;
+  profiles: ProfileSpec[];
+  compile: { artifacts: unknown[]; diagnostics: string[] };
+  runtime: {
+    health: { ok: boolean; [key: string]: unknown };
+    diagnostics: Record<string, unknown>;
+    sessions: { ok: boolean; payload?: unknown[] };
+  };
+  generatedAt: string;
+}
+
+export type CanonicalStudioStateResponse = CanonicalStudioState;
+export type CoreFilesDiffResponse = { snapshotId?: string; diffs: CoreFileDiff[]; generatedAt?: string };
+export type CoreFilesPreviewResponse = { snapshotId?: string; artifacts: unknown[]; diagnostics: string[]; generatedAt?: string };
+
+export * from './types-base';
+export type * from '../../../../packages/core-types/src/studio-canonical';


### PR DESCRIPTION
## Resumen

Tres fixes de UI en `ChannelsSettingsTab.tsx` más pre-requisitos en `types.ts` y `channels-api.ts`.

---

### FIX 1 — `CHANNEL_KINDS` y header description

**Problema:** `CHANNEL_KINDS` solo tenía 5 entradas. Si un canal `teams` o `webhook` existía en DB, su `kind` se mostraba como texto crudo (el valor del enum) en la columna de la lista.

**Fix:**
- Añadidas 2 entradas: `{ kind: 'teams', label: 'Microsoft Teams', needsToken: true }` y `{ kind: 'webhook', label: 'Webhook', needsToken: false }`
- Header description actualizado: `"Connect Telegram, WhatsApp, Discord, Slack, Web Chat, Teams, or Webhook."`
- `'webhook'` añadido a `ChannelKind` en `types.ts` (faltaba — `'teams'` ya estaba desde AUDIT-30)

---

### FIX 2 — SSE status guard

**Problema:** `subscribeChannelStatus` casteaba `data.status` directamente a `ChannelRecord['status']` sin validar que fuera un valor esperado. Si el servidor enviaba un valor fuera del enum (p.ej. `'active'` del enum antiguo, o un typo), el componente actualizaba el estado con un valor inválido, rompiendo `STATUS_ICON` y `STATUS_LABEL` (acceso con clave no existente → `undefined`).

**Fix:**
- `VALID_STATUSES = new Set(['provisioned', 'bound', 'error', 'offline'])` — constante de módulo, agrupada junto a `STATUS_LABEL`
- Guard `if (!VALID_STATUSES.has(data.status)) return;` antes del cast y `setChannels`

---

### FIX 3 — Campos `appId` + `appSecret` para Slack / Teams

**Problema:** El form mostraba un único campo "Bot Token" para todos los kinds con `needsToken=true`. Slack y Teams no usan un bot token sino App ID + App Secret — provisionar con el campo incorrecto fallaba silenciosamente en el backend.

**Fix:**
- `AddForm` extendido con `appId: string` y `appSecret: string`
- `needsAppCredentials = selectedKind === 'slack' || selectedKind === 'teams'`
- Form condicional:
  - `needsToken && !needsAppCredentials` → input `Bot Token` (Telegram, WhatsApp, Discord)
  - `needsAppCredentials` → grid 2 cols con `App ID` + `App Secret` (Slack, Teams)
- `handleAdd` enruta los campos correctamente según `needsAppCredentials`
- `channels-api.ts` renombrado campo `secret` → `appSecret` en el tipo del payload de `provisionChannel` para consistencia

---

## Archivos cambiados

| Archivo | Cambio |
|---------|--------|
| `apps/web/src/lib/types.ts` | `+webhook` a `ChannelKind` |
| `apps/web/src/lib/channels-api.ts` | `secret` → `appSecret` en payload type |
| `apps/web/src/features/settings/components/ChannelsSettingsTab.tsx` | FIX 1 + FIX 2 + FIX 3 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Teams and Webhook channel types
  * Channels can now authenticate using app credentials (ID and secret) in addition to bot tokens
  * Updated channel status indicators to reflect provisioning states (provisioned, bound, error, offline)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->