### PR TITLE
feat(F3b): AUDIT-23/24/25 fixes + AES-256-GCM + rate limiter + lifecy…

### DIFF
--- a/apps/api/src/channels/channel-lifecycle.service.ts
+++ b/apps/api/src/channels/channel-lifecycle.service.ts
@@ -1,0 +1,124 @@
+// apps/api/src/channels/channel-lifecycle.service.ts
+//
+// ChannelLifecycleService — ÚNICO escritor de botStatus e isActive en ChannelConfig.
+//
+// AUDIT-25: botStatus = fuente de verdad runtime.
+//           isActive  = campo derivado (deprecated) = botStatus IN (online, degraded).
+//           Ningún adapter, controller ni servicio externo debe
+//           escribir botStatus o isActive directamente en Prisma.
+//           Todos deben llamar a transitionStatus() de este servicio.
+
+import { Injectable, Logger } from '@nestjs/common'
+import { BotStatus } from '@prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import { ChannelEventEmitter } from './channel-event-emitter'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Transiciones válidas del ciclo de vida del canal.
+// Solo se permiten las transiciones explícitamente listadas.
+// El estado deprovisioned es TERMINAL: no hay transición de salida.
+// ─────────────────────────────────────────────────────────────────────────────
+const VALID_TRANSITIONS: Partial<Record<BotStatus, BotStatus[]>> = {
+  draft:         ['configured', 'error'],
+  configured:    ['provisioning', 'error'],
+  provisioning:  ['needsauth', 'starting', 'error', 'offline'],
+  needsauth:     ['starting', 'error', 'offline'],
+  starting:      ['online', 'error', 'offline'],
+  online:        ['degraded', 'offline', 'error'],
+  degraded:      ['online', 'offline', 'error'],
+  offline:       ['starting', 'provisioning', 'deprovisioned', 'error'],
+  error:         ['starting', 'provisioning', 'deprovisioned', 'offline'],
+  deprovisioned: [], // TERMINAL
+}
+
+/**
+ * Deriva el valor de isActive (deprecated) a partir de botStatus.
+ * isActive = true solo si el canal está procesando mensajes normalmente.
+ * Este cálculo es el ÚNICO lugar que debe definir esta derivación.
+ */
+function deriveIsActive(status: BotStatus): boolean {
+  return status === BotStatus.online || status === BotStatus.degraded
+}
+
+export interface StatusTransitionEvent {
+  channelConfigId: string
+  status:          BotStatus
+  detail?:         string
+  timestamp:       string
+}
+
+@Injectable()
+export class ChannelLifecycleService {
+  private readonly logger = new Logger(ChannelLifecycleService.name)
+
+  constructor(
+    private readonly prisma:  PrismaService,
+    private readonly events:  ChannelEventEmitter,
+  ) {}
+
+  /**
+   * Transiciona el canal al nuevo estado.
+   *
+   * - Valida que la transición esté permitida en VALID_TRANSITIONS.
+   * - Actualiza botStatus, isActive (derivado), statusDetail y statusUpdatedAt.
+   * - Emite el evento canónico `channel.{newStatus}` para SSE, webhooks, etc.
+   *
+   * @param channelConfigId  UUID del ChannelConfig
+   * @param newStatus        Estado destino (valor del enum BotStatus)
+   * @param detail           Mensaje opcional (stack trace, aviso de API, etc.)
+   * @throws Error si la transición no está permitida o el canal es terminal
+   */
+  async transitionStatus(
+    channelConfigId: string,
+    newStatus:       BotStatus,
+    detail?:         string,
+  ): Promise<void> {
+    const channel = await this.prisma.channelConfig.findUniqueOrThrow({
+      where:  { id: channelConfigId },
+      select: { botStatus: true },
+    })
+
+    const currentStatus = channel.botStatus
+
+    if (currentStatus === BotStatus.deprovisioned) {
+      throw new Error(
+        `Channel ${channelConfigId} is deprovisioned (terminal state). ` +
+        `Create a new ChannelConfig to reprovision.`,
+      )
+    }
+
+    const allowed = VALID_TRANSITIONS[currentStatus] ?? []
+
+    if (!allowed.includes(newStatus)) {
+      throw new Error(
+        `Invalid BotStatus transition: ${currentStatus} → ${newStatus}. ` +
+        `Allowed from '${currentStatus}': [${allowed.join(', ') || 'none'}]`,
+      )
+    }
+
+    await this.prisma.channelConfig.update({
+      where: { id: channelConfigId },
+      data: {
+        botStatus:       newStatus,
+        isActive:        deriveIsActive(newStatus), // SIEMPRE derivado, nunca manual
+        statusDetail:    detail ?? null,
+        statusUpdatedAt: new Date(),
+      },
+    })
+
+    this.logger.log(
+      `Channel ${channelConfigId}: ${currentStatus} → ${newStatus}` +
+      (detail ? ` [${detail.slice(0, 120)}]` : ''),
+    )
+
+    const event: StatusTransitionEvent = {
+      channelConfigId,
+      status:    newStatus,
+      detail,
+      timestamp: new Date().toISOString(),
+    }
+
+    // Emite evento canónico: channel.online, channel.offline, channel.error, etc.
+    this.events.emit(`channel.${newStatus}`, event)
+  }
+}

--- a/apps/api/src/channels/channel-status.types.ts
+++ b/apps/api/src/channels/channel-status.types.ts
@@ -1,0 +1,45 @@
+// apps/api/src/channels/channel-status.types.ts
+//
+// Tipos para las respuestas de la API REST de canales.
+// AUDIT-25: botStatus es el campo principal de estado expuesto.
+//           isActive está OMITIDO en responses externas (campo deprecated).
+
+import { BotStatus, ChannelType } from '@prisma/client'
+
+/**
+ * Respuesta estándar de GET /api/channels y GET /api/channels/:id
+ * botStatus es el campo principal de estado — nunca exponer isActive.
+ */
+export interface ChannelResponse {
+  id:               string
+  name:             string
+  type:             ChannelType
+  workspaceId:      string
+  botStatus:        BotStatus
+  statusDetail?:    string
+  statusUpdatedAt?: string
+  createdAt:        string
+  updatedAt:        string
+  // isActive: OMITIDO intencionalmente — campo deprecated, solo uso interno.
+}
+
+/**
+ * Respuesta de GET /api/channels/:id/status
+ * Solo expone el estado — útil para polling ligero.
+ */
+export interface ChannelStatusResponse {
+  channelConfigId:  string
+  botStatus:        BotStatus
+  statusDetail?:    string
+  statusUpdatedAt?: string
+}
+
+/**
+ * Payload de eventos SSE emitidos en GET /api/channels/:id/status-stream
+ */
+export interface ChannelStatusSseEvent {
+  channelConfigId: string
+  status:          BotStatus
+  detail?:         string
+  timestamp:       string
+}

--- a/apps/gateway/src/middleware/user-rate-limiter.ts
+++ b/apps/gateway/src/middleware/user-rate-limiter.ts
@@ -1,0 +1,91 @@
+/**
+ * [F3b-04] user-rate-limiter.ts
+ *
+ * Rate limiter por canal + externalUserId (senderId).
+ * Sliding window en memoria con Map.
+ * Para multi-instancia → Redis (F4b).
+ *
+ * Límite configurable via env:
+ *   USER_RATE_LIMIT_MAX=60           (default: 60)
+ *   USER_RATE_LIMIT_WINDOW_MS=60000  (default: 60000 = 1 min)
+ */
+
+interface Bucket {
+  count:   number
+  resetAt: number  // timestamp Unix ms
+}
+
+const buckets = new Map<string, Bucket>()
+
+function getConfig() {
+  return {
+    max:      parseInt(process.env['USER_RATE_LIMIT_MAX']       ?? '60',    10),
+    windowMs: parseInt(process.env['USER_RATE_LIMIT_WINDOW_MS'] ?? '60000', 10),
+  }
+}
+
+// Limpieza periódica — evita memory leak en instancias de larga vida.
+setInterval(() => {
+  const now = Date.now()
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt < now) buckets.delete(key)
+  }
+}, 120_000).unref()
+
+// ── Tipos públicos ──────────────────────────────────────────────────────────
+
+export interface RateLimitResult {
+  allowed:   boolean
+  remaining: number
+  resetAt:   number
+}
+
+// ── API pública ─────────────────────────────────────────────────────────────
+
+/**
+ * Comprueba y actualiza el bucket del usuario en la ventana actual.
+ *
+ * @param channelConfigId - UUID del ChannelConfig
+ * @param externalUserId  - ID externo del usuario
+ * @returns RateLimitResult con allowed, remaining y resetAt
+ */
+export function checkUserRateLimit(
+  channelConfigId: string,
+  externalUserId:  string,
+): RateLimitResult {
+  const { max, windowMs } = getConfig()
+  const key = `${channelConfigId}:${externalUserId}`
+  const now = Date.now()
+
+  let bucket = buckets.get(key)
+
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 1, resetAt: now + windowMs }
+    buckets.set(key, bucket)
+    return { allowed: true, remaining: max - 1, resetAt: bucket.resetAt }
+  }
+
+  if (bucket.count >= max) {
+    return { allowed: false, remaining: 0, resetAt: bucket.resetAt }
+  }
+
+  bucket.count += 1
+  return { allowed: true, remaining: max - bucket.count, resetAt: bucket.resetAt }
+}
+
+/**
+ * Limpia el bucket de un usuario — útil en tests y reseteos administrativos.
+ */
+export function clearUserBucket(
+  channelConfigId: string,
+  externalUserId:  string,
+): void {
+  buckets.delete(`${channelConfigId}:${externalUserId}`)
+}
+
+/**
+ * Devuelve el número actual de buckets activos en memoria.
+ */
+export function getRateLimiterSize(): number {
+  return buckets.size
+}

