### PR TITLE
feat(F3b-07): Añadir run/agent event helpers al AuditService

### DIFF
--- a/apps/api/src/modules/audit/audit.service.spec.ts
+++ b/apps/api/src/modules/audit/audit.service.spec.ts
@@ -379,9 +379,8 @@ describe('logAgentCreated', () => {
       workspaceId: 'ws-1',
       scopeLevel:  'agent',
       createdBy:   'user-1',
-      // @ts-expect-error — probando sanitización
       apiKey:      'sk-secret-key',
-    } as AgentCreatedMeta;
+    } as unknown as AgentCreatedMeta;
     const entry = service.logAgentCreated({ agentId: 'agent-sec', meta });
     expect(entry.metadata?.apiKey).toBe('[REDACTED]');
   });

--- a/apps/api/src/modules/audit/audit.service.spec.ts
+++ b/apps/api/src/modules/audit/audit.service.spec.ts
@@ -11,9 +11,14 @@ jest.mock('../../config', () => ({
 import {
   AuditService,
   CHANNEL_AUDIT_ACTIONS,
+  RUN_AUDIT_ACTIONS,
+  AGENT_AUDIT_ACTIONS,
   ChannelErrorMeta,
   ChannelMessageMeta,
   ChannelProvisionedMeta,
+  RunStartedMeta,
+  RunCompletedMeta,
+  AgentCreatedMeta,
 } from './audit.service';
 
 function flushImmediate(): Promise<void> {
@@ -65,6 +70,22 @@ describe('CHANNEL_AUDIT_ACTIONS', () => {
     expect(CHANNEL_AUDIT_ACTIONS.PROVISIONED).toBe('channel.provisioned');
     expect(CHANNEL_AUDIT_ACTIONS.MESSAGE).toBe('channel.message');
     expect(CHANNEL_AUDIT_ACTIONS.ERROR).toBe('channel.error');
+  });
+});
+
+describe('RUN_AUDIT_ACTIONS', () => {
+  it('has canonical string values', () => {
+    expect(RUN_AUDIT_ACTIONS.STARTED).toBe('run.started');
+    expect(RUN_AUDIT_ACTIONS.COMPLETED).toBe('run.completed');
+    expect(RUN_AUDIT_ACTIONS.FAILED).toBe('run.failed');
+  });
+});
+
+describe('AGENT_AUDIT_ACTIONS', () => {
+  it('has canonical string values', () => {
+    expect(AGENT_AUDIT_ACTIONS.CREATED).toBe('agent.created');
+    expect(AGENT_AUDIT_ACTIONS.UPDATED).toBe('agent.updated');
+    expect(AGENT_AUDIT_ACTIONS.DELETED).toBe('agent.deleted');
   });
 });
 
@@ -213,5 +234,167 @@ describe('queryChannelMessages filters', () => {
     const results = new AuditService().queryChannelMessages({ channelId: 'nonexistent' });
     // File may or may not exist depending on test order — just verify no crash
     expect(Array.isArray(results)).toBe(true);
+  });
+});
+
+// ── run.started ───────────────────────────────────────────────────────────────
+describe('logRunStarted', () => {
+  it('escribe entrada con action run.started y severity info', async () => {
+    const meta: RunStartedMeta = {
+      runId:       'run-001',
+      agentId:     'agent-xyz',
+      workspaceId: 'ws-1',
+      triggeredBy: 'user',
+    };
+    service.logRunStarted({ runId: 'run-001', userId: 'user-abc', meta });
+    await flushImmediate();
+    const entries = service.query({ action: 'run.started' });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].severity).toBe('info');
+    expect(entries[0].resourceId).toBe('run-001');
+  });
+
+  it('detail contiene agentId y triggeredBy', async () => {
+    const meta: RunStartedMeta = {
+      runId:       'run-001b',
+      agentId:     'agent-detail',
+      workspaceId: 'ws-1',
+      triggeredBy: 'webhook',
+    };
+    service.logRunStarted({ runId: 'run-001b', meta });
+    await flushImmediate();
+    const entries = service.query({ action: 'run.started' });
+    expect(entries[0].detail).toContain('agent-detail');
+    expect(entries[0].detail).toContain('webhook');
+  });
+});
+
+// ── run.completed ─────────────────────────────────────────────────────────────
+describe('logRunCompleted', () => {
+  it('severity "warn" cuando status es error', async () => {
+    const meta: RunCompletedMeta = {
+      runId:        'run-002',
+      agentId:      'agent-xyz',
+      workspaceId:  'ws-1',
+      status:       'error',
+      durationMs:   1500,
+      errorCode:    'LLM_TIMEOUT',
+      errorMessage: 'OpenAI timed out',
+    };
+    service.logRunCompleted({ runId: 'run-002', meta });
+    await flushImmediate();
+    const entries = service.query({ action: 'run.completed' });
+    expect(entries[0].severity).toBe('warn');
+    expect(entries[0].metadata?.errorCode).toBe('LLM_TIMEOUT');
+  });
+
+  it('severity "error" cuando status es timeout', async () => {
+    const meta: RunCompletedMeta = {
+      runId: 'run-003', agentId: 'a', workspaceId: 'w',
+      status: 'timeout', durationMs: 30000,
+    };
+    service.logRunCompleted({ runId: 'run-003', meta });
+    await flushImmediate();
+    const entries = service.query({ action: 'run.completed' });
+    const entry = entries.find(e => e.resourceId === 'run-003');
+    expect(entry?.severity).toBe('error');
+  });
+
+  it('severity "info" cuando status es success', async () => {
+    const meta: RunCompletedMeta = {
+      runId: 'run-004', agentId: 'a', workspaceId: 'w',
+      status: 'success', durationMs: 500, totalTokens: 120,
+    };
+    service.logRunCompleted({ runId: 'run-004', meta });
+    await flushImmediate();
+    const entries = service.query({ action: 'run.completed' });
+    const entry = entries.find(e => e.resourceId === 'run-004');
+    expect(entry?.severity).toBe('info');
+    expect(entry?.detail).toContain('120 tokens');
+  });
+
+  it('severity "info" cuando status es cancelled', async () => {
+    const meta: RunCompletedMeta = {
+      runId: 'run-005', agentId: 'a', workspaceId: 'w',
+      status: 'cancelled', durationMs: 200,
+    };
+    service.logRunCompleted({ runId: 'run-005', meta });
+    await flushImmediate();
+    const entries = service.query({ action: 'run.completed' });
+    const entry = entries.find(e => e.resourceId === 'run-005');
+    expect(entry?.severity).toBe('info');
+  });
+});
+
+// ── agent.created ─────────────────────────────────────────────────────────────
+describe('logAgentCreated', () => {
+  it('escribe síncronamente y devuelve AuditEntry', () => {
+    const meta: AgentCreatedMeta = {
+      agentId:     'agent-new',
+      agentName:   'Support Bot',
+      workspaceId: 'ws-1',
+      scopeLevel:  'workspace',
+      createdBy:   'user-123',
+    };
+    const entry = service.logAgentCreated({ agentId: 'agent-new', meta });
+    expect(entry.id).toMatch(/^audit-/);
+    expect(entry.action).toBe('agent.created');
+    expect(entry.severity).toBe('info');
+    // Verificar que está en el log inmediatamente (síncrono)
+    const entries = service.query({ action: 'agent.created' });
+    expect(entries.some(e => e.id === entry.id)).toBe(true);
+  });
+
+  it('detail contiene agentName, workspaceId y scopeLevel', () => {
+    const meta: AgentCreatedMeta = {
+      agentId:     'agent-detail',
+      agentName:   'Sales Agent',
+      workspaceId: 'ws-sales',
+      scopeLevel:  'department',
+      createdBy:   'user-456',
+    };
+    const entry = service.logAgentCreated({ agentId: 'agent-detail', meta });
+    expect(entry.detail).toContain('Sales Agent');
+    expect(entry.detail).toContain('ws-sales');
+    expect(entry.detail).toContain('department');
+  });
+
+  it('detail incluye parentId cuando está presente', () => {
+    const meta: AgentCreatedMeta = {
+      agentId:     'agent-child',
+      agentName:   'Child Bot',
+      workspaceId: 'ws-1',
+      scopeLevel:  'agent',
+      createdBy:   'user-1',
+      parentId:    'agent-parent-001',
+    };
+    const entry = service.logAgentCreated({ agentId: 'agent-child', meta });
+    expect(entry.detail).toContain('agent-parent-001');
+  });
+
+  it('redacta campos sensibles en metadata', () => {
+    const meta = {
+      agentId:     'agent-sec',
+      agentName:   'Bot',
+      workspaceId: 'ws-1',
+      scopeLevel:  'agent',
+      createdBy:   'user-1',
+      // @ts-expect-error — probando sanitización
+      apiKey:      'sk-secret-key',
+    } as AgentCreatedMeta;
+    const entry = service.logAgentCreated({ agentId: 'agent-sec', meta });
+    expect(entry.metadata?.apiKey).toBe('[REDACTED]');
+  });
+
+  it('usa createdBy como userId cuando userId no se pasa', () => {
+    const meta: AgentCreatedMeta = {
+      agentId:     'agent-userid',
+      agentName:   'Bot',
+      workspaceId: 'ws-1',
+      scopeLevel:  'workspace',
+      createdBy:   'user-from-meta',
+    };
+    const entry = service.logAgentCreated({ agentId: 'agent-userid', meta });
+    expect(entry.userId).toBe('user-from-meta');
   });
 });

