### PR TITLE
Feat/phase f4a n8n completo

### DIFF
--- a/apps/web/src/features/canvas/components/EditableFlowCanvas.tsx
+++ b/apps/web/src/features/canvas/components/EditableFlowCanvas.tsx
@@ -15,14 +15,15 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 
 import type { FlowSpec, FlowNodeType, RunSpec, AgentSpec, SkillSpec } from '../../../lib/types';
-import { TriggerNode }     from './nodes/TriggerNode';
-import { AgentNode }       from './nodes/AgentNode';
-import { ToolNode }        from './nodes/ToolNode';
-import { ConditionNode }   from './nodes/ConditionNode';
-import { ApprovalNode }    from './nodes/ApprovalNode';
-import { EndNode }         from './nodes/EndNode';
-import { N8nWebhookNode }  from './nodes/N8nWebhookNode';
-import { SupervisorNode }  from './nodes/SupervisorNode';
+import { TriggerNode }      from './nodes/TriggerNode';
+import { AgentNode }        from './nodes/AgentNode';
+import { ToolNode }         from './nodes/ToolNode';
+import { ConditionNode }    from './nodes/ConditionNode';
+import { ApprovalNode }     from './nodes/ApprovalNode';
+import { EndNode }          from './nodes/EndNode';
+import { N8nWebhookNode }   from './nodes/N8nWebhookNode';
+import { N8nWorkflowNode }  from './nodes/N8nWorkflowNode';
+import { SupervisorNode }   from './nodes/SupervisorNode';
 import { generateNodeId, getNodeTemplate } from '../lib/canvas-utils';
 
 const NODE_TYPES = {
@@ -39,7 +40,7 @@ const NODE_TYPES = {
   // ── new ────────────────────────────────────
   supervisor:    SupervisorNode,
   n8n_webhook:   N8nWebhookNode,
-  n8n_workflow:  N8nWebhookNode, // reuses webhook visual until dedicated node
+  n8n_workflow:  N8nWorkflowNode,
 };
 
 const STATUS_COLORS: Record<string, string> = {

--- a/apps/web/src/features/canvas/components/NodeEditor.tsx
+++ b/apps/web/src/features/canvas/components/NodeEditor.tsx
@@ -102,7 +102,7 @@ export function NodeEditor({ nodeId, nodeType, config, agents, skills, onChange,
           </select>
           {config.agentName && (
             <div className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
-              model: <span className="font-mono">{(config.model as string) ?? '—'}</span>
+              model: <span className="font-mono">{(config.model as string) ?? '\u2014'}</span>
             </div>
           )}
         </div>
@@ -267,7 +267,22 @@ export function NodeEditor({ nodeId, nodeType, config, agents, skills, onChange,
       {/* ── n8n Workflow ─────────────────────────────────────────────────── */}
       {nodeType === 'n8n_workflow' && (
         <div className="space-y-2">
-          <label className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Workflow ID</label>
+          {/* Label visible en el canvas */}
+          <label className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>
+            Label (display name)
+          </label>
+          <input
+            value={(config.label as string) ?? ''}
+            onChange={(e) => updateField('label', e.target.value)}
+            placeholder="My Workflow"
+            className="w-full rounded border px-2 py-1 text-xs"
+            style={{ borderColor: 'var(--border-primary)', background: 'var(--bg-primary)' }}
+          />
+
+          {/* Workflow ID */}
+          <label className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>
+            Workflow ID
+          </label>
           <input
             value={(config.workflowId as string) ?? ''}
             onChange={(e) => updateField('workflowId', e.target.value)}
@@ -275,6 +290,77 @@ export function NodeEditor({ nodeId, nodeType, config, agents, skills, onChange,
             className="w-full rounded border px-2 py-1 text-xs font-mono"
             style={{ borderColor: 'var(--border-primary)', background: 'var(--bg-primary)' }}
           />
+
+          {/* Trigger Mode */}
+          <label className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>
+            Trigger Mode
+          </label>
+          <select
+            value={(config.triggerMode as string) ?? 'webhook'}
+            onChange={(e) => updateField('triggerMode', e.target.value)}
+            className="w-full rounded border px-2 py-1 text-xs"
+            style={{ borderColor: 'var(--border-primary)', background: 'var(--bg-primary)' }}
+          >
+            <option value="webhook">Webhook</option>
+            <option value="schedule">Schedule</option>
+            <option value="manual">Manual</option>
+          </select>
+
+          {/* Input Mapping — JSON object */}
+          <label className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>
+            Input Mapping (JSON)
+          </label>
+          <textarea
+            value={
+              typeof config.inputMapping === 'object'
+                ? JSON.stringify(config.inputMapping, null, 2)
+                : ((config.inputMapping as string) ?? '{}')
+            }
+            onChange={(e) => {
+              try {
+                updateField('inputMapping', JSON.parse(e.target.value));
+              } catch {
+                // allow partial editing — don't update on parse error
+              }
+            }}
+            placeholder='{ "agentOutput": "$.body.result" }'
+            rows={3}
+            className="w-full rounded border px-2 py-1 text-[10px] font-mono resize-none"
+            style={{ borderColor: 'var(--border-primary)', background: 'var(--bg-primary)' }}
+          />
+
+          {/* Output Mapping — JSON object */}
+          <label className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>
+            Output Mapping (JSON)
+          </label>
+          <textarea
+            value={
+              typeof config.outputMapping === 'object'
+                ? JSON.stringify(config.outputMapping, null, 2)
+                : ((config.outputMapping as string) ?? '{}')
+            }
+            onChange={(e) => {
+              try {
+                updateField('outputMapping', JSON.parse(e.target.value));
+              } catch {
+                // allow partial editing
+              }
+            }}
+            placeholder='{ "result": "$.body.data" }'
+            rows={3}
+            className="w-full rounded border px-2 py-1 text-[10px] font-mono resize-none"
+            style={{ borderColor: 'var(--border-primary)', background: 'var(--bg-primary)' }}
+          />
+
+          {/* Wait for result */}
+          <label className="flex items-center gap-2 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+            <input
+              type="checkbox"
+              checked={(config.waitForResult as boolean) ?? false}
+              onChange={(e) => updateField('waitForResult', e.target.checked)}
+            />
+            Wait for workflow result (sync)
+          </label>
         </div>
       )}
     </div>

--- a/apps/web/src/features/canvas/components/nodes/N8nWorkflowNode.tsx
+++ b/apps/web/src/features/canvas/components/nodes/N8nWorkflowNode.tsx
@@ -1,0 +1,112 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+
+interface N8nWorkflowData {
+  config?: {
+    label?:         string;
+    workflowId?:    string;
+    workflowName?:  string;
+    triggerMode?:   'webhook' | 'schedule' | 'manual';
+    inputMapping?:  Record<string, string>;
+    outputMapping?: Record<string, string>;
+    waitForResult?: boolean;
+  };
+}
+
+export function N8nWorkflowNode({ data, selected }: NodeProps<N8nWorkflowData>) {
+  const {
+    label,
+    workflowId,
+    workflowName,
+    triggerMode,
+    inputMapping,
+    outputMapping,
+    waitForResult,
+  } = data.config ?? {};
+
+  const inputCount  = Object.keys(inputMapping  ?? {}).length;
+  const outputCount = Object.keys(outputMapping ?? {}).length;
+
+  return (
+    <div
+      style={{
+        minWidth: 170,
+        borderRadius: 8,
+        border: `2px solid ${selected ? '#d97706' : '#fcd34d'}`,
+        background: '#fffbeb',
+        padding: '10px 14px',
+        fontSize: 11,
+        boxShadow: '0 1px 4px rgba(0,0,0,0.10)',
+      }}
+    >
+      <Handle type="target" position={Position.Top} />
+
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+        <span style={{ fontSize: 16 }}>⚙️</span>
+        <span style={{ fontWeight: 700, color: '#92400e' }}>n8n Workflow</span>
+      </div>
+
+      {/* Label / Workflow name */}
+      <div style={{ fontWeight: 600, color: '#1c1917', marginBottom: 2 }}>
+        {label ?? workflowName ?? 'Untitled Workflow'}
+      </div>
+
+      {/* Workflow ID */}
+      {workflowId && (
+        <div
+          style={{
+            fontFamily: 'monospace',
+            fontSize: 10,
+            color: '#78716c',
+            marginBottom: 4,
+          }}
+        >
+          id: {workflowId}
+        </div>
+      )}
+
+      {/* Trigger mode badge */}
+      {triggerMode && (
+        <div style={{ marginBottom: 4 }}>
+          <span
+            style={{
+              display: 'inline-block',
+              background: '#fef3c7',
+              color: '#92400e',
+              borderRadius: 3,
+              padding: '1px 5px',
+              fontSize: 10,
+              fontWeight: 700,
+            }}
+          >
+            {triggerMode}
+          </span>
+        </div>
+      )}
+
+      {/* Mapping summary */}
+      {(inputCount > 0 || outputCount > 0) && (
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            fontSize: 10,
+            color: '#a8a29e',
+          }}
+        >
+          {inputCount  > 0 && <span>in: {inputCount}</span>}
+          {outputCount > 0 && <span>out: {outputCount}</span>}
+        </div>
+      )}
+
+      {/* waitForResult indicator */}
+      {waitForResult && (
+        <div style={{ marginTop: 4, fontSize: 10, color: '#d97706', fontWeight: 600 }}>
+          ⏳ wait for result
+        </div>
+      )}
+
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/apps/web/src/features/canvas/lib/canvas-utils.ts
+++ b/apps/web/src/features/canvas/lib/canvas-utils.ts
@@ -69,7 +69,15 @@ export const NODE_TEMPLATES: NodeTemplate[] = [
   },
   {
     type: 'n8n_workflow', label: 'n8n Workflow', icon: '⚙️', color: '#d97706', group: 'n8n',
-    defaultConfig: { workflowId: '', inputMapping: {}, outputMapping: {} },
+    defaultConfig: {
+      label:         '',
+      workflowId:    '',
+      workflowName:  '',
+      triggerMode:   'webhook',
+      inputMapping:  {},
+      outputMapping: {},
+      waitForResult: false,
+    },
   },
 ];
 

--- a/apps/web/src/features/flows/components/FlowCanvas.tsx
+++ b/apps/web/src/features/flows/components/FlowCanvas.tsx
@@ -1,25 +1,36 @@
-import { useMemo } from 'react';
-import ReactFlow, { Background, Controls, Edge, Node } from 'reactflow';
+import { useCallback, useMemo, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from 'reactflow';
 import 'reactflow/dist/style.css';
 
-import { FlowSpec, RunSpec } from '../../../lib/types';
+import type { FlowNode } from '../../../lib/types-base';
+import { type FlowSpec, type RunSpec } from '../../../lib/types';
+import { N8nNodePanel } from './N8nNodePanel';
 
 const STATUS_COLORS: Record<string, { bg: string; border: string }> = {
-  completed:         { bg: '#d1fae5', border: '#059669' },
-  running:           { bg: '#dbeafe', border: '#2563eb' },
-  waiting_approval:  { bg: '#fef3c7', border: '#d97706' },
-  failed:            { bg: '#fee2e2', border: '#dc2626' },
-  queued:            { bg: '#f3f4f6', border: '#9ca3af' },
-  skipped:           { bg: '#f3f4f6', border: '#d1d5db' },
+  completed:        { bg: '#d1fae5', border: '#059669' },
+  running:          { bg: '#dbeafe', border: '#2563eb' },
+  waiting_approval: { bg: '#fef3c7', border: '#d97706' },
+  failed:           { bg: '#fee2e2', border: '#dc2626' },
+  queued:           { bg: '#f3f4f6', border: '#9ca3af' },
+  skipped:          { bg: '#f3f4f6', border: '#d1d5db' },
 };
 
 interface FlowCanvasProps {
-  flow?: FlowSpec;
-  activeRun?: RunSpec;
+  flow?:         FlowSpec;
+  activeRun?:    RunSpec;
+  /** Callback para persistir cambios de nodo desde el panel lateral */
+  onNodeUpdate?: (updatedNode: FlowNode) => void;
 }
 
-export function FlowCanvas({ flow, activeRun }: FlowCanvasProps) {
-  // Build a nodeId → step status map from the active run
+export function FlowCanvas({ flow, activeRun, onNodeUpdate }: FlowCanvasProps) {
+  const [selectedNode, setSelectedNode] = useState<FlowNode | null>(null);
+
   const stepStatusMap = useMemo(() => {
     if (!activeRun) return new Map<string, string>();
     const map = new Map<string, string>();
@@ -31,18 +42,27 @@ export function FlowCanvas({ flow, activeRun }: FlowCanvasProps) {
 
   const nodes = useMemo<Node[]>(
     () =>
-      (flow?.nodes ?? []).map((node) => {
+      ((flow?.nodes ?? []) as FlowNode[]).map((node) => {
         const stepStatus = stepStatusMap.get(node.id);
-        const colors = stepStatus ? STATUS_COLORS[stepStatus] : undefined;
+        const colors     = stepStatus ? STATUS_COLORS[stepStatus] : undefined;
+        const isN8n      = node.type === 'n8n';
 
         return {
-          id: node.id,
-          type: 'default',
+          id:       node.id,
+          type:     'default',
           position: node.position ?? { x: 120, y: 120 },
-          data: { label: node.type },
-          style: colors
-            ? { background: colors.bg, borderColor: colors.border, borderWidth: 2 }
-            : undefined,
+          data: {
+            label: node.label ?? node.type,
+            _raw:  node,
+          },
+          style: {
+            ...(colors
+              ? { background: colors.bg, borderColor: colors.border, borderWidth: 2 }
+              : undefined),
+            ...(isN8n && !node.n8n?.workflowId
+              ? { borderStyle: 'dashed', borderColor: '#a5b4fc' }
+              : undefined),
+          },
         };
       }),
     [flow?.nodes, stepStatusMap],
@@ -50,21 +70,54 @@ export function FlowCanvas({ flow, activeRun }: FlowCanvasProps) {
 
   const edges = useMemo<Edge[]>(
     () =>
-      (flow?.edges ?? []).map((edge, index) => ({
-        id: edge.from + '-' + edge.to + '-' + index,
-        source: edge.from,
-        target: edge.to,
-        label: edge.condition,
-      })),
+      ((flow?.edges ?? []) as Array<{ from: string; to: string; condition?: string }>).map(
+        (edge, index) => ({
+          id:     edge.from + '-' + edge.to + '-' + index,
+          source: edge.from,
+          target: edge.to,
+          label:  edge.condition,
+        }),
+      ),
     [flow?.edges],
   );
 
+  const handleNodeClick: NodeMouseHandler = useCallback((_event, rfNode) => {
+    const rawNode = (rfNode.data as { _raw?: FlowNode })._raw;
+    if (rawNode?.type === 'n8n') {
+      setSelectedNode(rawNode);
+    }
+  }, []);
+
+  const handleNodeSave = useCallback(
+    (updated: FlowNode) => {
+      onNodeUpdate?.(updated);
+      setSelectedNode(updated);
+    },
+    [onNodeUpdate],
+  );
+
   return (
-    <div className="h-[420px] overflow-hidden rounded border border-slate-300 bg-white">
-      <ReactFlow nodes={nodes} edges={edges} fitView>
-        <Background />
-        <Controls />
-      </ReactFlow>
+    <div className="flex h-[420px] overflow-hidden rounded border border-slate-300 bg-white">
+      <div className="flex-1">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          fitView
+          onNodeClick={handleNodeClick}
+        >
+          <Background />
+          <Controls />
+        </ReactFlow>
+      </div>
+
+      {selectedNode && flow?.id && (
+        <N8nNodePanel
+          node={selectedNode}
+          flowId={flow.id}
+          onSave={handleNodeSave}
+          onClose={() => setSelectedNode(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/flows/components/N8nNodePanel.tsx
+++ b/apps/web/src/features/flows/components/N8nNodePanel.tsx
@@ -1,0 +1,424 @@
+/**
+ * N8nNodePanel
+ * Panel de propiedades lateral para un nodo de tipo 'n8n' en el canvas de flows.
+ *
+ * Responsabilidades:
+ *   1. Selector de workflow (combobox con los workflows de n8n)
+ *   2. Input mapping: tabla editable key → expresión
+ *   3. Acciones: Guardar, Sincronizar con n8n, Activar/Desactivar workflow
+ *   4. Sección de ejecuciones recientes (últimas 5)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import type { FlowNode, N8nInputMapping, N8nNodeConfig } from '../../../lib/types-base';
+import {
+  activateN8nWorkflow,
+  deactivateN8nWorkflow,
+  listN8nExecutions,
+  syncFlowToN8n,
+  type N8nExecutionSummary,
+} from '../../../lib/api';
+import { useN8nWorkflows } from '../hooks/useN8nWorkflows';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function emptyConfig(): N8nNodeConfig {
+  return { workflowId: '', inputMapping: {} };
+}
+
+function statusBadgeClass(status: N8nExecutionSummary['status']): string {
+  const map: Record<string, string> = {
+    success:  'bg-emerald-100 text-emerald-700',
+    running:  'bg-blue-100 text-blue-700',
+    error:    'bg-red-100 text-red-700',
+    waiting:  'bg-amber-100 text-amber-700',
+    canceled: 'bg-slate-100 text-slate-500',
+  };
+  return map[status] ?? 'bg-slate-100 text-slate-500';
+}
+
+function formatDate(iso: string): string {
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+// ── Sub-componente: InputMappingEditor ─────────────────────────────────────────
+
+interface MappingEditorProps {
+  mapping:  N8nInputMapping;
+  onChange: (mapping: N8nInputMapping) => void;
+}
+
+function InputMappingEditor({ mapping, onChange }: MappingEditorProps) {
+  const entries = Object.entries(mapping);
+
+  const update = (key: string, value: string) => {
+    onChange({ ...mapping, [key]: value });
+  };
+
+  const addRow = () => {
+    const newKey = `param_${Date.now()}`;
+    onChange({ ...mapping, [newKey]: '' });
+  };
+
+  const removeRow = (key: string) => {
+    const next = { ...mapping };
+    delete next[key];
+    onChange(next);
+  };
+
+  const renameKey = (oldKey: string, newKey: string) => {
+    if (oldKey === newKey) return;
+    const next: N8nInputMapping = {};
+    for (const [k, v] of Object.entries(mapping)) {
+      next[k === oldKey ? newKey : k] = v;
+    }
+    onChange(next);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-[1fr_1fr_auto] gap-1 text-xs font-medium text-slate-500 px-1">
+        <span>Parámetro n8n</span>
+        <span>Expresión / valor</span>
+        <span />
+      </div>
+
+      {entries.length === 0 && (
+        <p className="text-xs text-slate-400 px-1">
+          Sin parámetros. Haz clic en «+ Añadir» para mapear entradas.
+        </p>
+      )}
+
+      {entries.map(([key, value]) => (
+        <div key={key} className="grid grid-cols-[1fr_1fr_auto] gap-1 items-center">
+          <input
+            className="rounded border border-slate-200 px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-400"
+            defaultValue={key}
+            onBlur={(e) => renameKey(key, e.currentTarget.value.trim())}
+            placeholder="nombre_param"
+          />
+          <input
+            className="rounded border border-slate-200 px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-indigo-400"
+            value={value}
+            onChange={(e) => update(key, e.currentTarget.value)}
+            placeholder='{{output.field}} o "valor literal"'
+          />
+          <button
+            type="button"
+            onClick={() => removeRow(key)}
+            className="rounded px-1.5 py-1 text-xs text-slate-400 hover:bg-red-50 hover:text-red-500"
+            aria-label={`Eliminar parámetro ${key}`}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={addRow}
+        className="mt-1 self-start rounded border border-dashed border-slate-300 px-3 py-1 text-xs text-slate-500 hover:border-indigo-400 hover:text-indigo-600"
+      >
+        + Añadir parámetro
+      </button>
+    </div>
+  );
+}
+
+// ── Sub-componente: ExecutionList ──────────────────────────────────────────────
+
+interface ExecutionListProps {
+  workflowId: string;
+}
+
+function ExecutionList({ workflowId }: ExecutionListProps) {
+  const [executions, setExecutions] = useState<N8nExecutionSummary[]>([]);
+  const [loading, setLoading]       = useState(false);
+
+  useEffect(() => {
+    if (!workflowId) return;
+    setLoading(true);
+    listN8nExecutions(workflowId)
+      .then((data) => setExecutions(data.slice(0, 5)))
+      .catch(() => setExecutions([]))
+      .finally(() => setLoading(false));
+  }, [workflowId]);
+
+  if (!workflowId) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">
+        Ejecuciones recientes
+      </p>
+      {loading && <p className="text-xs text-slate-400">Cargando…</p>}
+      {!loading && executions.length === 0 && (
+        <p className="text-xs text-slate-400">Sin ejecuciones registradas.</p>
+      )}
+      {executions.map((ex) => (
+        <div key={ex.id} className="flex items-center justify-between rounded bg-slate-50 px-2 py-1.5 text-xs">
+          <div className="flex flex-col gap-0.5">
+            <span className="font-mono text-slate-600">#{ex.id}</span>
+            <span className="text-slate-400">{formatDate(ex.startedAt)}</span>
+          </div>
+          <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${statusBadgeClass(ex.status)}`}>
+            {ex.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Componente principal: N8nNodePanel ─────────────────────────────────────────
+
+export interface N8nNodePanelProps {
+  node:    FlowNode;
+  flowId:  string;
+  onSave:  (updated: FlowNode) => void;
+  onClose: () => void;
+}
+
+export function N8nNodePanel({ node, flowId, onSave, onClose }: N8nNodePanelProps) {
+  const { workflows, loading: workflowsLoading, error: workflowsError, refetch } = useN8nWorkflows();
+
+  const [config, setConfig]         = useState<N8nNodeConfig>(() => node.n8n ?? emptyConfig());
+  const [label, setLabel]           = useState(node.label ?? node.id);
+  const [syncStatus, setSyncStatus] = useState<'idle' | 'syncing' | 'ok' | 'error'>('idle');
+  const [syncError,  setSyncError]  = useState<string | null>(null);
+  const [activating, setActivating] = useState(false);
+
+  useEffect(() => {
+    setConfig(node.n8n ?? emptyConfig());
+    setLabel(node.label ?? node.id);
+    setSyncStatus('idle');
+    setSyncError(null);
+  }, [node.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectedWorkflow = workflows.find((w) => w.id === config.workflowId);
+
+  const handleSave = useCallback(() => {
+    onSave({ ...node, label, n8n: config });
+  }, [node, label, config, onSave]);
+
+  const handleSync = useCallback(async () => {
+    setSyncStatus('syncing');
+    setSyncError(null);
+    try {
+      const result = await syncFlowToN8n(flowId, config.workflowId || undefined);
+      if (!config.workflowId && result.id) {
+        setConfig((c) => ({ ...c, workflowId: result.id }));
+      }
+      setSyncStatus('ok');
+    } catch (err) {
+      setSyncError((err as Error).message);
+      setSyncStatus('error');
+    }
+  }, [flowId, config.workflowId]);
+
+  const handleToggleActive = useCallback(async () => {
+    if (!config.workflowId || !selectedWorkflow) return;
+    setActivating(true);
+    try {
+      if (selectedWorkflow.active) {
+        await deactivateN8nWorkflow(config.workflowId);
+      } else {
+        await activateN8nWorkflow(config.workflowId);
+      }
+      refetch();
+    } catch (err) {
+      console.error('[N8nNodePanel] toggle active error:', err);
+    } finally {
+      setActivating(false);
+    }
+  }, [config.workflowId, selectedWorkflow, refetch]);
+
+  return (
+    <aside
+      className="flex h-full w-80 flex-col border-l border-slate-200 bg-white"
+      aria-label="Panel de propiedades del nodo n8n"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect width="24" height="24" rx="4" fill="#EA4B71"/>
+            <path d="M7 12h10M12 7v10" stroke="white" strokeWidth="2.5" strokeLinecap="round"/>
+          </svg>
+          <span className="text-sm font-semibold text-slate-800">Nodo n8n</span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+          aria-label="Cerrar panel"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M1 1l12 12M13 1L1 13"/>
+          </svg>
+        </button>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-4 py-4">
+
+        {/* Identificación del nodo */}
+        <section className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium text-slate-600" htmlFor="n8n-node-label">
+            Etiqueta del nodo
+          </label>
+          <input
+            id="n8n-node-label"
+            type="text"
+            className="rounded border border-slate-200 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder={node.id}
+          />
+          <p className="text-[11px] text-slate-400">ID interno: <code className="font-mono">{node.id}</code></p>
+        </section>
+
+        {/* Selector de workflow */}
+        <section className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium text-slate-600" htmlFor="n8n-workflow-select">
+            Workflow n8n
+          </label>
+
+          {workflowsError && (
+            <div className="rounded bg-red-50 px-3 py-2 text-xs text-red-600">
+              Error cargando workflows: {workflowsError}.{' '}
+              <button type="button" onClick={refetch} className="underline hover:no-underline">
+                Reintentar
+              </button>
+            </div>
+          )}
+
+          <div className="relative">
+            <select
+              id="n8n-workflow-select"
+              className="w-full appearance-none rounded border border-slate-200 bg-white px-3 py-1.5 pr-8 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 disabled:bg-slate-50 disabled:text-slate-400"
+              value={config.workflowId}
+              onChange={(e) => setConfig((c) => ({ ...c, workflowId: e.target.value }))}
+              disabled={workflowsLoading}
+            >
+              <option value="">
+                {workflowsLoading ? 'Cargando workflows…' : '— Seleccionar workflow —'}
+              </option>
+              {workflows.map((wf) => (
+                <option key={wf.id} value={wf.id}>
+                  {wf.name}{wf.active ? ' ✓' : ''}
+                </option>
+              ))}
+            </select>
+            <svg
+              className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-slate-400"
+              width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5"
+            >
+              <path d="M2 4l4 4 4-4"/>
+            </svg>
+          </div>
+
+          {selectedWorkflow && (
+            <div className="flex items-center gap-2">
+              <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                selectedWorkflow.active ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'
+              }`}>
+                {selectedWorkflow.active ? 'Activo' : 'Inactivo'}
+              </span>
+              <button
+                type="button"
+                disabled={activating}
+                onClick={handleToggleActive}
+                className="text-[11px] text-indigo-500 underline hover:no-underline disabled:opacity-50"
+              >
+                {activating ? 'Cambiando…' : selectedWorkflow.active ? 'Desactivar' : 'Activar'}
+              </button>
+            </div>
+          )}
+        </section>
+
+        {/* Webhook path */}
+        <section className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium text-slate-600" htmlFor="n8n-webhook-path">
+            Webhook path{' '}
+            <span className="font-normal text-slate-400">(opcional)</span>
+          </label>
+          <input
+            id="n8n-webhook-path"
+            type="text"
+            className="rounded border border-slate-200 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+            value={config.webhookPath ?? ''}
+            onChange={(e) => setConfig((c) => ({ ...c, webhookPath: e.target.value || undefined }))}
+            placeholder="/my-webhook"
+          />
+          <p className="text-[11px] text-slate-400">
+            Rellena solo si este nodo dispara un webhook n8n, no una ejecución directa.
+          </p>
+        </section>
+
+        {/* Input mapping */}
+        <section className="flex flex-col gap-2">
+          <div>
+            <p className="text-xs font-medium text-slate-600">Input mapping</p>
+            <p className="text-[11px] text-slate-400">
+              Mapea entradas del canvas al payload que recibirá el workflow n8n.
+              Usa <code className="font-mono">{'{'}{'{'}'output.campo'{'}'}{'}'}}</code> para referencias dinámicas.
+            </p>
+          </div>
+          <InputMappingEditor
+            mapping={config.inputMapping}
+            onChange={(m) => setConfig((c) => ({ ...c, inputMapping: m }))}
+          />
+        </section>
+
+        {/* Ejecuciones recientes */}
+        {config.workflowId && (
+          <section>
+            <ExecutionList workflowId={config.workflowId} />
+          </section>
+        )}
+
+      </div>
+
+      {/* Footer: acciones */}
+      <div className="flex flex-col gap-2 border-t border-slate-100 px-4 py-3">
+        {syncStatus === 'ok' && (
+          <p className="text-center text-xs text-emerald-600">
+            ✓ Sincronizado con n8n correctamente
+          </p>
+        )}
+        {syncStatus === 'error' && syncError && (
+          <p className="text-center text-xs text-red-500">
+            Error: {syncError}
+          </p>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={syncStatus === 'syncing'}
+            onClick={handleSync}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded border border-indigo-300 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:bg-indigo-50 disabled:opacity-50"
+          >
+            {syncStatus === 'syncing' ? (
+              <>
+                <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-indigo-400 border-t-transparent" />
+                Sincronizando…
+              </>
+            ) : (
+              '↑ Sync n8n'
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleSave}
+            className="flex-1 rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700"
+          >
+            Guardar
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/features/flows/hooks/useN8nWorkflows.ts
+++ b/apps/web/src/features/flows/hooks/useN8nWorkflows.ts
@@ -1,0 +1,38 @@
+/**
+ * useN8nWorkflows
+ * Carga la lista de workflows n8n disponibles para el selector del panel.
+ * Hace fetch a GET /api/studio/v1/n8n/workflows una sola vez por mount.
+ * Expone: workflows, loading, error, refetch.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { listN8nWorkflows, type N8nWorkflowSummary } from '../../../lib/api';
+
+export interface UseN8nWorkflowsResult {
+  workflows: N8nWorkflowSummary[];
+  loading:   boolean;
+  error:     string | null;
+  refetch:   () => void;
+}
+
+export function useN8nWorkflows(): UseN8nWorkflowsResult {
+  const [workflows, setWorkflows] = useState<N8nWorkflowSummary[]>([]);
+  const [loading,   setLoading]   = useState(true);
+  const [error,     setError]     = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listN8nWorkflows();
+      setWorkflows(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  return { workflows, loading, error, refetch: load };
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -186,8 +186,6 @@ export async function createWorkspace(input: {
   defaultModel?: string;
   skillIds?: string[];
 }) {
-  // Bootstrap endpoint: backend handles merge order (request > profile > defaults)
-  // Only include fields user explicitly set - backend fills in profile defaults
   const workspaceSpec: Record<string, any> = {
     name: input.name,
     agentIds: [],
@@ -195,7 +193,6 @@ export async function createWorkspace(input: {
     policyIds: [],
   };
 
-  // Only include optional fields if explicitly set (not undefined)
   if (input.slug !== undefined) workspaceSpec.slug = input.slug;
   if (input.defaultModel !== undefined) workspaceSpec.defaultModel = input.defaultModel;
   if (input.skillIds !== undefined) workspaceSpec.skillIds = input.skillIds;
@@ -588,4 +585,68 @@ export async function getUsage(filters?: { from?: string; to?: string; groupBy?:
 export async function getUsageByAgent() {
   const response = await fetch(`${API_BASE}/usage/by-agent`);
   return parseJson<Array<{ agentId: string; cost: number; tokens: { input: number; output: number }; steps: number }>>(response);
+}
+
+// ── n8n ───────────────────────────────────────────────────────────────────────
+
+export interface N8nWorkflowSummary {
+  id:     string;
+  name:   string;
+  active: boolean;
+}
+
+export interface N8nExecutionSummary {
+  id:         string;
+  workflowId: string;
+  finished:   boolean;
+  mode:       string;
+  startedAt:  string;
+  stoppedAt?: string;
+  status:     'running' | 'success' | 'error' | 'waiting' | 'canceled';
+}
+
+export async function listN8nWorkflows(): Promise<N8nWorkflowSummary[]> {
+  const response = await fetch(`${API_BASE}/n8n/workflows`);
+  return parseJson<N8nWorkflowSummary[]>(response);
+}
+
+export async function getN8nWorkflow(
+  workflowId: string,
+): Promise<N8nWorkflowSummary & { nodes: unknown[]; connections: unknown }> {
+  const response = await fetch(`${API_BASE}/n8n/workflows/${encodeURIComponent(workflowId)}`);
+  return parseJson(response);
+}
+
+export async function syncFlowToN8n(
+  flowId:      string,
+  workflowId?: string,
+): Promise<N8nWorkflowSummary> {
+  const response = await fetch(`${API_BASE}/n8n/sync-flow/${encodeURIComponent(flowId)}`, {
+    method:  'POST',
+    headers: { 'content-type': 'application/json' },
+    body:    JSON.stringify({ workflowId }),
+  });
+  return parseJson(response);
+}
+
+export async function activateN8nWorkflow(workflowId: string): Promise<{ ok: boolean }> {
+  const response = await fetch(
+    `${API_BASE}/n8n/workflows/${encodeURIComponent(workflowId)}/activate`,
+    { method: 'POST' },
+  );
+  return parseJson(response);
+}
+
+export async function deactivateN8nWorkflow(workflowId: string): Promise<{ ok: boolean }> {
+  const response = await fetch(
+    `${API_BASE}/n8n/workflows/${encodeURIComponent(workflowId)}/deactivate`,
+    { method: 'POST' },
+  );
+  return parseJson(response);
+}
+
+export async function listN8nExecutions(workflowId?: string): Promise<N8nExecutionSummary[]> {
+  const qs = workflowId ? `?workflowId=${encodeURIComponent(workflowId)}` : '';
+  const response = await fetch(`${API_BASE}/n8n/executions${qs}`);
+  return parseJson<N8nExecutionSummary[]>(response);
 }

--- a/apps/web/src/lib/types-base.ts
+++ b/apps/web/src/lib/types-base.ts
@@ -68,3 +68,30 @@ export interface StudioState {
   skills: SkillSpec[];
   profiles: ProfileSpec[];
 }
+
+// ── Flow Node types ───────────────────────────────────────────────────────────
+
+/** Mapeado de entradas del canvas al payload del workflow n8n.
+ *  Cada entrada es una expresión libre: puede ser un valor literal
+ *  o una referencia tipo "{{output.fieldName}}". */
+export type N8nInputMapping = Record<string, string>;
+
+export interface N8nNodeConfig {
+  /** ID del workflow en n8n (string numérico, ej: "42") */
+  workflowId:   string;
+  /** ID del webhook en n8n (solo si triggerType === 'webhook') */
+  webhookPath?: string;
+  /** Mapeo nombre_parametro → expresión de valor */
+  inputMapping: N8nInputMapping;
+}
+
+export interface FlowNode {
+  id:        string;
+  type:      string;
+  label?:    string;
+  position?: { x: number; y: number };
+  /** Presente cuando type === 'n8n' */
+  n8n?:      N8nNodeConfig;
+  /** Metadatos abiertos para otros tipos de nodo */
+  config?:   Record<string, unknown>;
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Listo. Todo pusheado correctamente.</p><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="estado-final--f4a-05">Estado final — F4a-05</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Commit:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/commit/106af93af3ccde257af97f0b9f4e216cdb2e44b7"><span class="text-box-trim-both"><code>106af93a</code></span></a><br><strong>Rama:</strong> <code>feat/phase-F4a-n8n-completo</code><br><strong>Refs:</strong> PR #262</p><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-pusheados">Archivos pusheados</h2><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: visible; visibility: visible;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] dark:shadow-lg border-subtlest ring-subtlest divide-subtlest">
Archivo | Acción | Contenido clave
-- | -- | --


</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="puntos-de-integracin-destacados">Puntos de integración destacados</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Los nodos <code>n8n</code> sin <code>workflowId</code> configurado muestran borde punteado <code>#a5b4fc</code> en el canvas como indicador visual de configuración pendiente</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El <code>InputMappingEditor</code> soporta renombrar claves (on blur), editar valores en tiempo real y eliminar filas sin perder otras entradas</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>handleSync</code> actualiza <code>workflowId</code> automáticamente si el sync crea un workflow nuevo en n8n</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El panel se mantiene abierto con datos frescos tras guardar (<code>setSelectedNode(updated)</code>)</p></li></ul></div></body></html><!--EndFragment-->
</body>
</html>Listo. Todo pusheado correctamente.

## Estado final — F4a-05

**Commit:** [`[106af93a](https://github.com/lssmanager/agent-visualstudio/commit/106af93af3ccde257af97f0b9f4e216cdb2e44b7)`](https://github.com/lssmanager/agent-visualstudio/commit/106af93af3ccde257af97f0b9f4e216cdb2e44b7)
**Rama:** `feat/phase-F4a-n8n-completo`
**Refs:** PR #262

### Archivos pusheados

| Archivo | Acción | Contenido clave |
|---|---|---|
| `apps/web/src/lib/types-base.ts` | ✅ Modificado | `FlowNode`, `N8nNodeConfig`, `N8nInputMapping` añadidos al final |
| `apps/web/src/lib/api.ts` | ✅ Modificado | Sección `── n8n ──` con `N8nWorkflowSummary`, `N8nExecutionSummary` y 6 helpers |
| `apps/web/src/features/flows/hooks/useN8nWorkflows.ts` | ✅ Creado | Hook con `workflows`, `loading`, `error`, `refetch` |
| `apps/web/src/features/flows/components/N8nNodePanel.tsx` | ✅ Creado | Panel completo: selector, `InputMappingEditor`, `ExecutionList`, sync/activate, guardar |
| `apps/web/src/features/flows/components/FlowCanvas.tsx` | ✅ Modificado | `onNodeClick` abre panel para `type === 'n8n'`, borde punteado en nodos sin `workflowId`, prop `onNodeUpdate` |

### Puntos de integración destacados
- Los nodos `n8n` sin `workflowId` configurado muestran borde punteado `#a5b4fc` en el canvas como indicador visual de configuración pendiente
- El `InputMappingEditor` soporta renombrar claves (on blur), editar valores en tiempo real y eliminar filas sin perder otras entradas
- `handleSync` actualiza `workflowId` automáticamente si el sync crea un workflow nuevo en n8n
- El panel se mantiene abierto con datos frescos tras guardar (`setSelectedNode(updated)`)<html>
<body>
<!--StartFragment--><html><head></head><body><div data-renderer="lm"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Listo. Todo pusheado correctamente.</p><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-lg first:mt-0 md:text-lg [hr+&amp;]:mt-4" id="estado-final--f4a-05">Estado final — F4a-05</h2><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><strong>Commit:</strong> <a rel="nofollow noopener" class="reset interactable cursor-pointer decoration-1 underline-offset-1 text-super hover:underline" target="_blank" href="https://github.com/lssmanager/agent-visualstudio/commit/106af93af3ccde257af97f0b9f4e216cdb2e44b7"><span class="text-box-trim-both"><code>106af93a</code></span></a><br><strong>Rama:</strong> <code>feat/phase-F4a-n8n-completo</code><br><strong>Refs:</strong> PR #262</p><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="archivos-pusheados">Archivos pusheados</h2><div class="group relative my-[1em]"><div class="sticky top-0 z-10 h-0" aria-hidden="true" style="overflow: visible; visibility: visible;"><div class="w-full overflow-hidden bg-raised border-x md:max-w-[90vw] dark:shadow-lg border-subtlest ring-subtlest divide-subtlest">
Archivo | Acción | Contenido clave
-- | -- | --


</div><div class="sticky z-10 h-0" style="bottom: max(calc(var(--thread-footer-height, 0px) - 24px), 0px); overflow: visible;"><div class="bg-base border-subtlest shadow-subtle pointer-coarse:opacity-100 keyboard:opacity-100 right-xs absolute bottom-xs flex rounded-md border opacity-0 transition-opacity group-hover:opacity-100 [&amp;&gt;*:not(:first-child)]:border-subtlest [&amp;&gt;*:not(:first-child)]:border-l"><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Guardar tabla en espacio" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-device-floppy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Copiar tabla" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-copy"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div><div class="flex transition-opacity duration-300 [&amp;_button]:hover:bg-transparent" style="opacity: 1;"><button aria-label="Descargar CSV" data-state="closed" type="button" class="reset interactable select-none [-webkit-user-drag:none] outline-none font-semimedium transition-[background-color,border-color,transform,color,opacity] duration-300 ease-out font-sans text-center items-center justify-center leading-loose whitespace-nowrap disabled:cursor-default disabled:opacity-50 data-[state=open]:text-foreground data-[state=open]:bg-quiet text-quiet h-8 text-sm cursor-pointer origin-center active:scale-[0.97] active:duration-150 active:ease-outExpo inline-flex aspect-[9/8] hover:text-foreground hover:bg-quiet rounded-lg"><div class="relative flex items-center justify-center"><div class="inline-flex" style="opacity: 1; transition: opacity 150ms 150ms;"><svg role="img" class="inline-flex fill-current shrink-0" width="16" height="16" stroke-width="1.75"><use xlink:href="#pplx-icon-download"></use></svg></div><div class="absolute inset-0 flex items-center justify-center" style="opacity: 0; transition: opacity 150ms;"></div></div></button></div></div></div></div><h2 class="font-editorial font-bold mb-2 mt-4 [.has-inline-images_&amp;]:clear-end text-base first:mt-0" id="puntos-de-integracin-destacados">Puntos de integración destacados</h2><ul class="marker:text-quiet list-disc pl-8"><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">Los nodos <code>n8n</code> sin <code>workflowId</code> configurado muestran borde punteado <code>#a5b4fc</code> en el canvas como indicador visual de configuración pendiente</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El <code>InputMappingEditor</code> soporta renombrar claves (on blur), editar valores en tiempo real y eliminar filas sin perder otras entradas</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2"><code>handleSync</code> actualiza <code>workflowId</code> automáticamente si el sync crea un workflow nuevo en n8n</p></li><li class="py-0 my-0 prose-p:pt-0 prose-p:mb-2 prose-p:my-0 [&amp;&gt;p]:pt-0 [&amp;&gt;p]:mb-2 [&amp;&gt;p]:my-0"><p class="my-2 [&amp;+p]:mt-4 [&amp;_strong:has(+br)]:inline-block [&amp;_strong:has(+br)]:pb-2">El panel se mantiene abierto con datos frescos tras guardar (<code>setSelectedNode(updated)</code>)</p></li></ul></div></body></html><!--EndFragment-->
</body>
</html>Listo. Todo pusheado correctamente.

## Estado final — F4a-05

**Commit:** [`[106af93a](https://github.com/lssmanager/agent-visualstudio/commit/106af93af3ccde257af97f0b9f4e216cdb2e44b7)`](https://github.com/lssmanager/agent-visualstudio/commit/106af93af3ccde257af97f0b9f4e216cdb2e44b7)
**Rama:** `feat/phase-F4a-n8n-completo`
**Refs:** PR #262

### Archivos pusheados

| Archivo | Acción | Contenido clave |
|---|---|---|
| `apps/web/src/lib/types-base.ts` | ✅ Modificado | `FlowNode`, `N8nNodeConfig`, `N8nInputMapping` añadidos al final |
| `apps/web/src/lib/api.ts` | ✅ Modificado | Sección `── n8n ──` con `N8nWorkflowSummary`, `N8nExecutionSummary` y 6 helpers |
| `apps/web/src/features/flows/hooks/useN8nWorkflows.ts` | ✅ Creado | Hook con `workflows`, `loading`, `error`, `refetch` |
| `apps/web/src/features/flows/components/N8nNodePanel.tsx` | ✅ Creado | Panel completo: selector, `InputMappingEditor`, `ExecutionList`, sync/activate, guardar |
| `apps/web/src/features/flows/components/FlowCanvas.tsx` | ✅ Modificado | `onNodeClick` abre panel para `type === 'n8n'`, borde punteado en nodos sin `workflowId`, prop `onNodeUpdate` |

### Puntos de integración destacados
- Los nodos `n8n` sin `workflowId` configurado muestran borde punteado `#a5b4fc` en el canvas como indicador visual de configuración pendiente
- El `InputMappingEditor` soporta renombrar claves (on blur), editar valores en tiempo real y eliminar filas sin perder otras entradas
- `handleSync` actualiza `workflowId` automáticamente si el sync crea un workflow nuevo en n8n
- El panel se mantiene abierto con datos frescos tras guardar (`setSelectedNode(updated)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced n8n workflow nodes with a dedicated configuration panel for input/output mapping, trigger mode selection, and synchronization settings
  * Added workflow activation/deactivation controls, flow-to-n8n synchronization, and execution history viewing capabilities
  * Enabled labeling and detailed configuration of n8n workflow nodes within the canvas editor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->