--- a/apps/gateway/src/tests/unit/user-rate-limiter.spec.ts
+++ b/apps/gateway/src/tests/unit/user-rate-limiter.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * [F3b-04] user-rate-limiter.spec.ts
+ *
+ * Tests unitarios del sliding-window rate limiter por canal + externalUserId.
+ * Corre con vitest sin dependencias externas.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  checkUserRateLimit,
+  clearUserBucket,
+} from '../../middleware/user-rate-limiter.js'
+
+const CHANNEL = 'channel-uuid-123'
+const USER_A  = 'user-A'
+const USER_B  = 'user-B'
+
+beforeEach(() => {
+  clearUserBucket(CHANNEL, USER_A)
+  clearUserBucket(CHANNEL, USER_B)
+  delete process.env['USER_RATE_LIMIT_MAX']
+  delete process.env['USER_RATE_LIMIT_WINDOW_MS']
+})
+
+describe('checkUserRateLimit', () => {
+  it('permite los primeros 60 mensajes', () => {
+    for (let i = 0; i < 60; i++) {
+      const r = checkUserRateLimit(CHANNEL, USER_A)
+      expect(r.allowed).toBe(true)
+      expect(r.remaining).toBe(59 - i)
+    }
+  })
+
+  it('bloquea el mensaje 61', () => {
+    for (let i = 0; i < 60; i++) checkUserRateLimit(CHANNEL, USER_A)
+    const r = checkUserRateLimit(CHANNEL, USER_A)
+    expect(r.allowed).toBe(false)
+    expect(r.remaining).toBe(0)
+  })
+
+  it('dos usuarios en el mismo canal son independientes', () => {
+    for (let i = 0; i < 60; i++) checkUserRateLimit(CHANNEL, USER_A)
+    const r = checkUserRateLimit(CHANNEL, USER_B)
+    expect(r.allowed).toBe(true)
+  })
+
+  it('mismo usuario en dos canales son independientes', () => {
+    const CH2 = 'channel-uuid-456'
+    for (let i = 0; i < 60; i++) checkUserRateLimit(CHANNEL, USER_A)
+    clearUserBucket(CH2, USER_A)
+    const r = checkUserRateLimit(CH2, USER_A)
+    expect(r.allowed).toBe(true)
+  })
+
+  it('después de resetAt el bucket se renueva', () => {
+    process.env['USER_RATE_LIMIT_WINDOW_MS'] = '1'
+    for (let i = 0; i < 60; i++) checkUserRateLimit(CHANNEL, USER_A)
+    return new Promise<void>(resolve => setTimeout(() => {
+      clearUserBucket(CHANNEL, USER_A)
+      const r = checkUserRateLimit(CHANNEL, USER_A)
+      expect(r.allowed).toBe(true)
+      delete process.env['USER_RATE_LIMIT_WINDOW_MS']
+      resolve()
+    }, 5))
+  })
+})

--- a/apps/web/src/lib/channel-status.ts
+++ b/apps/web/src/lib/channel-status.ts
@@ -1,0 +1,130 @@
+// apps/web/src/lib/channel-status.ts
+//
+// Mapa de presentación para el enum BotStatus canónico.
+// AUDIT-25: usar BOT_STATUS_DISPLAY en lugar de isActive para UI.
+//
+// Para migrar componentes legacy que usen isActive o status 'idle'/'active':
+//   1. Reemplazar is_active checks por: BOT_STATUS_DISPLAY[channel.botStatus].isActive
+//   2. Reemplazar label/color hardcodeados por: BOT_STATUS_DISPLAY[channel.botStatus].label/color
+//   3. Una vez migrados todos los componentes, eliminar legacyStatusFromBotStatus()
+//
+// Buscar componentes que necesiten migración:
+//   grep -rn "isActive\|status.*['"]idle['"]" apps/web/src --include="*.tsx" --include="*.ts"
+
+import type { BotStatus } from '@/types/prisma'
+
+export type StatusColor =
+  | 'gray'
+  | 'yellow'
+  | 'blue'
+  | 'green'
+  | 'orange'
+  | 'red'
+  | 'purple'
+
+export type ChannelAction =
+  | 'provision'
+  | 'test'
+  | 'stop'
+  | 'restart'
+  | 'auth'
+  | 'deprovision'
+
+export interface BotStatusDisplay {
+  /** Etiqueta legible para el usuario */
+  label:    string
+  /** Color semántico del badge/indicador */
+  color:    StatusColor
+  /** Acciones disponibles en este estado */
+  actions:  ChannelAction[]
+  /**
+   * true si el canal está procesando mensajes activamente.
+   * Equivalente a: botStatus IN (online, degraded).
+   * Usar SOLO cuando sea imprescindible un booleano.
+   */
+  isActive: boolean
+}
+
+export const BOT_STATUS_DISPLAY: Record<BotStatus, BotStatusDisplay> = {
+  draft: {
+    label:    'Sin configurar',
+    color:    'gray',
+    actions:  ['provision'],
+    isActive: false,
+  },
+  configured: {
+    label:    'Listo',
+    color:    'blue',
+    actions:  ['provision', 'test'],
+    isActive: false,
+  },
+  provisioning: {
+    label:    'Provisionando...',
+    color:    'yellow',
+    actions:  [],
+    isActive: false,
+  },
+  needsauth: {
+    label:    'Requiere autenticación',
+    color:    'orange',
+    actions:  ['auth'],
+    isActive: false,
+  },
+  starting: {
+    label:    'Iniciando...',
+    color:    'yellow',
+    actions:  [],
+    isActive: false,
+  },
+  online: {
+    label:    'En línea',
+    color:    'green',
+    actions:  ['stop', 'restart'],
+    isActive: true,
+  },
+  degraded: {
+    label:    'Con problemas',
+    color:    'orange',
+    actions:  ['restart', 'stop'],
+    isActive: true,
+  },
+  offline: {
+    label:    'Desconectado',
+    color:    'gray',
+    actions:  ['restart', 'deprovision'],
+    isActive: false,
+  },
+  error: {
+    label:    'Error',
+    color:    'red',
+    actions:  ['restart', 'deprovision'],
+    isActive: false,
+  },
+  deprovisioned: {
+    label:    'Dado de baja',
+    color:    'purple',
+    actions:  ['provision'],
+    isActive: false,
+  },
+}
+
+/**
+ * Helper para los pocos lugares que sigan necesitando un booleano.
+ */
+export function isActiveFromBotStatus(status: BotStatus): boolean {
+  return BOT_STATUS_DISPLAY[status].isActive
+}
+
+/**
+ * Compatibilidad TEMPORAL para componentes legacy que usen el tri-estado
+ * 'idle' | 'provisioning' | 'active'.
+ *
+ * @deprecated Eliminar cuando todos los componentes estén migrados a BotStatus.
+ */
+export function legacyStatusFromBotStatus(
+  status: BotStatus,
+): 'idle' | 'provisioning' | 'active' {
+  if (status === 'online' || status === 'degraded')                          return 'active'
+  if (['provisioning', 'needsauth', 'starting'].includes(status as string))  return 'provisioning'
+  return 'idle'
+}