--- a/apps/api/src/modules/audit/audit.service.ts
+++ b/apps/api/src/modules/audit/audit.service.ts
@@ -130,6 +130,7 @@ const REDACTED_KEYS = new Set([
   'privateKey', 'private_key', 'credential', 'credentials',
 ]);
 
+/** Recursively redact sensitive keys from a metadata object, including inside arrays. */
 export function sanitizeAuditMeta(
   meta: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -137,13 +138,31 @@ export function sanitizeAuditMeta(
   for (const [key, val] of Object.entries(meta)) {
     if (REDACTED_KEYS.has(key)) {
       result[key] = '[REDACTED]';
-    } else if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+    } else if (Array.isArray(val)) {
+      result[key] = val.map((item) =>
+        typeof item === 'object' && item !== null
+          ? sanitizeAuditMeta(item as Record<string, unknown>)
+          : item,
+      );
+    } else if (typeof val === 'object' && val !== null) {
       result[key] = sanitizeAuditMeta(val as Record<string, unknown>);
     } else {
       result[key] = val;
     }
   }
   return result;
+}
+
+/**
+ * Truncate and strip common secret patterns from a free-text error message
+ * before persisting it in the audit detail string.
+ */
+function sanitizeErrorMessage(msg: string): string {
+  return msg
+    .replace(/sk-[a-zA-Z0-9]{20,}/g, '[REDACTED]')
+    .replace(/Bearer\s+[\w\-\.]+/gi, 'Bearer [REDACTED]')
+    .replace(/token[=:\s]+[\w\-\.]{16,}/gi, 'token=[REDACTED]')
+    .substring(0, 300);
 }
 
 // ── AuditService ──────────────────────────────────────────────────────────────
