### PR TITLE
feat(F4a-02): CRUD N8nConnection — service, controller, tests

### DIFF
--- a/apps/api/src/modules/n8n/__tests__/n8n-connections.spec.ts
+++ b/apps/api/src/modules/n8n/__tests__/n8n-connections.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * n8n-connections.spec.ts
+ *
+ * Tests unitarios para N8nConnectionsService.
+ * Prisma y @lss/crypto mockeados — sin DB real.
+ */
+
+import { N8nConnectionsService } from '../n8n-connections.service';
+
+// ── Mocks globales ────────────────────────────────────────────────────
+
+const prismaMock = {
+  n8nConnection: {
+    findMany:   jest.fn(),
+    findUnique: jest.fn(),
+    create:     jest.fn(),
+    update:     jest.fn(),
+    delete:     jest.fn(),
+  },
+  n8nWorkflow: {
+    deleteMany: jest.fn(),
+  },
+};
+
+jest.mock('../../modules/core/db/prisma.service', () => ({
+  prisma: prismaMock,
+}));
+
+jest.mock('@lss/crypto', () => ({
+  encrypt: jest.fn((v: string) => `enc:${v}`),
+  decrypt: jest.fn((v: string) => v.replace('enc:', '')),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const mockRow = (overrides: Record<string, unknown> = {}) => ({
+  id:              'conn-1',
+  name:            'Mi n8n',
+  baseUrl:         'http://n8n:5678',
+  isActive:        true,
+  apiKeyEncrypted: 'enc:secret',
+  createdAt:       new Date(),
+  updatedAt:       new Date(),
+  _count:          { workflows: 3 },
+  ...overrides,
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('N8nConnectionsService', () => {
+
+  it('create() encripta apiKey antes de guardar', async () => {
+    prismaMock.n8nConnection.create.mockResolvedValue(mockRow());
+    const svc = new N8nConnectionsService();
+    await svc.create({
+      name:    'Mi n8n',
+      baseUrl: 'http://n8n:5678',
+      apiKey:  'secret',
+    });
+    expect(prismaMock.n8nConnection.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ apiKeyEncrypted: 'enc:secret' }),
+      }),
+    );
+  });
+
+  it('create() elimina trailing slash de baseUrl', async () => {
+    prismaMock.n8nConnection.create.mockResolvedValue(mockRow());
+    const svc = new N8nConnectionsService();
+    await svc.create({ name: 'X', baseUrl: 'http://n8n:5678/', apiKey: 'k' });
+    expect(prismaMock.n8nConnection.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ baseUrl: 'http://n8n:5678' }),
+      }),
+    );
+  });
+
+  it('list() nunca expone apiKeyEncrypted', async () => {
+    prismaMock.n8nConnection.findMany.mockResolvedValue([mockRow()]);
+    const svc = new N8nConnectionsService();
+    const result = await svc.list();
+    expect(result[0]).not.toHaveProperty('apiKeyEncrypted');
+    expect(result[0]?.workflowCount).toBe(3);
+  });
+
+  it('delete() elimina workflows antes de la conexión', async () => {
+    prismaMock.n8nConnection.findUnique.mockResolvedValue(mockRow());
+    prismaMock.n8nWorkflow.deleteMany.mockResolvedValue({ count: 3 });
+    prismaMock.n8nConnection.delete.mockResolvedValue({});
+    const svc = new N8nConnectionsService();
+    expect(await svc.delete('conn-1')).toBe(true);
+    expect(prismaMock.n8nWorkflow.deleteMany).toHaveBeenCalledWith(
+      { where: { connectionId: 'conn-1' } },
+    );
+  });
+
+  it('delete() retorna false si no existe', async () => {
+    prismaMock.n8nConnection.findUnique.mockResolvedValue(null);
+    expect(await new N8nConnectionsService().delete('no-id')).toBe(false);
+  });
+
+  it('testConnection() retorna ok:false si decrypt falla', async () => {
+    prismaMock.n8nConnection.findUnique.mockResolvedValue(mockRow());
+    const { decrypt } = require('@lss/crypto') as { decrypt: jest.Mock };
+    decrypt.mockImplementationOnce(() => { throw new Error('fail'); });
+    const r = await new N8nConnectionsService().testConnection('conn-1');
+    expect(r.ok).toBe(false);
+    expect((r as { ok: false; error: string }).error).toContain('decrypt');
+  });
+
+  it('testConnection() retorna ok:false si la conexión no existe', async () => {
+    prismaMock.n8nConnection.findUnique.mockResolvedValue(null);
+    const r = await new N8nConnectionsService().testConnection('no-id');
+    expect(r.ok).toBe(false);
+  });
+});