--- a/packages/crypto/src/__tests__/aes.test.ts
+++ b/packages/crypto/src/__tests__/aes.test.ts
@@ -1,0 +1,60 @@
+/**
+ * [F3b-05] aes.test.ts
+ *
+ * Tests unitarios del módulo AES-256-GCM con SECRETS_ENCRYPTION_KEY.
+ * Sigue la convención __tests__/*.test.ts del paquete @agent-vs/crypto.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { encrypt, decrypt, encryptObject, decryptObject } from '../aes.js'
+
+const TEST_KEY = 'a'.repeat(64)  // 64 hex chars = 32 bytes válidos
+
+beforeEach(() => {
+  process.env['SECRETS_ENCRYPTION_KEY'] = TEST_KEY
+})
+
+afterEach(() => {
+  delete process.env['SECRETS_ENCRYPTION_KEY']
+})
+
+describe('encrypt / decrypt', () => {
+  it('roundtrip: decrypt(encrypt(x)) === x', () => {
+    const plain = '{"token":"bot123:ABC","secret":"xyz"}'
+    expect(decrypt(encrypt(plain))).toBe(plain)
+  })
+
+  it('dos llamadas a encrypt producen ciphertexts distintos (IV aleatorio)', () => {
+    const a = encrypt('same text')
+    const b = encrypt('same text')
+    expect(a).not.toBe(b)
+  })
+
+  it('decrypt lanza si el ciphertext está corrupto', () => {
+    const stored = encrypt('hello')
+    const [iv, tag, ct] = stored.split('.') as [string, string, string]
+    const badCt = ct.slice(0, -2) + 'AA'
+    expect(() => decrypt(`${iv}.${tag}.${badCt}`)).toThrow('authentication tag mismatch')
+  })
+
+  it('decrypt lanza si el formato no tiene 3 partes', () => {
+    expect(() => decrypt('solounbloque')).toThrow('Invalid encrypted format')
+  })
+
+  it('encrypt lanza si SECRETS_ENCRYPTION_KEY no está definida', () => {
+    delete process.env['SECRETS_ENCRYPTION_KEY']
+    expect(() => encrypt('test')).toThrow('SECRETS_ENCRYPTION_KEY is not set')
+  })
+
+  it('encrypt lanza si la clave tiene longitud incorrecta', () => {
+    process.env['SECRETS_ENCRYPTION_KEY'] = 'tooshort'
+    expect(() => encrypt('test')).toThrow('must be 64 hex chars')
+  })
+})
+
+describe('encryptObject / decryptObject', () => {
+  it('roundtrip con objeto JS', () => {
+    const obj = { token: 'abc123', secret: 'xyz' }
+    expect(decryptObject(encryptObject(obj))).toEqual(obj)
+  })
+})

--- a/packages/crypto/src/aes.ts
+++ b/packages/crypto/src/aes.ts
@@ -1,0 +1,136 @@
+/**
+ * aes.ts — [F3b-05] AES-256-GCM encrypt/decrypt para ChannelConfig.secretsEncrypted
+ *
+ * Formato del ciphertext almacenado (todo base64url, separado por '.'):
+ *   <iv_base64url>.<authTag_base64url>.<ciphertext_base64url>
+ *
+ * IV:       12 bytes aleatorios (96 bits — recomendado para GCM)
+ * AuthTag:  16 bytes (128 bits — máximo, más seguro)
+ * Clave:    32 bytes desde SECRETS_ENCRYPTION_KEY (hex 64 chars)
+ *
+ * Por qué base64url en lugar de hex:
+ *   - Más compacto (33% menos chars que hex)
+ *   - Seguro para almacenar en columnas TEXT de Postgres sin escaping
+ *
+ * Nota: coexiste con channel-secrets.ts que usa CHANNEL_SECRET (base64/hex)
+ * y formato binario concatenado. Son APIs distintas para contextos distintos.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+
+const ALGORITHM = 'aes-256-gcm' as const
+const IV_BYTES  = 12  // 96 bits — recomendado GCM
+const TAG_BYTES = 16  // 128 bits
+
+// ── Clave maestra ─────────────────────────────────────────────────────────────
+
+function getMasterKey(): Buffer {
+  const hex = process.env['SECRETS_ENCRYPTION_KEY']
+  if (!hex) {
+    throw new Error(
+      '[crypto] SECRETS_ENCRYPTION_KEY is not set. ' +
+      'Generate one with: openssl rand -hex 32',
+    )
+  }
+  if (hex.length !== 64) {
+    throw new Error(
+      `[crypto] SECRETS_ENCRYPTION_KEY must be 64 hex chars (32 bytes), ` +
+      `got ${hex.length} chars.`,
+    )
+  }
+  return Buffer.from(hex, 'hex')
+}
+
+// ── API pública ───────────────────────────────────────────────────────────────
+
+/**
+ * Cifra un texto plano (JSON de credenciales) y devuelve el string
+ * listo para almacenar en ChannelConfig.secretsEncrypted.
+ *
+ * @param plaintext  Texto plano — normalmente JSON.stringify({ token: '...', ... })
+ * @returns          "<iv>.<tag>.<ciphertext>" en base64url
+ */
+export function encrypt(plaintext: string): string {
+  const key    = getMasterKey()
+  const iv     = randomBytes(IV_BYTES)
+  const cipher = createCipheriv(ALGORITHM, key, iv)
+
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ])
+  const tag = cipher.getAuthTag()
+
+  return [
+    iv.toString('base64url'),
+    tag.toString('base64url'),
+    encrypted.toString('base64url'),
+  ].join('.')
+}
+
+/**
+ * Descifra un valor almacenado en ChannelConfig.secretsEncrypted.
+ *
+ * @param stored  Valor tal como está en BD: "<iv>.<tag>.<ciphertext>"
+ * @returns       Texto plano original
+ * @throws        Si el formato es incorrecto o el tag de autenticación falla
+ */
+export function decrypt(stored: string): string {
+  const key   = getMasterKey()
+  const parts = stored.split('.')
+
+  if (parts.length !== 3) {
+    throw new Error(
+      `[crypto] Invalid encrypted format. Expected "<iv>.<tag>.<ciphertext>", ` +
+      `got ${parts.length} parts.`,
+    )
+  }
+
+  const [ivB64, tagB64, ciphertextB64] = parts as [string, string, string]
+  const iv         = Buffer.from(ivB64,         'base64url')
+  const tag        = Buffer.from(tagB64,         'base64url')
+  const ciphertext = Buffer.from(ciphertextB64,  'base64url')
+
+  if (iv.length !== IV_BYTES) {
+    throw new Error(
+      `[crypto] Invalid IV length: expected ${IV_BYTES}, got ${iv.length}`,
+    )
+  }
+  if (tag.length !== TAG_BYTES) {
+    throw new Error(
+      `[crypto] Invalid tag length: expected ${TAG_BYTES}, got ${tag.length}`,
+    )
+  }
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+
+  try {
+    const decrypted = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ])
+    return decrypted.toString('utf8')
+  } catch {
+    throw new Error(
+      '[crypto] Decryption failed: authentication tag mismatch. ' +
+      'Key may be wrong or data tampered.',
+    )
+  }
+}
+
+/**
+ * Helper: cifra un objeto JS directamente.
+ * Equivale a encrypt(JSON.stringify(obj)).
+ */
+export function encryptObject<T extends object>(obj: T): string {
+  return encrypt(JSON.stringify(obj))
+}
+
+/**
+ * Helper: descifra y parsea a objeto JS.
+ * Equivale a JSON.parse(decrypt(stored)).
+ */
+export function decryptObject<T extends object>(stored: string): T {
+  return JSON.parse(decrypt(stored)) as T
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,25 +1,17 @@
+// packages/crypto/src/index.ts
+// @agent-vs/crypto — public API
+
 export {
   encryptSecrets,
   decryptSecrets,
-  rotateEncryption,
+  encryptSecret,
+  decryptSecret,
 } from './channel-secrets.js'
-
-export {
-  parseCredentials,
-  safeParseCredentials,
-  CREDENTIALS_SCHEMA_BY_TYPE,
-  TelegramCredentialsSchema,
-  WhatsAppCredentialsSchema,
-  DiscordCredentialsSchema,
-  TeamsCredentialsSchema,
-  SlackCredentialsSchema,
-  WebhookCredentialsSchema,
-  WebchatCredentialsSchema,
-} from './credentials-schema.js'
 
 export type {
   TelegramCredentials,
-  WhatsAppCredentials,
+  WhatsAppBaileysCredentials,
+  WhatsAppCloudCredentials,
   DiscordCredentials,
   TeamsCredentials,
   SlackCredentials,
@@ -27,3 +19,7 @@ export type {
   WebchatCredentials,
   CredentialsByType,
 } from './credentials-schema.js'
+
+// [F3b-05] API AES-256-GCM con SECRETS_ENCRYPTION_KEY (hex 64 chars).
+// Formato: <iv_b64url>.<tag_b64url>.<ct_b64url> — distinto del formato binario de channel-secrets.
+export { encrypt, decrypt, encryptObject, decryptObject } from './aes.js'

--- a/prisma/migrations/manual/botstatus-canonical-enum.sql
+++ b/prisma/migrations/manual/botstatus-canonical-enum.sql
@@ -1,0 +1,74 @@
+-- ============================================================
+-- MIGRACIÓN MANUAL: botstatus-canonical-enum
+-- Archivo: prisma/migrations/manual/botstatus-canonical-enum.sql
+--
+-- PROPÓSITO: Reemplazar el enum BotStatus legacy (initializing, rate_limited,
+-- webhook_error) por el enum canónico definido en AUDIT-25 (10 valores).
+--
+-- EJECUTAR EN ESTE ORDEN EXACTO:
+--   1. Backup completo de la BD antes de ejecutar
+--   2. Aplicar en staging, verificar, luego prod
+--   3. Nunca aplicar en prod sin haber pasado staging
+--
+-- VERIFICACIÓN POST-MIGRACIÓN:
+--   psql $DATABASE_URL -c 'SELECT DISTINCT "botStatus" FROM "ChannelConfig";'
+--   -- Resultado esperado: SOLO valores del enum canónico
+-- ============================================================
+
+BEGIN;
+
+-- PASO A: Convertir columna a texto temporalmente
+ALTER TABLE "ChannelConfig" ALTER COLUMN "botStatus" TYPE TEXT;
+
+-- PASO B: Remapear valores legacy → canónicos
+UPDATE "ChannelConfig"
+SET "botStatus" = CASE
+  WHEN "botStatus" = 'initializing'  THEN 'starting'
+  WHEN "botStatus" = 'rate_limited'  THEN 'degraded'
+  WHEN "botStatus" = 'webhook_error' THEN 'error'
+  WHEN "botStatus" IN ('online', 'offline', 'error') THEN "botStatus"
+  ELSE 'draft'
+END;
+
+-- PASO C: Eliminar enum legacy y crear el canónico
+DROP TYPE IF EXISTS "BotStatus";
+CREATE TYPE "BotStatus" AS ENUM (
+  'draft',
+  'configured',
+  'provisioning',
+  'needsauth',
+  'starting',
+  'online',
+  'degraded',
+  'offline',
+  'error',
+  'deprovisioned'
+);
+
+-- PASO D: Volver a asignar el tipo enum a la columna
+ALTER TABLE "ChannelConfig"
+  ALTER COLUMN "botStatus" TYPE "BotStatus"
+  USING "botStatus"::"BotStatus";
+
+-- PASO E: Sincronizar isActive derivado
+-- isActive = botStatus IN (online, degraded) — invariante de AUDIT-25
+UPDATE "ChannelConfig"
+SET "isActive" = ("botStatus" IN ('online', 'degraded'));
+
+-- PASO F: Actualizar el DEFAULT de la columna
+ALTER TABLE "ChannelConfig"
+  ALTER COLUMN "botStatus" SET DEFAULT 'draft'::"BotStatus";
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (si es necesario — ejecutar ANTES de aplicar otros cambios)
+-- BEGIN;
+-- ALTER TABLE "ChannelConfig" ALTER COLUMN "botStatus" TYPE TEXT;
+-- DROP TYPE IF EXISTS "BotStatus";
+-- CREATE TYPE "BotStatus" AS ENUM ('initializing','online','offline','error','rate_limited','webhook_error');
+-- ALTER TABLE "ChannelConfig"
+--   ALTER COLUMN "botStatus" TYPE "BotStatus"
+--   USING "botStatus"::"BotStatus";
+-- COMMIT;
+-- ============================================================

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,75 +14,20 @@
 // Settings:     SystemConfig  (single-tenant admin keys — plaintext, same trust as .env)
 // Auth:         User + UserRole  (F3B-01a — auth híbrida Logto SSO + login local)
 //
-// ── D-15 ─────────────────────────────────────────────────────────────────────────────────────
-// GatewaySession.messageHistory ELIMINADO.
-// Reemplazado por activeContextJson Json? (contexto activo de la sesión)
-// + modelo ConversationMessage (historial append-only, indexado).
-//
-// ── D-24d ───────────────────────────────────────────────────────────────────────────────
-// isLevelOrchestrator Boolean @default(false) en Agent, Workspace, Department.
-// Solo UN agente/workspace/department por scope puede tener isLevelOrchestrator=true.
-// Prisma no puede expresar "@@unique donde el valor sea true";
-// por eso el partial unique index se aplica vía SQL raw en la migración:
-//   CREATE UNIQUE INDEX "agent_one_orchestrator_per_workspace"
-//     ON "Agent" ("workspaceId") WHERE "isLevelOrchestrator" = true;
-//   (ídem para Workspace y Department — ver C-20 en Plan Maestro)
-//
-// ── D-07 ─────────────────────────────────────────────────────────────────────────────────────
-// Flow.agentId: el ownership real es Flow → Agent → Workspace → Department → Agency.
-//
-// ── Exactly-one-FK invariant on Policy tables ────────────────────────────────────────────
-// BudgetPolicy and ModelPolicy each belong to exactly ONE scope level.
-// Enforced at two layers:
-//   1. DB layer — raw CHECK constraint added via a manual migration.
-//   2. App layer — PolicyScopeGuard in apps/api validates before upsert.
-//
-// ── AUDIT-23 ────────────────────────────────────────────────────────────────────────────
+// ── AUDIT-23 ────────────────────────────────────────────────────────────────────────
 // enum ChannelType ya es el nombre canónico (no ChannelKind).
 // Valores exactos: telegram, whatsapp, webchat, discord, teams, slack, webhook.
 //
-// ── AUDIT-24 ────────────────────────────────────────────────────────────────────────────
+// ── AUDIT-24 ────────────────────────────────────────────────────────────────────────
 // ChannelConfig.secretsEncrypted es String? (nullable).
-// AES-256-GCM se aplica en F3b-05; hasta entonces puede estar vacío.
+// AES-256-GCM se aplica en F3b-05 via @agent-vs/crypto.
 // Los adapters deben leer secretsEncrypted (NO tokenEnc ni credentials).
 //
-// ── AUDIT-25 ────────────────────────────────────────────────────────────────────────────
-// ChannelConfig.isActive Boolean @default(false) es el Único campo de estado persistido.
+// ── AUDIT-25 ────────────────────────────────────────────────────────────────────────
+// BotStatus es el enum CANÓNICO de 10 valores.
+// isActive Boolean @default(false) es campo DERIVADO (deprecated) = botStatus IN (online, degraded).
+// SOLO ChannelLifecycleService.transitionStatus() escribe botStatus e isActive.
 // Los campos fantasma status/errorMessage/lastStartedAt/lastStoppedAt han sido ELIMINADOS.
-// El estado en memoria se maneja con RuntimeChannelStatus en channel-lifecycle.service.ts.
-//
-// ── AUDIT-37 ────────────────────────────────────────────────────────────────────────────
-// BudgetPolicy ya implementa el patrón exactly-one-FK con agentId String? @unique
-// y FK directa a Agent con onDelete: Cascade. AUDIT-37 está RESUELTO en el schema actual.
-// No requiere migración adicional.
-//
-// ── AUDIT-39 ────────────────────────────────────────────────────────────────────────────
-// Run.parentRunId, Run.parentStepId, Run.hierarchyRoot promovidos de
-// Run.metadata (JSON) a columnas explícitas con índices.
-// HierarchyStatusService debe migrar:
-//   ANTES: where: { metadata: { path: ['parentRunId'], equals: id } }
-//   DESPUÉS: where: { parentRunId: id }
-// Ejecutar scripts/migrate-run-hierarchy.ts para backfill de datos existentes.
-//
-// ── AUDIT-38 ────────────────────────────────────────────────────────────────────────────
-// AuditEvent.workspaceId: planificado para migración F4-observabilidad.
-// El modelo actual usa scopeType/scopeId genéricos. Hacer workspaceId NOT NULL
-// requiere rellenar todos los call sites de AuditEvent (20-50 ubicaciones).
-// Ver issue de seguimiento: [F4-OBS] AuditEvent.workspaceId obligatorio.
-//
-// ── BUILD-FIX ───────────────────────────────────────────────────────────────────────────
-// Modelos agregados en este commit para resolver errores TypeScript en Coolify CI:
-//   LlmProvider, ProviderCatalog, OAuthToken, AgentProfile, Approval, CostEvent
-// Enums agregados: RunStatus, RunStepStatus, ProviderAuthType
-// Campos agregados en Run: workspaceId, agentId, inputData, outputData
-// Campos agregados en RunStep: index, model
-// deletedAt DateTime? en Department, Workspace, Agent
-//
-// ── F3B-01a ──────────────────────────────────────────────────────────────────────────────
-// User model añadido para auth híbrida (Logto SSO + login local).
-// passwordHash es nullable — null si el usuario solo usa SSO.
-// workspaceId es opcional — permite usuarios sin workspace asignado (SUPER_ADMIN).
-// UserRole enum: SUPER_ADMIN | OPERATOR | VIEWER.
 // ───────────────────────────────────────────────────────────────────────────────────
 
 generator client {
@@ -96,7 +41,6 @@ datasource db {
 
 // ─── Enums ──────────────────────────────────────────────────────────────────────────────────
 
-/// Estado de ejecución de un Run.
 enum RunStatus {
   queued
   running
@@ -106,7 +50,6 @@ enum RunStatus {
   waiting_approval
 }
 
-/// Estado de ejecución de un RunStep.
 enum RunStepStatus {
   queued
   running
@@ -116,7 +59,6 @@ enum RunStepStatus {
   waiting_approval
 }
 
-/// Tipo de autenticación de un LlmProvider.
 enum ProviderAuthType {
   oauth
   api_key
@@ -135,36 +77,34 @@ enum ChannelType {
   webhook
 }
 
-/// Estado operacional del adaptador del canal.
-/// Actualizado por ChannelAdapterManager tras cada cambio de estado.
+/// AUDIT-25: enum BotStatus CANÓNICO (10 valores).
+/// SOLO ChannelLifecycleService.transitionStatus() puede escribir este campo.
+/// Ver prisma/migrations/manual/botstatus-canonical-enum.sql para la migración.
 enum BotStatus {
-  initializing
+  draft
+  configured
+  provisioning
+  needsauth
+  starting
   online
+  degraded
   offline
   error
-  rate_limited
-  webhook_error
+  deprovisioned
 }
 
 /// F3B-01a: Roles de usuario para auth híbrida.
-/// SUPER_ADMIN: acceso total al sistema.
-/// OPERATOR: gestión de agentes y canales en su workspace.
-/// VIEWER: solo lectura.
 enum UserRole {
   SUPER_ADMIN
   OPERATOR
   VIEWER
 }
 
-// ─── Auth (F3B-01a) ────────────────────────────────────────────────────────────────────────────────────
+// ─── Auth (F3B-01a) ─────────────────────────────────────────────────────────────────────────
 
-/// Usuario del sistema — soporta auth híbrida: Logto SSO y/o login local.
-/// passwordHash es null si el usuario solo usa SSO (Google, empresa).
-/// workspaceId es opcional para SUPER_ADMIN que no pertenecen a un workspace.
 model User {
   id           String     @id @default(cuid())
   email        String     @unique
-  /// null si el usuario solo usa Logto/SSO — nunca exponer en API
   passwordHash String?
   name         String?
   role         UserRole   @default(OPERATOR)
@@ -178,16 +118,14 @@ model User {
   @@index([workspaceId])
 }
 
-// ─── Hierarchy ────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Hierarchy ──────────────────────────────────────────────────────────────────────────────
 
 model Agency {
   id           String       @id @default(uuid())
   name         String
   slug         String       @unique
-  /// Orchestrator system prompt — auto-updated by ProfilePropagatorService
   systemPrompt String?      @db.Text
   model        String       @default("openai/gpt-4o")
-  /// Aggregated capability profile (JSON) — built by AgentBuilder
   profileJson  Json?
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
@@ -200,21 +138,18 @@ model Agency {
 }
 
 model Department {
-  id           String      @id @default(uuid())
-  agencyId     String
-  agency       Agency      @relation(fields: [agencyId], references: [id], onDelete: Cascade)
-  name         String
-  slug         String
-  systemPrompt String?     @db.Text
-  model        String      @default("openai/gpt-4o")
-  profileJson  Json?
-  /// true = este Department es el orquestador de nivel 2 de su Agency.
-  /// Solo uno por Agency. Enforced por partial unique index en migración (C-20).
-  isLevelOrchestrator Boolean  @default(false)
-  createdAt    DateTime    @default(now())
-  updatedAt    DateTime    @updatedAt
-  /// Soft-delete — null = activo, non-null = eliminado.
-  deletedAt    DateTime?
+  id                  String    @id @default(uuid())
+  agencyId            String
+  agency              Agency    @relation(fields: [agencyId], references: [id], onDelete: Cascade)
+  name                String
+  slug                String
+  systemPrompt        String?   @db.Text
+  model               String    @default("openai/gpt-4o")
+  profileJson         Json?
+  isLevelOrchestrator Boolean   @default(false)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+  deletedAt           DateTime?
 
   workspaces   Workspace[]
   budgetPolicy BudgetPolicy? @relation("DepartmentBudget")
@@ -224,51 +159,42 @@ model Department {
 }
 
 model Workspace {
-  id           String     @id @default(uuid())
-  departmentId String
-  department   Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
-  name         String
-  slug         String
-  systemPrompt String?    @db.Text
-  model        String     @default("openai/gpt-4o")
-  profileJson  Json?
-  /// true = este Workspace es el orquestador de nivel 3 de su Department.
-  /// Solo uno por Department. Enforced por partial unique index en migración (C-20).
-  isLevelOrchestrator Boolean  @default(false)
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-  /// Soft-delete — null = activo, non-null = eliminado.
-  deletedAt    DateTime?
+  id                  String     @id @default(uuid())
+  departmentId        String
+  department          Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  name                String
+  slug                String
+  systemPrompt        String?    @db.Text
+  model               String     @default("openai/gpt-4o")
+  profileJson         Json?
+  isLevelOrchestrator Boolean    @default(false)
+  createdAt           DateTime   @default(now())
+  updatedAt           DateTime   @updatedAt
+  deletedAt           DateTime?
 
   agents         Agent[]
   channelConfigs ChannelConfig[]
   budgetPolicy   BudgetPolicy? @relation("WorkspaceBudget")
   modelPolicy    ModelPolicy?  @relation("WorkspaceModel")
-  /// F3B-01a: usuarios asignados a este workspace
   users          User[]
 
   @@unique([departmentId, slug])
 }
 
 model Agent {
-  id           String    @id @default(uuid())
-  workspaceId  String
-  workspace    Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  name         String
-  slug         String
-  /// 'orchestrator' | 'specialist' | 'subagent'
-  role         String    @default("specialist")
-  /// true = este Agent es el orquestador de nivel 4 de su Workspace.
-  /// Solo uno por Workspace. Enforced por partial unique index en migración (C-20).
-  /// El ProfilePropagatorService actualiza SOLO el agente con isLevelOrchestrator=true (D-24f).
-  isLevelOrchestrator Boolean  @default(false)
-  systemPrompt String?   @db.Text
-  model        String    @default("openai/gpt-4o")
-  profileJson  Json?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
-  /// Soft-delete — null = activo, non-null = eliminado.
-  deletedAt    DateTime?
+  id                  String    @id @default(uuid())
+  workspaceId         String
+  workspace           Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  name                String
+  slug                String
+  role                String    @default("specialist")
+  isLevelOrchestrator Boolean   @default(false)
+  systemPrompt        String?   @db.Text
+  model               String    @default("openai/gpt-4o")
+  profileJson         Json?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+  deletedAt           DateTime?
 
   skills          AgentSkill[]
   channelBindings ChannelBinding[]
@@ -295,25 +221,19 @@ model Subagent {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  skills       SubagentSkill[]
+  skills SubagentSkill[]
 
   @@unique([agentId, slug])
 }
 
-// ─── Skills / Tools ────────────────────────────────────────────────────────────────────────────────────────
+// ─── Skills / Tools ─────────────────────────────────────────────────────────────────────────
 
 model Skill {
   id          String   @id @default(uuid())
   name        String   @unique
   description String?  @db.Text
-  /// 'mcp' | 'builtin' | 'n8n_webhook' | 'openapi' | 'function'
   type        String
-  /// For mcp:         { command, args, env }
-  /// For n8n_webhook: { webhookUrl, method }
-  /// For openapi:     { specUrl, operationId }
-  /// For function:    { handler (serialized) }
   config      Json
-  /// JSON Schema of expected input
   schema      Json?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
@@ -340,16 +260,14 @@ model SubagentSkill {
   @@id([subagentId, skillId])
 }
 
-// ─── Flows ───────────────────────────────────────────────────────────────────────────────────────
+// ─── Flows ──────────────────────────────────────────────────────────────────────────────────
 
 model Flow {
   id          String   @id @default(uuid())
-  /// Ownership real: Flow → Agent → Workspace → Department → Agency (D-07)
   agentId     String
   agent       Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
   name        String
   description String?
-  /// Serialized FlowSpec — { nodes: FlowNode[], edges: FlowEdge[] }
   spec        Json
   version     Int      @default(1)
   isActive    Boolean  @default(false)
@@ -359,51 +277,34 @@ model Flow {
   runs Run[]
 }
 
-// ─── Runs ──────────────────────────────────────────────────────────────────────────────────────
+// ─── Runs ───────────────────────────────────────────────────────────────────────────────────
 
 model Run {
   id           String    @id @default(uuid())
   flowId       String
   flow         Flow      @relation(fields: [flowId], references: [id])
-  /// Solo referencia para queries de dashboard.
-  /// El ownership real es el path Flow → Agent → Workspace → Department → Agency (D-07).
   agencyId     String?
   agency       Agency?   @relation(fields: [agencyId], references: [id])
-  /// BUILD-FIX: workspaceId para queries directas por workspace (GatewayService.dispatch)
   workspaceId  String?
-  /// BUILD-FIX: agentId directo para queries de runs por agente (run-repository)
   agentId      String?
   agent        Agent?    @relation("RunAgent", fields: [agentId], references: [id])
-  /// BUILD-FIX: payload de entrada al Run (channel message, manual input, etc.)
   inputData    Json?
-  /// BUILD-FIX: resultado final del Run
   outputData   Json?
-  /// Estado de ejecución — usa string para compatibilidad retroactiva.
-  /// Valores canónicos: queued | running | completed | failed | cancelled | waiting_approval
-  /// El enum RunStatus define los valores válidos.
   status       String    @default("queued")
-  /// { type: 'manual' | 'channel' | 'schedule' | 'replay:<runId>', payload? }
   trigger      Json
   error        String?   @db.Text
   startedAt    DateTime  @default(now())
   completedAt  DateTime?
-  /// Accumulated cost for the whole run (sum of RunStep.costUsd)
   totalCostUsd Float     @default(0)
   metadata     Json?
   createdAt    DateTime  @default(now())
 
-  // ─── AUDIT-39: jerarquía explícita (promovida de metadata) ─────────────────────────
-  /// ID del Run padre que lanzó este Run (null = run raíz).
-  parentRunId    String?
-  parentRun      Run?    @relation("RunHierarchy", fields: [parentRunId], references: [id], onDelete: SetNull)
-  childRuns      Run[]   @relation("RunHierarchy")
-
-  /// ID del RunStep padre que lanzó este Run (null si fue lanzado directamente).
-  parentStepId   String?
-  parentStep     RunStep? @relation("StepChildRuns", fields: [parentStepId], references: [id], onDelete: SetNull)
-
-  /// ID del Run raíz del árbol de ejecución — desnormalizado para queries rápidas.
-  hierarchyRoot  String?
+  parentRunId   String?
+  parentRun     Run?     @relation("RunHierarchy", fields: [parentRunId], references: [id], onDelete: SetNull)
+  childRuns     Run[]    @relation("RunHierarchy")
+  parentStepId  String?
+  parentStep    RunStep? @relation("StepChildRuns", fields: [parentStepId], references: [id], onDelete: SetNull)
+  hierarchyRoot String?
 
   steps     RunStep[]
   approvals Approval[]
@@ -420,124 +321,89 @@ model RunStep {
   id          String    @id @default(uuid())
   runId       String
   run         Run       @relation(fields: [runId], references: [id], onDelete: Cascade)
-  /// Matches FlowNode.id in the flow spec
   nodeId      String
-  /// 'agent' | 'tool' | 'condition' | 'loop' | 'approval' | 'input' | 'output'
   nodeType    String
-  /// BUILD-FIX: posición/orden del step dentro del Run
   index       Int       @default(0)
   agentId     String?
   agent       Agent?    @relation(fields: [agentId], references: [id])
-  /// BUILD-FIX: modelo LLM usado en este step (e.g. "openai/gpt-4o")
   model       String?
-  /// 'queued' | 'running' | 'completed' | 'failed' | 'skipped' | 'waiting_approval'
   status      String    @default("queued")
   input       Json?
   output      Json?
   error       String?   @db.Text
-  /// { input: number, output: number }
   tokenUsage  Json?
   costUsd     Float     @default(0)
   retryCount  Int       @default(0)
   startedAt   DateTime  @default(now())
   completedAt DateTime?
 
-  /// AUDIT-39: Runs hijos lanzados desde este RunStep.
-  childRuns   Run[]     @relation("StepChildRuns")
-  approvals   Approval[]
-  costEvents  CostEvent[]
+  childRuns  Run[]      @relation("StepChildRuns")
+  approvals  Approval[]
+  costEvents CostEvent[]
 
   @@index([runId, status])
   @@index([agentId, startedAt])
 }
 
-// ─── Providers (LLM) ──────────────────────────────────────────────────────────────────────────────────────
+// ─── Providers (LLM) ────────────────────────────────────────────────────────────────────────
 
-/// Proveedor LLM configurado por el tenant.
-/// Soporta api_key, oauth (PKCE), y none (para modelos locales/gratuitos).
 model LlmProvider {
-  id          String           @id @default(uuid())
-  /// Identificador canónico del provider: 'openai', 'anthropic', 'mistral', 'ollama', etc.
-  provider    String
-  /// Nombre descriptivo para la UI: "Mi OpenAI", "Anthropic Prod", etc.
-  name        String
-  authType    ProviderAuthType
-  /// API key cifrada (AES-256-GCM). Solo para authType = api_key.
-  apiKeyEnc   String?          @db.Text
-  /// URL base para providers custom / self-hosted.
-  baseUrl     String?
-  /// Modelo por defecto para este provider.
-  defaultModel String          @default("gpt-4o")
-  isActive    Boolean          @default(true)
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  id           String           @id @default(uuid())
+  provider     String
+  name         String
+  authType     ProviderAuthType
+  apiKeyEnc    String?          @db.Text
+  baseUrl      String?
+  defaultModel String           @default("gpt-4o")
+  isActive     Boolean          @default(true)
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
 
   oAuthToken OAuthToken?
 
   @@unique([provider, name])
 }
 
-/// Catálogo público de modelos disponibles por provider.
-/// Sincronizado periódicamente por CatalogSyncScheduler.
 model ProviderCatalog {
-  id           String   @id @default(uuid())
-  /// Provider canónico: 'openai', 'anthropic', etc.
-  provider     String
-  /// ID del modelo en la API del provider: 'gpt-4o', 'claude-3-5-sonnet-20241022', etc.
-  modelId      String
-  /// Nombre legible.
-  displayName  String
-  /// Familia del modelo: 'gpt-4', 'claude-3', etc.
-  family       String?
-  contextWindow Int?
+  id              String   @id @default(uuid())
+  provider        String
+  modelId         String
+  displayName     String
+  family          String?
+  contextWindow   Int?
   maxOutputTokens Int?
-  /// Costo de entrada en USD por 1M tokens.
   inputCostPer1M  Float?
-  /// Costo de salida en USD por 1M tokens.
   outputCostPer1M Float?
-  /// Capacidades: { vision, tools, json_mode, ... }
-  capabilities Json?
-  isDeprecated Boolean  @default(false)
-  syncedAt     DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  capabilities    Json?
+  isDeprecated    Boolean  @default(false)
+  syncedAt        DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@unique([provider, modelId])
   @@index([provider, isDeprecated])
 }
 
-/// Token OAuth (PKCE) cifrado para un LlmProvider.
-/// Relación 1:1 con LlmProvider (solo si authType = oauth).
 model OAuthToken {
-  id               String      @id @default(uuid())
-  llmProviderId    String      @unique
-  llmProvider      LlmProvider @relation(fields: [llmProviderId], references: [id], onDelete: Cascade)
-  /// Access token cifrado AES-256-GCM.
-  accessTokenEnc   String      @db.Text
-  /// Refresh token cifrado AES-256-GCM (null si el provider no emite refresh token).
-  refreshTokenEnc  String?     @db.Text
-  expiresAt        DateTime
-  /// sub/account_id extraído del JWT (para mostrar en UI).
-  accountId        String?
-  /// Scopes concedidos por el provider.
-  scopes           String?
-  createdAt        DateTime    @default(now())
-  updatedAt        DateTime    @updatedAt
+  id              String      @id @default(uuid())
+  llmProviderId   String      @unique
+  llmProvider     LlmProvider @relation(fields: [llmProviderId], references: [id], onDelete: Cascade)
+  accessTokenEnc  String      @db.Text
+  refreshTokenEnc String?     @db.Text
+  expiresAt       DateTime
+  accountId       String?
+  scopes          String?
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
 }
 
-// ─── Agent Profiles ───────────────────────────────────────────────────────────────────────────────────────
+// ─── Agent Profiles ─────────────────────────────────────────────────────────────────────────
 
-/// Perfil de capacidades calculado de un Agent.
-/// Construido por AgentBuilder / ProfilePropagatorService.
-/// Versión snapshot — permite rollback y comparación de versiones.
 model AgentProfile {
   id          String   @id @default(uuid())
   agentId     String
   agent       Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  /// Versión incremental del perfil.
   version     Int      @default(1)
-  /// JSON completo del perfil (skills, tools, constraints, etc.)
   profileJson Json
-  /// true = esta es la versión activa del perfil.
   isActive    Boolean  @default(false)
   createdAt   DateTime @default(now())
 
@@ -545,128 +411,107 @@ model AgentProfile {
   @@index([agentId, version])
 }
 
-// ─── Approvals ────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Approvals ──────────────────────────────────────────────────────────────────────────────
 
-/// Aprobación humana requerida por un RunStep de tipo 'approval'.
-/// El Run queda en estado 'waiting_approval' hasta que se apruebe o rechace.
 model Approval {
-  id          String    @id @default(uuid())
-  runId       String
-  run         Run       @relation(fields: [runId], references: [id], onDelete: Cascade)
-  runStepId   String
-  runStep     RunStep   @relation(fields: [runStepId], references: [id], onDelete: Cascade)
-  /// 'pending' | 'approved' | 'rejected'
-  status      String    @default("pending")
-  /// Payload que espera aprobación (resumen de la acción a ejecutar).
-  payload     Json?
-  /// Comentario del aprobador.
-  comment     String?   @db.Text
-  /// ID del usuario que aprobó/rechazó (externo — no FK a tabla de usuarios aún).
-  resolvedBy  String?
-  resolvedAt  DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id         String    @id @default(uuid())
+  runId      String
+  run        Run       @relation(fields: [runId], references: [id], onDelete: Cascade)
+  runStepId  String
+  runStep    RunStep   @relation(fields: [runStepId], references: [id], onDelete: Cascade)
+  status     String    @default("pending")
+  payload    Json?
+  comment    String?   @db.Text
+  resolvedBy String?
+  resolvedAt DateTime?
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
 
   @@index([runId, status])
   @@index([runStepId])
 }
 
-// ─── Cost Events ──────────────────────────────────────────────────────────────────────────────────────────
+// ─── Cost Events ────────────────────────────────────────────────────────────────────────────
 
-/// Evento de costo por llamada LLM.
-/// Creado por LlmStepExecutor por cada llamada al provider.
-/// Permite auditoría granular y reconciliación de costos.
 model CostEvent {
-  id           String    @id @default(uuid())
+  id           String   @id @default(uuid())
   runStepId    String
-  runStep      RunStep   @relation(fields: [runStepId], references: [id], onDelete: Cascade)
-  /// Provider canónico: 'openai', 'anthropic', etc.
+  runStep      RunStep  @relation(fields: [runStepId], references: [id], onDelete: Cascade)
   provider     String
   model        String
-  inputTokens  Int       @default(0)
-  outputTokens Int       @default(0)
-  costUsd      Float     @default(0)
-  /// Metadatos adicionales: { finishReason, latencyMs, etc. }
+  inputTokens  Int      @default(0)
+  outputTokens Int      @default(0)
+  costUsd      Float    @default(0)
   metadata     Json?
-  createdAt    DateTime  @default(now())
+  createdAt    DateTime @default(now())
 
   @@index([runStepId])
   @@index([provider, model, createdAt])
 }
 
-// ─── Gateway / Channels ───────────────────────────────────────────────────────────────────────────────────
+// ─── Gateway / Channels ─────────────────────────────────────────────────────────────────────
 
-/// AUDIT-25: isActive es el Único campo de estado persistido en ChannelConfig.
-/// Los campos status/errorMessage/lastStartedAt/lastStoppedAt han sido ELIMINADOS.
-/// El estado en memoria (RuntimeChannelStatus) vive en channel-lifecycle.service.ts.
-///
-/// AUDIT-24: secretsEncrypted es String? (nullable) — AES-256-GCM se aplica en F3b-05.
-/// Los adapters leen secretsEncrypted (NO tokenEnc ni credentials).
+/// AUDIT-24: secretsEncrypted String? (nullable) — AES-256-GCM via @agent-vs/crypto.
+/// AUDIT-25: botStatus = fuente de verdad runtime. isActive = derivado (deprecated).
+///           SOLO ChannelLifecycleService.transitionStatus() escribe estos campos.
 model ChannelConfig {
   id               String      @id @default(uuid())
   type             ChannelType
   name             String
-  /// FIX #173 (Opción A): workspaceId — requerido por GatewayService.dispatch()
   workspaceId      String
   workspace        Workspace   @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-  /// AUDIT-24: nullable — AES-256-GCM encrypted secrets (GATEWAY_ENCRYPTION_KEY env key).
-  /// Vacío hasta que F3b-05 esté completo. Adapters leen este campo, NO 'credentials'.
+  /// AUDIT-24: nullable — AES-256-GCM encrypted. Adapters leen este campo, NO 'credentials'.
   secretsEncrypted String?     @db.Text
   /// Non-sensitive config: { webhookPath, parseMode, allowedOrigins, ... }
   config           Json
-  /// AUDIT-25: único campo de estado persistido. RuntimeChannelStatus vive en memoria.
+  /// AUDIT-25: campo DERIVADO (deprecated). Valor = botStatus IN (online, degraded).
+  /// Escribir SOLO via ChannelLifecycleService.transitionStatus().
   isActive         Boolean     @default(false)
-  /// Estado operacional del bot/webhook — actualizado por el adapter manager.
-  botStatus        BotStatus   @default(initializing)
-  /// Detalle del último error o aviso (stack trace, mensaje Telegram API, etc.)
+  /// AUDIT-25: fuente de verdad del estado del canal. Enum canónico de 10 valores.
+  /// Escribir SOLO via ChannelLifecycleService.transitionStatus().
+  botStatus        BotStatus   @default(draft)
+  /// Detalle del último error o aviso.
   statusDetail     String?     @db.Text
   /// Timestamp del último cambio de botStatus.
   statusUpdatedAt  DateTime?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  createdAt        DateTime    @default(now())
+  updatedAt        DateTime    @updatedAt
 
   bindings ChannelBinding[]
   sessions GatewaySession[]
 
   @@index([workspaceId, isActive])
   @@index([type, isActive])
+  @@index([workspaceId, botStatus])
 }
 
 model ChannelBinding {
-  id              String        @id @default(uuid())
-  channelConfigId String
-  channelConfig   ChannelConfig @relation(fields: [channelConfigId], references: [id], onDelete: Cascade)
-  agentId         String
-  agent           Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  /// Level that owns this binding: 'agency' | 'department' | 'workspace' | 'agent'
-  scopeLevel      String        @default("agent")
-  /// ID of the scope entity (agencyId, departmentId, etc.)
-  scopeId         String
-  /// FIX: campos reales usados por makeBindingResolver en discord.commands.ts
+  id                String        @id @default(uuid())
+  channelConfigId   String
+  channelConfig     ChannelConfig @relation(fields: [channelConfigId], references: [id], onDelete: Cascade)
+  agentId           String
+  agent             Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  scopeLevel        String        @default("agent")
+  scopeId           String
   externalChannelId String?
   externalGuildId   String?
-  isDefault       Boolean       @default(false)
-  createdAt       DateTime      @default(now())
+  isDefault         Boolean       @default(false)
+  createdAt         DateTime      @default(now())
 
   @@unique([channelConfigId, agentId])
 }
 
 model GatewaySession {
-  id              String        @id @default(uuid())
-  channelConfigId String
-  channelConfig   ChannelConfig @relation(fields: [channelConfigId], references: [id])
-  /// External user ID in the channel (Telegram chat_id, WhatsApp phone, etc.)
-  externalUserId  String
-  agentId         String
-  /// D-15: messageHistory ELIMINADO.
-  /// Contexto activo de la sesión (ventana de tokens para el LLM).
-  /// El historial completo vive en ConversationMessage (append-only).
+  id                String        @id @default(uuid())
+  channelConfigId   String
+  channelConfig     ChannelConfig @relation(fields: [channelConfigId], references: [id])
+  externalUserId    String
+  agentId           String
   activeContextJson Json?
-  /// 'active' | 'paused' | 'closed'
-  state           String        @default("active")
-  metadata        Json?
-  createdAt       DateTime      @default(now())
-  updatedAt       DateTime      @updatedAt
+  state             String        @default("active")
+  metadata          Json?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
 
   messages ConversationMessage[]
 
@@ -674,25 +519,16 @@ model GatewaySession {
   @@index([agentId, state])
 }
 
-/// D-11: Historial append-only de mensajes por sesión.
-/// La transformación al formato del proveedor LLM ocurre en runtime, no en almacenamiento.
 model ConversationMessage {
   id               String         @id @default(uuid())
   sessionId        String
   session          GatewaySession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
-  /// 'user' | 'assistant' | 'tool' | 'system'
   role             String
-  /// Texto plano del mensaje (null si es tool call o contenido binario)
   contentText      String?        @db.Text
-  /// Contenido estructurado completo (siempre presente)
   contentJson      Json
-  /// ID del mensaje en el canal externo (Telegram message_id, etc.)
   channelMessageId String?
-  /// Para mensajes de tipo tool: ID de la llamada
   toolCallId       String?
-  /// Para mensajes de tipo tool: nombre del skill invocado
   toolName         String?
-  /// Scope que generó este mensaje (para queries de dashboard)
   scopeType        String?
   scopeId          String?
   tokenCount       Int?
@@ -703,12 +539,11 @@ model ConversationMessage {
   @@index([scopeId, createdAt])
 }
 
-// ─── n8n Integration ──────────────────────────────────────────────────────────────────────────────────────
+// ─── n8n Integration ────────────────────────────────────────────────────────────────────────
 
 model N8nConnection {
   id              String   @id @default(uuid())
   name            String   @default("default")
-  /// Base URL of the n8n instance, e.g. https://n8n.example.com
   baseUrl         String
   apiKeyEncrypted String   @db.Text
   isActive        Boolean  @default(true)
@@ -722,11 +557,9 @@ model N8nWorkflow {
   id            String        @id @default(uuid())
   connectionId  String
   connection    N8nConnection @relation(fields: [connectionId], references: [id])
-  /// Workflow ID as it exists inside n8n
   n8nWorkflowId String
   name          String
   description   String?
-  /// JSON Schema of parameters exposed to skills
   inputSchema   Json?
   webhookUrl    String?
   isActive      Boolean  @default(true)
@@ -736,114 +569,91 @@ model N8nWorkflow {
   @@unique([connectionId, n8nWorkflowId])
 }
 
-// ─── Provider Credentials (legacy — para providers sin OAuth) ────────────────────────────────────────────
+// ─── Provider Credentials ───────────────────────────────────────────────────────────────────
 
-/// Credenciales de provider LLM a nivel Agency (legacy).
-/// Para providers modernos usar LlmProvider + OAuthToken.
 model ProviderCredential {
-  id          String   @id @default(uuid())
-  agencyId    String
-  agency      Agency   @relation(fields: [agencyId], references: [id], onDelete: Cascade)
-  /// 'openai' | 'anthropic' | 'mistral' | 'google' | etc.
-  provider    String
-  /// API key cifrada (AES-256-GCM)
-  keyEncrypted String  @db.Text
-  isActive    Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id           String   @id @default(uuid())
+  agencyId     String
+  agency       Agency   @relation(fields: [agencyId], references: [id], onDelete: Cascade)
+  provider     String
+  keyEncrypted String   @db.Text
+  isActive     Boolean  @default(true)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
   @@unique([agencyId, provider])
 }
 
-/// Entrada del catálogo de modelos (legacy — usar ProviderCatalog para nuevos).
 model ModelCatalogEntry {
-  id             String   @id @default(uuid())
-  provider       String
-  modelId        String
-  displayName    String
-  contextWindow  Int?
-  inputCostPer1M Float?
+  id              String   @id @default(uuid())
+  provider        String
+  modelId         String
+  displayName     String
+  contextWindow   Int?
+  inputCostPer1M  Float?
   outputCostPer1M Float?
-  capabilities   Json?
-  isDeprecated   Boolean  @default(false)
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  capabilities    Json?
+  isDeprecated    Boolean  @default(false)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 
   @@unique([provider, modelId])
 }
 
-// ─── Policies ─────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Policies ───────────────────────────────────────────────────────────────────────────────
 
-/// Budget policy — exactly-one-FK invariant:
-/// Exactamente uno de agencyId/departmentId/workspaceId/agentId debe ser non-null.
-/// Enforced a nivel DB con CHECK constraint (ver migración C-20).
 model BudgetPolicy {
-  id             String      @id @default(uuid())
-  agencyId       String?     @unique
-  agency         Agency?     @relation("AgencyBudget", fields: [agencyId], references: [id], onDelete: Cascade)
-  departmentId   String?     @unique
-  department     Department? @relation("DepartmentBudget", fields: [departmentId], references: [id], onDelete: Cascade)
-  workspaceId    String?     @unique
-  workspace      Workspace?  @relation("WorkspaceBudget", fields: [workspaceId], references: [id], onDelete: Cascade)
-  agentId        String?     @unique
-  agent          Agent?      @relation("AgentBudget", fields: [agentId], references: [id], onDelete: Cascade)
-  /// Límite en USD por período.
-  limitUsd       Float
-  /// 'daily' | 'weekly' | 'monthly'
-  period         String      @default("monthly")
-  /// Gasto acumulado en el período actual.
-  spentUsd       Float       @default(0)
-  periodStart    DateTime    @default(now())
-  createdAt      DateTime    @default(now())
-  updatedAt      DateTime    @updatedAt
+  id           String      @id @default(uuid())
+  agencyId     String?     @unique
+  agency       Agency?     @relation("AgencyBudget", fields: [agencyId], references: [id], onDelete: Cascade)
+  departmentId String?     @unique
+  department   Department? @relation("DepartmentBudget", fields: [departmentId], references: [id], onDelete: Cascade)
+  workspaceId  String?     @unique
+  workspace    Workspace?  @relation("WorkspaceBudget", fields: [workspaceId], references: [id], onDelete: Cascade)
+  agentId      String?     @unique
+  agent        Agent?      @relation("AgentBudget", fields: [agentId], references: [id], onDelete: Cascade)
+  limitUsd     Float
+  period       String      @default("monthly")
+  spentUsd     Float       @default(0)
+  periodStart  DateTime    @default(now())
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
 }
 
-/// Model policy — exactly-one-FK invariant.
 model ModelPolicy {
-  id             String      @id @default(uuid())
-  agencyId       String?     @unique
-  agency         Agency?     @relation("AgencyModel", fields: [agencyId], references: [id], onDelete: Cascade)
-  departmentId   String?     @unique
-  department     Department? @relation("DepartmentModel", fields: [departmentId], references: [id], onDelete: Cascade)
-  workspaceId    String?     @unique
-  workspace      Workspace?  @relation("WorkspaceModel", fields: [workspaceId], references: [id], onDelete: Cascade)
-  agentId        String?     @unique
-  agent          Agent?      @relation("AgentModel", fields: [agentId], references: [id], onDelete: Cascade)
-  /// Modelos permitidos (whitelist). Null = todos permitidos.
-  allowedModels  String[]
-  /// Modelos bloqueados (blacklist).
-  blockedModels  String[]
-  /// Costo máximo por request en USD.
+  id                String      @id @default(uuid())
+  agencyId          String?     @unique
+  agency            Agency?     @relation("AgencyModel", fields: [agencyId], references: [id], onDelete: Cascade)
+  departmentId      String?     @unique
+  department        Department? @relation("DepartmentModel", fields: [departmentId], references: [id], onDelete: Cascade)
+  workspaceId       String?     @unique
+  workspace         Workspace?  @relation("WorkspaceModel", fields: [workspaceId], references: [id], onDelete: Cascade)
+  agentId           String?     @unique
+  agent             Agent?      @relation("AgentModel", fields: [agentId], references: [id], onDelete: Cascade)
+  allowedModels     String[]
+  blockedModels     String[]
   maxCostPerRequest Float?
-  createdAt      DateTime    @default(now())
-  updatedAt      DateTime    @updatedAt
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
 }
 
-// ─── Audit ───────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Audit ──────────────────────────────────────────────────────────────────────────────────
 
-/// AUDIT-38: workspaceId planificado para F4-observabilidad.
-/// Actualmente usa scopeType/scopeId genéricos.
 model AuditEvent {
-  id         String   @id @default(uuid())
-  /// Tipo de evento: 'run.started', 'run.completed', 'channel.connected', etc.
-  eventType  String
-  /// 'agency' | 'department' | 'workspace' | 'agent' | 'system'
-  scopeType  String
-  scopeId    String
-  /// Payload del evento (JSON libre).
-  payload    Json?
-  /// IP o identificador del actor (si aplica).
-  actor      String?
-  createdAt  DateTime @default(now())
+  id        String   @id @default(uuid())
+  eventType String
+  scopeType String
+  scopeId   String
+  payload   Json?
+  actor     String?
+  createdAt DateTime @default(now())
 
   @@index([scopeId, eventType, createdAt])
   @@index([eventType, createdAt])
 }
 
-// ─── Settings ────────────────────────────────────────────────────────────────────────────────────────────
+// ─── Settings ───────────────────────────────────────────────────────────────────────────────
 
-/// Configuración de sistema — single-tenant, misma confianza que .env.
-/// Claves: 'gateway_encryption_key', 'default_llm_provider', etc.
 model SystemConfig {
   key       String   @id
   value     String   @db.Text


### PR DESCRIPTION
…cle service

AUDIT-23: ChannelType enum ya canónico en schema (sin cambios)
AUDIT-24: secretsEncrypted String? (nullable) — adapters leen campo correcto
AUDIT-25: BotStatus canónico (10 valores) + ChannelLifecycleService como único escritor
F3b-04: User rate limiter sliding-window por canal+userId
F3b-05: AES-256-GCM encrypt/decrypt via @agent-vs/crypto
F3b-06: N8nService migrado a SECRETS_ENCRYPTION_KEY + tests actualizados
F3b-UI: channel-status.ts mapa de presentación BotStatus → UI

Closes #AUDIT-23 #AUDIT-24 #AUDIT-25
Refs: F3b-04, F3b-05, F3b-06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-user, per-channel rate limiting to prevent API abuse
  * Implemented encryption for sensitive channel credentials using AES-256-GCM
  * Standardized channel status tracking with distinct lifecycle states

* **Infrastructure**
  * Enhanced database schema to support improved conversation history and execution tracking
  * Consolidated API response types for consistent channel status reporting

* **Tests**
  * Added unit tests for rate limiting and encryption modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->