@@ -217,6 +236,7 @@ export class AuditService {
     });
   }
 
+  /** Query audit entries from the main log with optional filters. */
   query(filters: {
     resource?:  string;
     action?:    string;
@@ -272,6 +292,7 @@ export class AuditService {
 
   // ── High-level channel event helpers ─────────────────────────────────────────
 
+  /** Log channel.provisioned — non-blocking. */
   logChannelProvisioned(params: {
     channelId:  string;
     userId?:    string;
@@ -310,6 +331,7 @@ export class AuditService {
     });
   }
 
+  /** Log channel.error — non-blocking. Severity escalates based on recoverability. */
   logChannelError(params: {
     channelId:  string;
     userId?:    string;
@@ -355,6 +377,7 @@ export class AuditService {
    * Log run.completed — non-blocking.
    * Llamar al finalizar la ejecución (éxito, error o cancelación).
    * El status 'error' eleva severity a 'warn'; 'timeout' a 'error'.
+   * errorMessage es truncado y sanitizado antes de persistirse en detail.
    */
   logRunCompleted(params: {
     runId:    string;
@@ -368,12 +391,16 @@ export class AuditService {
       timeout:   'error',
     };
 
+    const safeErrorMessage = params.meta.errorMessage
+      ? sanitizeErrorMessage(params.meta.errorMessage)
+      : undefined;
+
     const detail = params.meta.status === 'success'
       ? `Run ${params.runId} completado en ${params.meta.durationMs}ms` +
         (params.meta.totalTokens != null ? ` — ${params.meta.totalTokens} tokens` : '')
       : `Run ${params.runId} terminó con status "${params.meta.status}"` +
         (params.meta.errorCode ? ` [${params.meta.errorCode}]` : '') +
-        (params.meta.errorMessage ? `: ${params.meta.errorMessage}` : '');
+        (safeErrorMessage ? `: ${safeErrorMessage}` : '');
 
     this.logAsync({
       resource:   'run',

--- a/apps/api/src/modules/audit/audit.service.ts
+++ b/apps/api/src/modules/audit/audit.service.ts
@@ -16,6 +16,26 @@ export const CHANNEL_AUDIT_ACTIONS = {
 export type ChannelAuditAction =
   (typeof CHANNEL_AUDIT_ACTIONS)[keyof typeof CHANNEL_AUDIT_ACTIONS];
 
+// ── Run action enum ────────────────────────────────────────────────────────────
+export const RUN_AUDIT_ACTIONS = {
+  STARTED:   'run.started',
+  COMPLETED: 'run.completed',
+  FAILED:    'run.failed',
+} as const;
+
+export type RunAuditAction =
+  (typeof RUN_AUDIT_ACTIONS)[keyof typeof RUN_AUDIT_ACTIONS];
+
+// ── Agent action enum ──────────────────────────────────────────────────────────
+export const AGENT_AUDIT_ACTIONS = {
+  CREATED:   'agent.created',
+  UPDATED:   'agent.updated',
+  DELETED:   'agent.deleted',
+} as const;
+
+export type AgentAuditAction =
+  (typeof AGENT_AUDIT_ACTIONS)[keyof typeof AGENT_AUDIT_ACTIONS];
+
 // ── Typed metadata per event ──────────────────────────────────────────────────
 export interface ChannelProvisionedMeta {
   channelType:      string;
@@ -43,6 +63,41 @@ export interface ChannelErrorMeta {
   recoverable:   boolean;
   stackTrace?:   string;
   attemptCount?: number;
+}
+
+// ── Run metadata ──────────────────────────────────────────────────────────────
+export interface RunStartedMeta {
+  runId:           string;
+  agentId:         string;
+  workspaceId:     string;
+  triggeredBy:     'user' | 'schedule' | 'webhook' | 'api' | 'chain';
+  channelType?:    string;
+  conversationId?: string;
+  inputTokens?:    number;
+}
+
+export interface RunCompletedMeta {
+  runId:          string;
+  agentId:        string;
+  workspaceId:    string;
+  status:         'success' | 'error' | 'cancelled' | 'timeout';
+  durationMs:     number;
+  totalTokens?:   number;
+  outputTokens?:  number;
+  stepCount?:     number;
+  errorCode?:     string;
+  errorMessage?:  string;
+}
+
+// ── Agent metadata ─────────────────────────────────────────────────────────────
+export interface AgentCreatedMeta {
+  agentId:      string;
+  agentName:    string;
+  workspaceId:  string;
+  scopeLevel:   string;
+  parentId?:    string;
+  templateId?:  string;
+  createdBy:    string;
 }
 
 // ── AuditEntry (backward-compatible: severity is optional) ────────────────────
@@ -75,7 +130,7 @@ const REDACTED_KEYS = new Set([
   'privateKey', 'private_key', 'credential', 'credentials',
 ]);
 
-function sanitizeAuditMeta(
+export function sanitizeAuditMeta(
   meta: Record<string, unknown>,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
@@ -269,6 +324,88 @@ export class AuditService {
                   (params.meta.recoverable ? ' (recuperable)' : ' (fatal)'),
       userId:     params.userId,
       severity:   params.severity ?? (params.meta.recoverable ? 'warn' : 'error'),
+      metadata:   sanitizeAuditMeta(params.meta as unknown as Record<string, unknown>),
+    });
+  }
+
+  // ── High-level run event helpers ──────────────────────────────────────────────
+
+  /**
+   * Log run.started — non-blocking.
+   * Llamar al iniciar la ejecución de un agente, antes del primer LLM call.
+   */
+  logRunStarted(params: {
+    runId:    string;
+    userId?:  string;
+    meta:     RunStartedMeta;
+  }): void {
+    this.logAsync({
+      resource:   'run',
+      resourceId: params.runId,
+      action:     RUN_AUDIT_ACTIONS.STARTED,
+      detail:     `Run ${params.runId} iniciado — agente: ${params.meta.agentId} ` +
+                  `(trigger: ${params.meta.triggeredBy})`,
+      userId:     params.userId,
+      severity:   'info',
+      metadata:   sanitizeAuditMeta(params.meta as unknown as Record<string, unknown>),
+    });
+  }
+
+  /**
+   * Log run.completed — non-blocking.
+   * Llamar al finalizar la ejecución (éxito, error o cancelación).
+   * El status 'error' eleva severity a 'warn'; 'timeout' a 'error'.
+   */
+  logRunCompleted(params: {
+    runId:    string;
+    userId?:  string;
+    meta:     RunCompletedMeta;
+  }): void {
+    const severityMap: Record<RunCompletedMeta['status'], AuditSeverity> = {
+      success:   'info',
+      error:     'warn',
+      cancelled: 'info',
+      timeout:   'error',
+    };
+
+    const detail = params.meta.status === 'success'
+      ? `Run ${params.runId} completado en ${params.meta.durationMs}ms` +
+        (params.meta.totalTokens != null ? ` — ${params.meta.totalTokens} tokens` : '')
+      : `Run ${params.runId} terminó con status "${params.meta.status}"` +
+        (params.meta.errorCode ? ` [${params.meta.errorCode}]` : '') +
+        (params.meta.errorMessage ? `: ${params.meta.errorMessage}` : '');
+
+    this.logAsync({
+      resource:   'run',
+      resourceId: params.runId,
+      action:     RUN_AUDIT_ACTIONS.COMPLETED,
+      detail,
+      userId:     params.userId,
+      severity:   severityMap[params.meta.status],
+      metadata:   sanitizeAuditMeta(params.meta as unknown as Record<string, unknown>),
+    });
+  }
+
+  // ── High-level agent event helpers ────────────────────────────────────────────
+
+  /**
+   * Log agent.created — SÍNCRONO (low-frequency, necesita confirmación).
+   * Llamar justo después de que el agente sea persistido en Prisma.
+   */
+  logAgentCreated(params: {
+    agentId:  string;
+    userId?:  string;
+    meta:     AgentCreatedMeta;
+  }): AuditEntry {
+    return this.log({
+      resource:   'agent',
+      resourceId: params.agentId,
+      action:     AGENT_AUDIT_ACTIONS.CREATED,
+      detail:     `Agente "${params.meta.agentName}" creado en workspace ` +
+                  `${params.meta.workspaceId} (scope: ${params.meta.scopeLevel})` +
+                  (params.meta.parentId ? ` — padre: ${params.meta.parentId}` : ''),
+      userId:     params.userId ?? params.meta.createdBy,
+      severity:   'info',
       metadata:   sanitizeAuditMeta(params.meta as unknown as Record<string, unknown>),
     });
   }


### PR DESCRIPTION
## [F3b-07] AuditEvent logger — `run.started`, `run.completed`, `agent.created`

### Qué se hizo

Este PR **añade** (sin reescribir) los tipos y helpers faltantes al `AuditService` existente.

#### `audit.service.ts`
- **`RUN_AUDIT_ACTIONS`** enum (`run.started`, `run.completed`, `run.failed`)
- **`AGENT_AUDIT_ACTIONS`** enum (`agent.created`, `agent.updated`, `agent.deleted`)
- **`RunStartedMeta`**, **`RunCompletedMeta`**, **`AgentCreatedMeta`** interfaces tipadas
- **`logRunStarted()`** — async/non-blocking, severity `info`
- **`logRunCompleted()`** — async/non-blocking, severity escalada: `success→info`, `error→warn`, `timeout→error`, `cancelled→info`
- **`logAgentCreated()`** — **síncrono**, retorna `AuditEntry`, aplica `sanitizeAuditMeta()`
- `sanitizeAuditMeta()` exportada (antes era función privada del módulo)

#### `audit.service.spec.ts`
- Tests para `RUN_AUDIT_ACTIONS` y `AGENT_AUDIT_ACTIONS` enums
- Tests completos para `logRunStarted` (2 casos)
- Tests completos para `logRunCompleted` (4 casos: error/timeout/success/cancelled)
- Tests completos para `logAgentCreated` (5 casos: sync, detail, parentId, redact, userId fallback)

### Criterios de aceptación cumplidos
- [x] `logRunStarted()` escribe action `run.started`, severity `info`, no-bloqueante
- [x] `logRunCompleted()` escribe action `run.completed` con severity escalada según status
- [x] `logAgentCreated()` escribe action `agent.created` SÍNCRONAMENTE, retorna `AuditEntry`, redacta campos sensibles
- [x] `sanitizeAuditMeta()` aplicado en los 3 helpers
- [x] Tests añadidos cubriendo todos los helpers nuevos

### Rama
`feat/phase-F3b-security-layer`

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced audit logging for run and agent lifecycle events, including non-blocking run log helpers and a synchronous agent-created log that returns the created entry.
  * Recursive metadata sanitization and error-message redaction/truncation before storing audit details.

* **Tests**
  * Added coverage for run/agent audit logging: severity mapping, metadata handling and redaction, returned entry contents, query synchronization, and userId fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->