### PR TITLE
docs(gateway-api): add README.md and index.ts barrel to apps/api/src/…

### DIFF
--- a/apps/api/src/modules/gateway/README.md
+++ b/apps/api/src/modules/gateway/README.md
@@ -1,0 +1,80 @@
+# Gateway Module — `apps/api/src/modules/gateway/`
+
+> **Este módulo es un cliente HTTP del gateway externo, no el runtime del gateway.**
+
+## Responsabilidad
+
+Este módulo expone el gateway runtime como servicios inyectables dentro de la API NestJS.
+**No implementa lógica de routing, sesiones ni despacho de mensajes.**
+
+| Servicio | Rol |
+|---|---|
+| `GatewayService` | Proxy REST → `studioConfig.gatewayBaseUrl` para RPC, health, diagnostics, sessions, agents y acciones de canal (activate/deactivate) |
+| `AgentResolverService` | Resuelve el agente que atiende un `ChannelConfig` dado, consultando `ChannelBinding` en BD con cache TTL de 60 s |
+| `GatewayHealthService` | Comprobación de salud del proceso gateway externo |
+| `GatewayDiagnosticsService` | Recolecta diagnósticos del gateway externo para el panel de administración |
+
+## Lo que NO está aquí
+
+| Componente | Dónde vive |
+|---|---|
+| `SessionManager` | `apps/gateway/src/` |
+| `MessageDispatcher` | `apps/gateway/src/` |
+| `ChannelRouter` | `apps/gateway/src/` |
+| WebSocket status-stream | `apps/gateway/src/` |
+| Adaptadores Telegram / Webchat | `apps/gateway/src/` |
+
+## Split arquitectural
+
+```text
+apps/api/src/modules/gateway/   ← ESTE módulo — cliente/proxy dentro de la API
+  GatewayService                  fetch a studioConfig.gatewayBaseUrl
+  AgentResolverService            ChannelBinding → agentId (cache TTL 60 s)
+  GatewayHealthService            health check del proceso gateway
+  GatewayDiagnosticsService       diagnósticos del proceso gateway
+
+apps/gateway/src/               ← Runtime del gateway (proceso separado)
+  SessionManager                  ciclo de vida de sesiones en Prisma
+  MessageDispatcher               orquestación: mensaje entrante → agente → respuesta
+  ChannelRouter                   routing por tipo de canal (telegram, webchat, …)
+  status-stream                   WebSocket push de estado en tiempo real
+```
+
+## Regla de oro
+
+> Si buscas lógica de sesiones, routing o despacho → `apps/gateway/src/`
+> Si buscas control del gateway desde la API → `apps/api/src/modules/gateway/`
+
+## Uso desde otros módulos de la API
+
+```typescript
+// Importar GatewayModule en el módulo consumidor:
+@Module({ imports: [GatewayModule] })
+export class MiModule {}
+
+// Inyectar los servicios:
+constructor(
+  private readonly gateway:     GatewayService,
+  private readonly health:      GatewayHealthService,
+  private readonly diagnostics: GatewayDiagnosticsService,
+) {}
+
+// Comprobar salud del proceso gateway:
+const h = await this.health.check()
+
+// Listar sesiones activas (RPC + fallback dashboard):
+const sessions = await this.gateway.listSessions()
+
+// Activar / desactivar un canal:
+await this.gateway.activateChannel(channelConfigId)
+await this.gateway.deactivateChannel(channelConfigId)
+
+// Resolver qué agente atiende un canal:
+const agentId = await this.agentResolver.resolve(channelConfigId)
+```
+
+## Variables de entorno relevantes
+
+| Variable | Uso |
+|---|---|
+| `GATEWAY_BASE_URL` | URL base del proceso gateway runtime (leída por `studioConfig.gatewayBaseUrl`) |

--- a/apps/api/src/modules/gateway/index.ts
+++ b/apps/api/src/modules/gateway/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @module gateway (API proxy)
+ *
+ * Este módulo es un CLIENTE HTTP del gateway runtime externo (apps/gateway/).
+ * NO implementa lógica de sesiones, routing ni despacho de mensajes.
+ *
+ * Exports públicos:
+ *   - GatewayModule              NestJS module — importar en AppModule o en el módulo consumidor
+ *   - GatewayService             Proxy REST → studioConfig.gatewayBaseUrl
+ *   - AgentResolverService       ChannelBinding → agentId con TTL cache de 60 s
+ *   - GatewayHealthService       Health check del proceso gateway externo
+ *   - GatewayDiagnosticsService  Diagnósticos del proceso gateway externo
+ *
+ * Runtime del gateway (NO está en este módulo):
+ *   → apps/gateway/src/
+ */
+
+export { GatewayModule }              from './gateway.module.js'
+export { GatewayService }             from './gateway.service.js'
+export { AgentResolverService }       from './agent-resolver.service.js'
+export { GatewayHealthService }       from './gateway-health.service.js'
+export { GatewayDiagnosticsService }  from './gateway-diagnostics.service.js'


### PR DESCRIPTION
…modules/gateway

- README.md clarifies this module is an HTTP proxy, not the gateway runtime
- Documents all 4 services: GatewayService, AgentResolverService, GatewayDiagnosticsService, GatewayHealthService
- Explicit table of what is NOT here and where it lives (apps/gateway/src/)
- Architectural split diagram and golden rule
- index.ts barrel exports all public symbols with proxy contract comment

Refs: F3a-D1, F3a-D2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the gateway module, detailing its functionality as an HTTP client to an external gateway, including service descriptions and usage guidelines.

* **Chores**
  * Organized gateway module exports for improved API usability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->