--- a/apps/api/src/modules/n8n/n8n-connections.controller.ts
+++ b/apps/api/src/modules/n8n/n8n-connections.controller.ts
@@ -1,0 +1,113 @@
+/**
+ * n8n-connections.controller.ts
+ *
+ * GET    /n8n/connections          → listar todas
+ * POST   /n8n/connections          → crear
+ * GET    /n8n/connections/:id      → obtener por id
+ * PATCH  /n8n/connections/:id      → actualizar (partial)
+ * DELETE /n8n/connections/:id      → eliminar
+ * POST   /n8n/connections/:id/test → probar conectividad
+ */
+
+import type { Router, Request, Response } from 'express';
+import { N8nConnectionsService }           from './n8n-connections.service';
+
+const connectionsService = new N8nConnectionsService();
+
+export function registerN8nConnectionRoutes(router: Router): void {
+
+  // GET /n8n/connections
+  router.get('/n8n/connections', async (_req: Request, res: Response) => {
+    try {
+      res.json(await connectionsService.list());
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // GET /n8n/connections/:id
+  router.get('/n8n/connections/:id', async (req: Request, res: Response) => {
+    try {
+      const conn = await connectionsService.findById(req.params.id);
+      if (!conn) {
+        res.status(404).json({ error: 'N8nConnection not found' });
+        return;
+      }
+      res.json(conn);
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // POST /n8n/connections
+  router.post('/n8n/connections', async (req: Request, res: Response) => {
+    try {
+      const body = req.body as {
+        name?: string;
+        baseUrl?: string;
+        apiKey?: string;
+        isActive?: boolean;
+      };
+      if (!body.name || !body.baseUrl || !body.apiKey) {
+        res.status(400).json({ error: 'name, baseUrl y apiKey son requeridos' });
+        return;
+      }
+      const conn = await connectionsService.create({
+        name:     body.name,
+        baseUrl:  body.baseUrl,
+        apiKey:   body.apiKey,
+        isActive: body.isActive,
+      });
+      res.status(201).json(conn);
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // PATCH /n8n/connections/:id
+  router.patch('/n8n/connections/:id', async (req: Request, res: Response) => {
+    try {
+      const body = req.body as {
+        name?: string;
+        baseUrl?: string;
+        apiKey?: string;
+        isActive?: boolean;
+      };
+      const conn = await connectionsService.update(req.params.id, body);
+      if (!conn) {
+        res.status(404).json({ error: 'N8nConnection not found' });
+        return;
+      }
+      res.json(conn);
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // DELETE /n8n/connections/:id
+  router.delete('/n8n/connections/:id', async (req: Request, res: Response) => {
+    try {
+      const deleted = await connectionsService.delete(req.params.id);
+      if (!deleted) {
+        res.status(404).json({ error: 'N8nConnection not found' });
+        return;
+      }
+      res.status(204).send();
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // POST /n8n/connections/:id/test
+  router.post(
+    '/n8n/connections/:id/test',
+    async (req: Request, res: Response) => {
+      try {
+        const result = await connectionsService.testConnection(req.params.id);
+        res.status(result.ok ? 200 : 502).json(result);
+      } catch (err: unknown) {
+        res.status(500).json({ error: (err as Error).message });
+      }
+    },
+  );
+}

--- a/apps/api/src/modules/n8n/n8n-connections.service.ts
+++ b/apps/api/src/modules/n8n/n8n-connections.service.ts
@@ -1,0 +1,161 @@
+/**
+ * n8n-connections.service.ts
+ *
+ * CRUD sobre el modelo N8nConnection de Prisma.
+ * Gestiona encrypt/decrypt del apiKey con @lss/crypto.
+ *
+ * Agent Visual Studio es usuario único — N8nConnection es una
+ * conexión global al servidor n8n del usuario. Sin jerarquía.
+ */
+
+import { encrypt, decrypt } from '@lss/crypto';
+import { prisma }           from '../../modules/core/db/prisma.service';
+
+// ── DTOs ──────────────────────────────────────────────────────────────
+
+export interface CreateN8nConnectionDto {
+  name:      string;
+  baseUrl:   string;
+  /** Texto plano — se encripta antes de guardar */
+  apiKey:    string;
+  isActive?: boolean;
+}
+
+export interface UpdateN8nConnectionDto {
+  name?:     string;
+  baseUrl?:  string;
+  /** Si se provee, se re-encripta antes de guardar */
+  apiKey?:   string;
+  isActive?: boolean;
+}
+
+/** Proyección segura — nunca expone apiKeyEncrypted */
+export interface N8nConnectionView {
+  id:            string;
+  name:          string;
+  baseUrl:       string;
+  isActive:      boolean;
+  createdAt:     Date;
+  updatedAt:     Date;
+  workflowCount: number;
+}
+
+// ── Service ───────────────────────────────────────────────────────────
+
+export class N8nConnectionsService {
+  private toView(row: any): N8nConnectionView {
+    return {
+      id:            row.id,
+      name:          row.name,
+      baseUrl:       row.baseUrl,
+      isActive:      row.isActive,
+      createdAt:     row.createdAt,
+      updatedAt:     row.updatedAt,
+      workflowCount: row._count?.workflows ?? 0,
+    };
+  }
+
+  async list(): Promise<N8nConnectionView[]> {
+    const rows = await prisma.n8nConnection.findMany({
+      orderBy: { createdAt: 'desc' },
+      include: { _count: { select: { workflows: true } } },
+    });
+    return rows.map((row: any) => this.toView(row));
+  }
+
+  async findById(id: string): Promise<N8nConnectionView | null> {
+    const row = await prisma.n8nConnection.findUnique({
+      where:   { id },
+      include: { _count: { select: { workflows: true } } },
+    });
+    return row ? this.toView(row) : null;
+  }
+
+  async create(dto: CreateN8nConnectionDto): Promise<N8nConnectionView> {
+    const apiKeyEncrypted = encrypt(dto.apiKey);
+    const row = await prisma.n8nConnection.create({
+      data: {
+        name:            dto.name,
+        baseUrl:         dto.baseUrl.replace(/\/$/, ''),
+        apiKeyEncrypted,
+        isActive:        dto.isActive ?? true,
+      },
+      include: { _count: { select: { workflows: true } } },
+    });
+    return this.toView(row);
+  }
+
+  async update(
+    id:  string,
+    dto: UpdateN8nConnectionDto,
+  ): Promise<N8nConnectionView | null> {
+    const existing = await prisma.n8nConnection.findUnique({ where: { id } });
+    if (!existing) return null;
+
+    const data: Record<string, unknown> = {};
+    if (dto.name     !== undefined) data['name']            = dto.name;
+    if (dto.baseUrl  !== undefined) data['baseUrl']         = dto.baseUrl.replace(/\/$/, '');
+    if (dto.isActive !== undefined) data['isActive']        = dto.isActive;
+    if (dto.apiKey   !== undefined) data['apiKeyEncrypted'] = encrypt(dto.apiKey);
+
+    const row = await prisma.n8nConnection.update({
+      where:   { id },
+      data,
+      include: { _count: { select: { workflows: true } } },
+    });
+    return this.toView(row);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const existing = await prisma.n8nConnection.findUnique({ where: { id } });
+    if (!existing) return false;
+    // Borrar workflows asociados antes de eliminar la conexión
+    await prisma.n8nWorkflow.deleteMany({ where: { connectionId: id } });
+    await prisma.n8nConnection.delete({ where: { id } });
+    return true;
+  }
+
+  /**
+   * Prueba conectividad real: desencripta apiKey y llama GET /api/v1/workflows.
+   * Timeout: 8 segundos.
+   */
+  async testConnection(id: string): Promise<
+    | { ok: true;  workflowCount: number }
+    | { ok: false; error: string }
+  > {
+    const row = await prisma.n8nConnection.findUnique({ where: { id } });
+    if (!row)          return { ok: false, error: 'Connection not found' };
+    if (!row.isActive) return { ok: false, error: 'Connection is inactive' };
+
+    let apiKey: string;
+    try {
+      apiKey = decrypt(row.apiKeyEncrypted);
+    } catch {
+      return { ok: false, error: 'Failed to decrypt API key' };
+    }
+
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 8_000);
+      let res: Response;
+      try {
+        res = await fetch(`${row.baseUrl}/api/v1/workflows`, {
+          signal:  controller.signal,
+          headers: { 'X-N8N-API-KEY': apiKey },
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+
+      if (!res.ok) return { ok: false, error: `n8n API returned ${res.status}` };
+
+      const body = await res.json() as { data?: unknown[] };
+      return { ok: true, workflowCount: body.data?.length ?? 0 };
+    } catch (err) {
+      return {
+        ok:    false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}

--- a/apps/api/src/routes.ts
+++ b/apps/api/src/routes.ts
@@ -32,6 +32,7 @@ import { registerDashboardRoutes } from './modules/dashboard/dashboard.controlle
 import { registerLlmProvidersRoutes } from './modules/llm-providers/llm-providers.controller';
 import { registerCatalogRoutes } from './modules/catalog/catalog.controller';
 import { registerSettingsRoutes } from './modules/settings/settings.controller';
+import { registerN8nConnectionRoutes } from './modules/n8n/n8n-connections.controller';
 
 export function registerRoutes(app: Express) {
   const router = Router();
@@ -74,6 +75,8 @@ export function registerRoutes(app: Express) {
   registerCatalogRoutes(router);
   // Settings: API keys de providers LLM + conexión n8n
   registerSettingsRoutes(router);
+  // N8n Connections CRUD (F4a-02)
+  registerN8nConnectionRoutes(router);
 
   app.use(studioConfig.apiPrefix, router);
 }


### PR DESCRIPTION
- n8n-connections.service.ts: list/findById/create/update/delete/testConnection
- encrypt/decrypt apiKey via @lss/crypto — never exposed in responses
- trailing slash stripped from baseUrl on create/update
- n8n-connections.controller.ts: 6 rutas REST con registerN8nConnectionRoutes()
- routes.ts: registerN8nConnectionRoutes(router) añadido
- __tests__/n8n-connections.spec.ts: 6 tests unitarios con mocks Prisma + crypto

Closes #F4a-02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added N8n integration management capabilities
  * Create, list, update, and delete connections to N8n instances
  * Test connectivity to verify connection health and retrieve workflow count
  * Secure API key encryption for safe credential storage
  * Automatic URL normalization for consistency
  * Cascading deletion of associated workflows when removing connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->