### PR TITLE
feat(F4b-01): N8nStudioHelper.createWorkflowFromDescription()

### DIFF
--- a/apps/api/src/modules/builder-agent/builder-agent.module.ts
+++ b/apps/api/src/modules/builder-agent/builder-agent.module.ts
@@ -12,10 +12,12 @@ import { Module }                    from '@nestjs/common';
 import { BuilderAgentService }       from './builder-agent.service';
 import { N8nStudioHelper }           from './n8n-studio-helper';
 import { ProfilePropagatorService }  from './profile-propagator.service';
+import { PrismaModule }              from '../../lib/prisma.module';
 import { N8nModule }                 from '../n8n/n8n.module';
 
 @Module({
   imports: [
+    PrismaModule,
     N8nModule,
   ],
   providers: [

--- a/apps/api/src/modules/builder-agent/builder-agent.module.ts
+++ b/apps/api/src/modules/builder-agent/builder-agent.module.ts
@@ -1,0 +1,31 @@
+/**
+ * builder-agent.module.ts
+ *
+ * Módulo NestJS para el AgentBuilder.
+ * Registra BuilderAgentService, N8nStudioHelper y ProfilePropagatorService.
+ * Importa N8nModule para que N8nService esté disponible como dependencia.
+ *
+ * Issue: #76 (F4b-01)
+ */
+
+import { Module }                    from '@nestjs/common';
+import { BuilderAgentService }       from './builder-agent.service';
+import { N8nStudioHelper }           from './n8n-studio-helper';
+import { ProfilePropagatorService }  from './profile-propagator.service';
+import { N8nModule }                 from '../n8n/n8n.module';
+
+@Module({
+  imports: [
+    N8nModule,
+  ],
+  providers: [
+    BuilderAgentService,
+    N8nStudioHelper,
+    ProfilePropagatorService,
+  ],
+  exports: [
+    BuilderAgentService,
+    N8nStudioHelper,
+  ],
+})
+export class BuilderAgentModule {}

--- a/apps/api/src/modules/builder-agent/n8n-studio-helper.ts
+++ b/apps/api/src/modules/builder-agent/n8n-studio-helper.ts
@@ -1,0 +1,303 @@
+/**
+ * n8n-studio-helper.ts
+ *
+ * N8nStudioHelper — cerebro del AgentBuilder para n8n.
+ *
+ * Recibe una descripción en lenguaje natural, usa el LLM resuelto por
+ * ModelPolicy (cascada agent→workspace→dept→agency, D-09) para generar
+ * un spec JSON de nodos/conexiones válido para n8n, materializa el workflow
+ * en n8n real via N8nService, y registra el resultado como un Skill de
+ * tipo n8n_webhook en Prisma.
+ *
+ * Bloquea: F4b-02, F4b-03, F4b-04
+ * Issue:   #76 (F4b-01)
+ */
+
+import { Injectable } from '@nestjs/common';
+import type { PrismaClient } from '@prisma/client';
+
+import { N8nService }          from '../n8n/n8n.service';
+import { resolveModelPolicy }  from '../../../../../packages/run-engine/src/policy-resolver';
+import { buildLLMClient }      from '../../../../../packages/run-engine/src/llm-client';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODEL     = 'openai/gpt-4o';
+const LLM_TEMPERATURE   = 0.2;
+const LLM_MAX_TOKENS    = 2048;
+
+const N8N_SYSTEM_PROMPT = `
+You are an expert n8n workflow architect.
+Your task: given a description, generate a valid n8n workflow spec as JSON.
+
+Rules:
+- Output ONLY valid JSON. No markdown, no explanation, no backticks.
+- The JSON must have exactly these top-level keys: "name", "nodes", "connections"
+- Every node must have: id (string), name (string), type (string),
+  typeVersion (number), position ([x, y]), parameters (object)
+- Include at least one trigger node (webhook, schedule, or manual)
+- Use n8n-nodes-base.* types only (no community nodes)
+- connections maps sourceNodeName → { main: [[{ node, type, index }]] }
+- webhookUrl path should be a short slug derived from the workflow name
+
+n8n node types reference (use these exact type strings):
+  n8n-nodes-base.webhook          → HTTP webhook trigger
+  n8n-nodes-base.emailSend        → Send email (requires SMTP credentials)
+  n8n-nodes-base.httpRequest      → HTTP request to external API
+  n8n-nodes-base.set              → Set/transform data
+  n8n-nodes-base.if               → Conditional branch
+  n8n-nodes-base.code             → Execute JavaScript code
+  n8n-nodes-base.respondToWebhook → Send response back to webhook caller
+  n8n-nodes-base.noOp             → No operation (passthrough)
+`.trim();
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Nodo n8n tal como lo entiende la REST API de n8n. */
+export interface N8nWorkflowNodeDefinition {
+  id:          string;
+  name:        string;
+  type:        string;
+  typeVersion: number;
+  position:    [number, number];
+  parameters:  Record<string, unknown>;
+  credentials?: Record<string, unknown>;
+}
+
+/** Estructura de conexiones n8n: sourceNodeName → { main: [[{node, type, index}]] } */
+export type N8nWorkflowConnection = Record<
+  string,
+  { main: Array<Array<{ node: string; type: string; index: number }>> }
+>;
+
+/** El spec que el LLM genera y que se envía a N8nService. */
+export interface N8nWorkflowSpec {
+  name:        string;
+  nodes:       N8nWorkflowNodeDefinition[];
+  connections: N8nWorkflowConnection;
+}
+
+/** Opciones para createWorkflowFromDescription(). */
+export interface CreateWorkflowFromDescriptionOptions {
+  /** Descripción en lenguaje natural del workflow deseado. */
+  description: string;
+  /**
+   * connectionId de N8nConnection en Prisma.
+   * Se usa como parte del nombre canónico del Skill: `n8n:{connectionId}:{workflowId}`
+   */
+  connectionId: string;
+  /**
+   * agentId para resolveModelPolicy (cascada agent→workspace→dept→agency).
+   * Requerido para seleccionar el LLM correcto según política D-09.
+   */
+  agentId: string;
+  /** workspaceId del agente — requerido por PolicyResolverContext. */
+  workspaceId: string;
+  /** departmentId del agente — requerido por PolicyResolverContext. */
+  departmentId: string;
+  /** agencyId del agente — requerido por PolicyResolverContext. */
+  agencyId: string;
+  /**
+   * Si true, activa el workflow en n8n inmediatamente tras crearlo.
+   * Default: false
+   */
+  activate?: boolean;
+}
+
+/** Resultado de createWorkflowFromDescription(). */
+export interface CreateWorkflowFromDescriptionResult {
+  /** n8n workflow ID asignado por n8n. */
+  n8nWorkflowId: string;
+  /** Nombre generado por el LLM para el workflow. */
+  name: string;
+  /** Skill.id creado/actualizado en Prisma. */
+  skillId: string;
+  /** Webhook URL del nodo trigger (si el workflow tiene nodo webhook). */
+  webhookUrl?: string;
+  /** true si el workflow quedó activo en n8n. */
+  active: boolean;
+  /** Spec JSON completo enviado a n8n (para auditoría/debug). */
+  generatedSpec: N8nWorkflowSpec;
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+@Injectable()
+export class N8nStudioHelper {
+  constructor(
+    private readonly n8nService: N8nService,
+    private readonly prisma: PrismaClient,
+  ) {}
+
+  /**
+   * Traduce una descripción en lenguaje natural a un workflow n8n real.
+   *
+   * Pasos:
+   *   1. Resolver ModelPolicy via cascada agent→workspace→dept→agency (D-09)
+   *   2. Construir prompt de sistema + usuario para el LLM
+   *   3. Llamar al LLM con el modelo resuelto (temperatura 0.2)
+   *   4. Parsear y validar el JSON devuelto
+   *   5. Crear el workflow en n8n via N8nService
+   *   6. Hacer upsert del Skill en Prisma con type='n8n_webhook'
+   *   7. Retornar CreateWorkflowFromDescriptionResult
+   */
+  async createWorkflowFromDescription(
+    options: CreateWorkflowFromDescriptionOptions,
+  ): Promise<CreateWorkflowFromDescriptionResult> {
+    const {
+      description,
+      connectionId,
+      agentId,
+      workspaceId,
+      departmentId,
+      agencyId,
+      activate = false,
+    } = options;
+
+    // ── Paso 1: Resolver ModelPolicy ──────────────────────────────────────────
+    let primaryModel = DEFAULT_MODEL;
+    try {
+      const modelPolicy = await resolveModelPolicy(this.prisma, {
+        agentId,
+        workspaceId,
+        departmentId,
+        agencyId,
+      });
+      if (modelPolicy?.primaryModel) {
+        primaryModel = modelPolicy.primaryModel;
+      }
+    } catch {
+      // Si falla la resolución de política, usamos el default. No es fatal.
+      primaryModel = DEFAULT_MODEL;
+    }
+
+    // ── Paso 2-3: Llamar al LLM ───────────────────────────────────────────────
+    const llmClient = buildLLMClient(primaryModel);
+
+    let rawContent: string;
+    try {
+      const response = await llmClient.chat({
+        messages: [
+          { role: 'system', content: N8N_SYSTEM_PROMPT },
+          { role: 'user',   content: `Create an n8n workflow for: ${description}` },
+        ],
+        temperature:     LLM_TEMPERATURE,
+        max_tokens:      LLM_MAX_TOKENS,
+        response_format: { type: 'json_object' },
+      });
+      rawContent = response.choices[0]?.message?.content ?? '';
+    } catch (err: unknown) {
+      throw new Error(
+        `[N8nStudioHelper] LLM call failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
+    // ── Paso 4: Parsear y validar JSON ────────────────────────────────────────
+    let spec: N8nWorkflowSpec;
+    try {
+      spec = JSON.parse(rawContent) as N8nWorkflowSpec;
+    } catch {
+      throw new Error(
+        `[N8nStudioHelper] LLM returned invalid JSON: ${rawContent.slice(0, 200)}`,
+      );
+    }
+
+    if (!spec.name || typeof spec.name !== 'string' || spec.name.trim() === '') {
+      throw new Error('[N8nStudioHelper] LLM spec missing required field: name');
+    }
+    if (!Array.isArray(spec.nodes) || spec.nodes.length === 0) {
+      throw new Error('[N8nStudioHelper] LLM spec missing required field: nodes (must be non-empty array)');
+    }
+    if (!spec.connections || typeof spec.connections !== 'object') {
+      // Conexiones vacías son válidas para un workflow de 1 nodo.
+      spec.connections = {};
+    }
+
+    // ── Paso 5: Crear el workflow en n8n via N8nService ───────────────────────
+    //
+    // N8nService.createWorkflow() en apps/api recibe { name, nodes, connections, settings }.
+    // Construimos el partial compatible con la interfaz N8nWorkflow del servicio.
+    let createdWorkflow: { id: string; name: string; active: boolean };
+    try {
+      createdWorkflow = await this.n8nService.createWorkflowRaw({
+        name:        spec.name,
+        nodes:       spec.nodes,
+        connections: spec.connections,
+        active:      activate,
+        settings:    { executionOrder: 'v1' },
+      });
+    } catch (err: unknown) {
+      throw new Error(
+        `[N8nStudioHelper] N8nService.createWorkflowRaw() failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
+    const n8nWorkflowId = createdWorkflow.id;
+
+    // ── Paso 6: Extraer webhookUrl del nodo webhook (si existe) ───────────────
+    const webhookNode = spec.nodes.find(
+      (n) => n.type === 'n8n-nodes-base.webhook',
+    );
+    const webhookPath = webhookNode?.parameters?.['path'] as string | undefined;
+    const baseUrl     = process.env.N8N_BASE_URL?.replace(/\/$/, '') ?? '';
+    const webhookUrl  = webhookPath ? `${baseUrl}/webhook/${webhookPath}` : undefined;
+
+    // ── Paso 7: Upsert Skill en Prisma ────────────────────────────────────────
+    //
+    // Nombre canónico del skill: 'n8n:{connectionId}:{n8nWorkflowId}'
+    // Este patrón es consistente con syncWorkflows() en packages/n8n-service.
+    const skillName = `n8n:${connectionId}:${n8nWorkflowId}`;
+
+    let skill: { id: string };
+    try {
+      skill = await (this.prisma as unknown as {
+        skill: {
+          upsert: (args: {
+            where: { name: string };
+            create: Record<string, unknown>;
+            update: Record<string, unknown>;
+          }) => Promise<{ id: string }>;
+        };
+      }).skill.upsert({
+        where:  { name: skillName },
+        create: {
+          name:   skillName,
+          type:   'n8n_webhook',
+          config: {
+            n8nWorkflowId,
+            connectionId,
+            webhookUrl: webhookUrl ?? null,
+            generatedFromDescription: description,
+          },
+        },
+        update: {
+          config: {
+            n8nWorkflowId,
+            connectionId,
+            webhookUrl: webhookUrl ?? null,
+            generatedFromDescription: description,
+          },
+        },
+      });
+    } catch (err: unknown) {
+      throw new Error(
+        `[N8nStudioHelper] Prisma skill upsert failed — syncToSkills may have failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
+    return {
+      n8nWorkflowId,
+      name:          createdWorkflow.name,
+      skillId:       skill.id,
+      webhookUrl,
+      active:        createdWorkflow.active,
+      generatedSpec: spec,
+    };
+  }
+}

--- a/apps/api/src/modules/builder-agent/n8n-studio-helper.ts
+++ b/apps/api/src/modules/builder-agent/n8n-studio-helper.ts
@@ -14,7 +14,7 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import type { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../../lib/prisma.service';
 
 import { N8nService }          from '../n8n/n8n.service';
 import { resolveModelPolicy }  from '../../../../../packages/run-engine/src/policy-resolver';
@@ -126,7 +126,7 @@ export interface CreateWorkflowFromDescriptionResult {
 export class N8nStudioHelper {
   constructor(
     private readonly n8nService: N8nService,
-    private readonly prisma: PrismaClient,
+    private readonly prisma: PrismaService,
   ) {}
 
   /**
@@ -176,16 +176,19 @@ export class N8nStudioHelper {
 
     let rawContent: string;
     try {
-      const response = await llmClient.chat({
-        messages: [
+      const response = await llmClient.chat(
+        [
           { role: 'system', content: N8N_SYSTEM_PROMPT },
           { role: 'user',   content: `Create an n8n workflow for: ${description}` },
         ],
-        temperature:     LLM_TEMPERATURE,
-        max_tokens:      LLM_MAX_TOKENS,
-        response_format: { type: 'json_object' },
-      });
-      rawContent = response.choices[0]?.message?.content ?? '';
+        [],
+        {
+          model:       primaryModel,
+          temperature: LLM_TEMPERATURE,
+          maxTokens:   LLM_MAX_TOKENS,
+        },
+      );
+      rawContent = response.content ?? '';
     } catch (err: unknown) {
       throw new Error(
         `[N8nStudioHelper] LLM call failed: ${
@@ -217,11 +220,12 @@ export class N8nStudioHelper {
 
     // ── Paso 5: Crear el workflow en n8n via N8nService ───────────────────────
     //
-    // N8nService.createWorkflow() en apps/api recibe { name, nodes, connections, settings }.
-    // Construimos el partial compatible con la interfaz N8nWorkflow del servicio.
+    // N8nService has a client with createWorkflow() that receives { name, nodes, connections, settings }.
+    // We construct the partial compatible with the N8nWorkflow interface.
     let createdWorkflow: { id: string; name: string; active: boolean };
     try {
-      createdWorkflow = await this.n8nService.createWorkflowRaw({
+      // Access the private client method through the service
+      createdWorkflow = await (this.n8nService as any).client.createWorkflow({
         name:        spec.name,
         nodes:       spec.nodes,
         connections: spec.connections,
@@ -230,7 +234,7 @@ export class N8nStudioHelper {
       });
     } catch (err: unknown) {
       throw new Error(
-        `[N8nStudioHelper] N8nService.createWorkflowRaw() failed: ${
+        `[N8nStudioHelper] N8nService.createWorkflow() failed: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );

--- a/apps/api/src/modules/builder-agent/n8n-studio-helper.ts
+++ b/apps/api/src/modules/builder-agent/n8n-studio-helper.ts
@@ -14,17 +14,17 @@
  */
 
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from '../../lib/prisma.service';
 
-import { N8nService }          from '../n8n/n8n.service';
-import { resolveModelPolicy }  from '../../../../../packages/run-engine/src/policy-resolver';
-import { buildLLMClient }      from '../../../../../packages/run-engine/src/llm-client';
+import { N8nService }         from '../n8n/n8n.service';
+import { PrismaService }      from '../../lib/prisma.service';
+import { resolveModelPolicy } from '../../../../../packages/run-engine/src/policy-resolver';
+import { buildLLMClient }     from '../../../../../packages/run-engine/src/llm-client';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const DEFAULT_MODEL     = 'openai/gpt-4o';
-const LLM_TEMPERATURE   = 0.2;
-const LLM_MAX_TOKENS    = 2048;
+const DEFAULT_MODEL   = 'openai/gpt-4o';
+const LLM_TEMPERATURE = 0.2;
+const LLM_MAX_TOKENS  = 2048;
 
 const N8N_SYSTEM_PROMPT = `
 You are an expert n8n workflow architect.
@@ -91,7 +91,7 @@ export interface CreateWorkflowFromDescriptionOptions {
    * Requerido para seleccionar el LLM correcto según política D-09.
    */
   agentId: string;
-  /** workspaceId del agente — requerido por PolicyResolverContext. */
+  /** workspaceId del agente — requerido por PolicyResolverContext y por Skill.create. */
   workspaceId: string;
   /** departmentId del agente — requerido por PolicyResolverContext. */
   departmentId: string;
@@ -137,8 +137,8 @@ export class N8nStudioHelper {
    *   2. Construir prompt de sistema + usuario para el LLM
    *   3. Llamar al LLM con el modelo resuelto (temperatura 0.2)
    *   4. Parsear y validar el JSON devuelto
-   *   5. Crear el workflow en n8n via N8nService
-   *   6. Hacer upsert del Skill en Prisma con type='n8n_webhook'
+   *   5. Crear el workflow en n8n via N8nService.createWorkflowRaw()
+   *   6. Hacer findFirst+update/create del Skill en Prisma con type='n8n_webhook'
    *   7. Retornar CreateWorkflowFromDescriptionResult
    */
   async createWorkflowFromDescription(
@@ -172,6 +172,8 @@ export class N8nStudioHelper {
     }
 
     // ── Paso 2-3: Llamar al LLM ───────────────────────────────────────────────
+    // buildLLMClient devuelve un ProviderAdapter cuyo chat() acepta
+    // (messages[], tools[], opts) y devuelve { content, toolCalls }.
     const llmClient = buildLLMClient(primaryModel);
 
     let rawContent: string;
@@ -181,14 +183,18 @@ export class N8nStudioHelper {
           { role: 'system', content: N8N_SYSTEM_PROMPT },
           { role: 'user',   content: `Create an n8n workflow for: ${description}` },
         ],
-        [],
+        [],   // tools: vacío — solo generamos JSON, no usamos tool calls
         {
           model:       primaryModel,
           temperature: LLM_TEMPERATURE,
           maxTokens:   LLM_MAX_TOKENS,
         },
       );
+      // ProviderAdapter devuelve { content: string, toolCalls: ToolCall[] }
       rawContent = response.content ?? '';
+      if (!rawContent) {
+        throw new Error('[N8nStudioHelper] LLM returned empty content');
+      }
     } catch (err: unknown) {
       throw new Error(
         `[N8nStudioHelper] LLM call failed: ${
@@ -218,14 +224,10 @@ export class N8nStudioHelper {
       spec.connections = {};
     }
 
-    // ── Paso 5: Crear el workflow en n8n via N8nService ───────────────────────
-    //
-    // N8nService has a client with createWorkflow() that receives { name, nodes, connections, settings }.
-    // We construct the partial compatible with the N8nWorkflow interface.
+    // ── Paso 5: Crear el workflow en n8n via N8nService.createWorkflowRaw() ───
     let createdWorkflow: { id: string; name: string; active: boolean };
     try {
-      // Access the private client method through the service
-      createdWorkflow = await (this.n8nService as any).client.createWorkflow({
+      createdWorkflow = await this.n8nService.createWorkflowRaw({
         name:        spec.name,
         nodes:       spec.nodes,
         connections: spec.connections,
@@ -234,7 +236,7 @@ export class N8nStudioHelper {
       });
     } catch (err: unknown) {
       throw new Error(
-        `[N8nStudioHelper] N8nService.createWorkflow() failed: ${
+        `[N8nStudioHelper] N8nService.createWorkflowRaw() failed: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -250,46 +252,47 @@ export class N8nStudioHelper {
     const baseUrl     = process.env.N8N_BASE_URL?.replace(/\/$/, '') ?? '';
     const webhookUrl  = webhookPath ? `${baseUrl}/webhook/${webhookPath}` : undefined;
 
-    // ── Paso 7: Upsert Skill en Prisma ────────────────────────────────────────
+    // ── Paso 7: findFirst + update/create del Skill en Prisma ─────────────────
     //
-    // Nombre canónico del skill: 'n8n:{connectionId}:{n8nWorkflowId}'
-    // Este patrón es consistente con syncWorkflows() en packages/n8n-service.
+    // Skill.name NO tiene @unique en el schema — no se puede usar upsert con
+    // where: { name }. Estrategia: findFirst por name+workspaceId, luego
+    // update (si existe) o create (si no existe).
+    // workspaceId es NOT NULL en el schema — requerido en create.
     const skillName = `n8n:${connectionId}:${n8nWorkflowId}`;
+    const skillConfig = {
+      n8nWorkflowId,
+      connectionId,
+      webhookUrl: webhookUrl ?? null,
+      generatedFromDescription: description,
+    };
 
     let skill: { id: string };
     try {
-      skill = await (this.prisma as unknown as {
-        skill: {
-          upsert: (args: {
-            where: { name: string };
-            create: Record<string, unknown>;
-            update: Record<string, unknown>;
-          }) => Promise<{ id: string }>;
-        };
-      }).skill.upsert({
-        where:  { name: skillName },
-        create: {
-          name:   skillName,
-          type:   'n8n_webhook',
-          config: {
-            n8nWorkflowId,
-            connectionId,
-            webhookUrl: webhookUrl ?? null,
-            generatedFromDescription: description,
-          },
-        },
-        update: {
-          config: {
-            n8nWorkflowId,
-            connectionId,
-            webhookUrl: webhookUrl ?? null,
-            generatedFromDescription: description,
-          },
-        },
+      const existing = await this.prisma.skill.findFirst({
+        where:  { name: skillName, workspaceId },
+        select: { id: true },
       });
+
+      if (existing) {
+        skill = await this.prisma.skill.update({
+          where:  { id: existing.id },
+          data:   { config: skillConfig },
+          select: { id: true },
+        });
+      } else {
+        skill = await this.prisma.skill.create({
+          data: {
+            name:        skillName,
+            type:        'n8n_webhook',
+            workspaceId,
+            config:      skillConfig,
+          },
+          select: { id: true },
+        });
+      }
     } catch (err: unknown) {
       throw new Error(
-        `[N8nStudioHelper] Prisma skill upsert failed — syncToSkills may have failed: ${
+        `[N8nStudioHelper] Prisma skill persist failed: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );

--- a/apps/api/src/modules/builder-agent/tools/assign-skill-to-agent.tool.ts
+++ b/apps/api/src/modules/builder-agent/tools/assign-skill-to-agent.tool.ts
@@ -1,0 +1,152 @@
+/**
+ * assign-skill-to-agent.tool.ts
+ *
+ * Tool definition para AgentBuilder: `assign_skill_to_agent`
+ *
+ * Registra un AgentSkill (relación Agent ↔ Skill) en Prisma y dispara
+ * ProfilePropagatorService.propagateUp() para regenerar el system prompt
+ * del orquestador del nivel.
+ *
+ * Issue: #79 (F4b-04)
+ * Depende de: #50 (F2b-04 — hook AgentRepository), #76 (F4b-01)
+ */
+
+import type { PrismaClient } from '@prisma/client';
+
+// ─── JSON Schema de la tool ───────────────────────────────────────────────────
+
+export const ASSIGN_SKILL_TO_AGENT_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'assign_skill_to_agent',
+    description:
+      'Assigns an existing Skill (e.g., an n8n workflow registered as n8n_webhook) to an agent. ' +
+      'Creates an AgentSkill record in the database and triggers profile propagation so that ' +
+      'the orchestrator at the agent\'s level has its system prompt regenerated with the new capability. ' +
+      'Use list_n8n_workflows to find the skillId first.',
+    parameters: {
+      type: 'object',
+      required: ['agentId', 'skillId'],
+      additionalProperties: false,
+      properties: {
+        agentId: {
+          type: 'string',
+          description: 'ID of the agent to assign the skill to.',
+        },
+        skillId: {
+          type: 'string',
+          description:
+            'ID of the Skill to assign. Use list_n8n_workflows to discover available skillIds.',
+        },
+        config: {
+          type: 'object',
+          additionalProperties: true,
+          description:
+            'Optional per-agent configuration for this skill assignment. ' +
+            'E.g., { "webhookPath": "/lead-handler", "credentials": {} }',
+        },
+      },
+    },
+  },
+} as const;
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export interface AssignSkillToAgentArgs {
+  agentId:  string;
+  skillId:  string;
+  config?:  Record<string, unknown>;
+}
+
+/**
+ * Tipos mínimos para acceso a Prisma sin tener el schema completo importado
+ * en tiempo de compilación de este archivo.
+ */
+type PrismaLike = {
+  agentSkill: {
+    upsert: (args: {
+      where: { agentId_skillId: { agentId: string; skillId: string } };
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    }) => Promise<{ id: string; agentId: string; skillId: string }>;
+  };
+  agent: {
+    findUnique: (args: {
+      where: { id: string };
+      select: { workspaceId: boolean; departmentId: boolean; agencyId: boolean };
+    }) => Promise<{ workspaceId: string; departmentId: string; agencyId: string } | null>;
+  };
+};
+
+/**
+ * Ejecuta la tool assign_skill_to_agent.
+ *
+ * 1. Upsert AgentSkill en Prisma
+ * 2. Dispara propagateUp() via evento en proceso o llamada directa
+ *    (si ProfilePropagatorService está disponible en el contenedor NestJS)
+ */
+export async function handleAssignSkillToAgent(
+  args: AssignSkillToAgentArgs,
+  prisma: PrismaClient,
+  propagateUp?: (agentId: string) => Promise<void>,
+): Promise<{
+  success:      boolean;
+  agentSkillId: string;
+  agentId:      string;
+  skillId:      string;
+  propagated:   boolean;
+  error?:       string;
+}> {
+  try {
+    const db = prisma as unknown as PrismaLike;
+
+    // ── Paso 1: Upsert AgentSkill ────────────────────────────────────────────
+    const agentSkill = await db.agentSkill.upsert({
+      where:  { agentId_skillId: { agentId: args.agentId, skillId: args.skillId } },
+      create: {
+        agentId: args.agentId,
+        skillId: args.skillId,
+        config:  args.config ?? {},
+      },
+      update: {
+        config: args.config ?? {},
+      },
+    });
+
+    // ── Paso 2: Disparar propagateUp() si está disponible ───────────────────
+    //
+    // ProfilePropagatorService.propagateUp() regenera el system prompt del
+    // orquestador del nivel del agente (D-24f).
+    // Si no está disponible (ej. en tests), se registra como no propagado.
+    let propagated = false;
+    if (typeof propagateUp === 'function') {
+      try {
+        await propagateUp(args.agentId);
+        propagated = true;
+      } catch (propagateErr: unknown) {
+        // No es fatal — el AgentSkill ya fue creado. Log para auditoría.
+        console.warn(
+          `[assign_skill_to_agent] propagateUp failed for agent ${args.agentId}:`,
+          propagateErr instanceof Error ? propagateErr.message : String(propagateErr),
+        );
+      }
+    }
+
+    return {
+      success:      true,
+      agentSkillId: agentSkill.id,
+      agentId:      agentSkill.agentId,
+      skillId:      agentSkill.skillId,
+      propagated,
+    };
+  } catch (err: unknown) {
+    return {
+      success:      false,
+      agentSkillId: '',
+      agentId:      args.agentId,
+      skillId:      args.skillId,
+      propagated:   false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/api/src/modules/builder-agent/tools/create-n8n-workflow.tool.ts
+++ b/apps/api/src/modules/builder-agent/tools/create-n8n-workflow.tool.ts
@@ -1,0 +1,144 @@
+/**
+ * create-n8n-workflow.tool.ts
+ *
+ * Tool definition para AgentBuilder: `create_n8n_workflow`
+ *
+ * Permite al AgentBuilder generar un workflow n8n real a partir de una
+ * descripción en lenguaje natural. Internamente llama a
+ * N8nStudioHelper.createWorkflowFromDescription().
+ *
+ * JSON Schema compatible con OpenAI function calling / tool_calls.
+ *
+ * Issue: #77 (F4b-02)
+ * Depende de: #76 (F4b-01) — N8nStudioHelper
+ */
+
+import type { N8nStudioHelper, CreateWorkflowFromDescriptionResult } from '../n8n-studio-helper';
+
+// ─── JSON Schema de la tool ───────────────────────────────────────────────────
+
+export const CREATE_N8N_WORKFLOW_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'create_n8n_workflow',
+    description:
+      'Generates and registers a real n8n workflow from a natural language description. ' +
+      'Uses an LLM to produce the node/connection spec, creates the workflow in n8n, ' +
+      'and registers it as a Skill of type n8n_webhook in the database. ' +
+      'Returns the skillId and webhookUrl so the workflow can immediately be assigned to an agent.',
+    parameters: {
+      type: 'object',
+      required: ['description', 'connectionId', 'agentId', 'workspaceId', 'departmentId', 'agencyId'],
+      additionalProperties: false,
+      properties: {
+        description: {
+          type: 'string',
+          minLength: 10,
+          maxLength: 2000,
+          description:
+            'Natural language description of the desired workflow. ' +
+            'Be specific about triggers (webhook, schedule), actions (send email, HTTP call), ' +
+            'and any conditions. Example: ' +
+            '"Create a workflow that sends an email when a lead arrives via webhook, ' +
+            'then posts a summary to a Slack channel."',
+        },
+        connectionId: {
+          type: 'string',
+          description:
+            'ID of the N8nConnection record in Prisma to use for creating the workflow. ' +
+            'Use list_n8n_workflows to see available connections first.',
+        },
+        agentId: {
+          type: 'string',
+          description:
+            'ID of the agent requesting the workflow creation. ' +
+            'Used to resolve the ModelPolicy (cascada agent→workspace→dept→agency).',
+        },
+        workspaceId: {
+          type: 'string',
+          description: 'Workspace ID of the requesting agent. Required for ModelPolicy resolution.',
+        },
+        departmentId: {
+          type: 'string',
+          description: 'Department ID of the requesting agent. Required for ModelPolicy resolution.',
+        },
+        agencyId: {
+          type: 'string',
+          description: 'Agency ID of the requesting agent. Required for ModelPolicy resolution.',
+        },
+        activate: {
+          type: 'boolean',
+          default: false,
+          description:
+            'If true, the workflow is activated in n8n immediately after creation. ' +
+            'Default is false (workflow created in inactive state).',
+        },
+      },
+    },
+  },
+} as const;
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export interface CreateN8nWorkflowArgs {
+  description:  string;
+  connectionId: string;
+  agentId:      string;
+  workspaceId:  string;
+  departmentId: string;
+  agencyId:     string;
+  activate?:    boolean;
+}
+
+/**
+ * Ejecuta la tool create_n8n_workflow.
+ *
+ * Retorna un objeto serializable que el LLM puede leer como tool result.
+ */
+export async function handleCreateN8nWorkflow(
+  args: CreateN8nWorkflowArgs,
+  helper: N8nStudioHelper,
+): Promise<{
+  success:       boolean;
+  skillId:       string;
+  n8nWorkflowId: string;
+  name:          string;
+  webhookUrl:    string | undefined;
+  active:        boolean;
+  nodesCount:    number;
+  error?:        string;
+}> {
+  try {
+    const result: CreateWorkflowFromDescriptionResult =
+      await helper.createWorkflowFromDescription({
+        description:  args.description,
+        connectionId: args.connectionId,
+        agentId:      args.agentId,
+        workspaceId:  args.workspaceId,
+        departmentId: args.departmentId,
+        agencyId:     args.agencyId,
+        activate:     args.activate ?? false,
+      });
+
+    return {
+      success:       true,
+      skillId:       result.skillId,
+      n8nWorkflowId: result.n8nWorkflowId,
+      name:          result.name,
+      webhookUrl:    result.webhookUrl,
+      active:        result.active,
+      nodesCount:    result.generatedSpec.nodes.length,
+    };
+  } catch (err: unknown) {
+    return {
+      success:       false,
+      skillId:       '',
+      n8nWorkflowId: '',
+      name:          '',
+      webhookUrl:    undefined,
+      active:        false,
+      nodesCount:    0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/api/src/modules/builder-agent/tools/index.ts
+++ b/apps/api/src/modules/builder-agent/tools/index.ts
@@ -1,0 +1,91 @@
+/**
+ * tools/index.ts
+ *
+ * Punto de entrada del directorio de tools del AgentBuilder (F4b).
+ *
+ * Exporta:
+ *   - Las definiciones de tool (JSON Schema compatible con OpenAI tool_calls)
+ *   - Los handlers correspondientes
+ *
+ * Uso desde BuilderAgentService:
+ *
+ *   import { BUILDER_AGENT_TOOLS, dispatchToolCall } from './tools';
+ *
+ *   // Para pasar al LLM:
+ *   const response = await llmClient.chat({ tools: BUILDER_AGENT_TOOLS, ... });
+ *
+ *   // Para ejecutar el tool_call devuelto:
+ *   const result = await dispatchToolCall(toolCall, { helper, prisma, propagateUp });
+ */
+
+export { CREATE_N8N_WORKFLOW_TOOL, handleCreateN8nWorkflow } from './create-n8n-workflow.tool';
+export type { CreateN8nWorkflowArgs } from './create-n8n-workflow.tool';
+
+export { LIST_N8N_WORKFLOWS_TOOL, handleListN8nWorkflows } from './list-n8n-workflows.tool';
+export type { ListN8nWorkflowsArgs, N8nWorkflowSkillItem } from './list-n8n-workflows.tool';
+
+export { ASSIGN_SKILL_TO_AGENT_TOOL, handleAssignSkillToAgent } from './assign-skill-to-agent.tool';
+export type { AssignSkillToAgentArgs } from './assign-skill-to-agent.tool';
+
+import { CREATE_N8N_WORKFLOW_TOOL }   from './create-n8n-workflow.tool';
+import { LIST_N8N_WORKFLOWS_TOOL }    from './list-n8n-workflows.tool';
+import { ASSIGN_SKILL_TO_AGENT_TOOL } from './assign-skill-to-agent.tool';
+
+import type { N8nStudioHelper }    from '../n8n-studio-helper';
+import type { PrismaClient }       from '@prisma/client';
+
+// ─── Array de tools para pasar directamente al LLM ───────────────────────────
+
+/** Todas las tool definitions del AgentBuilder, listas para el array `tools` del LLM. */
+export const BUILDER_AGENT_TOOLS = [
+  CREATE_N8N_WORKFLOW_TOOL,
+  LIST_N8N_WORKFLOWS_TOOL,
+  ASSIGN_SKILL_TO_AGENT_TOOL,
+] as const;
+
+// ─── Dispatcher ──────────────────────────────────────────────────────────────
+
+export interface DispatchToolCallDeps {
+  helper:      N8nStudioHelper;
+  prisma:      PrismaClient;
+  propagateUp?: (agentId: string) => Promise<void>;
+}
+
+/**
+ * Despacha un tool_call del LLM al handler correcto.
+ *
+ * @param toolCall  - El objeto tool_call devuelto por el LLM
+ * @param deps      - Dependencias necesarias por los handlers
+ * @returns         - Resultado serializable como tool result
+ */
+export async function dispatchToolCall(
+  toolCall: { function: { name: string; arguments: string } },
+  deps: DispatchToolCallDeps,
+): Promise<unknown> {
+  const { name, arguments: argsJson } = toolCall.function;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let args: any;
+  try {
+    args = JSON.parse(argsJson);
+  } catch {
+    throw new Error(`[dispatchToolCall] Invalid JSON arguments for tool '${name}': ${argsJson.slice(0, 100)}`);
+  }
+
+  switch (name) {
+    case 'create_n8n_workflow':  {
+      const { handleCreateN8nWorkflow }  = await import('./create-n8n-workflow.tool');
+      return handleCreateN8nWorkflow(args, deps.helper);
+    }
+    case 'list_n8n_workflows': {
+      const { handleListN8nWorkflows }   = await import('./list-n8n-workflows.tool');
+      return handleListN8nWorkflows(args, deps.prisma);
+    }
+    case 'assign_skill_to_agent': {
+      const { handleAssignSkillToAgent } = await import('./assign-skill-to-agent.tool');
+      return handleAssignSkillToAgent(args, deps.prisma, deps.propagateUp);
+    }
+    default:
+      throw new Error(`[dispatchToolCall] Unknown tool: '${name}'`);
+  }
+}

--- a/apps/api/src/modules/builder-agent/tools/list-n8n-workflows.tool.ts
+++ b/apps/api/src/modules/builder-agent/tools/list-n8n-workflows.tool.ts
@@ -1,0 +1,134 @@
+/**
+ * list-n8n-workflows.tool.ts
+ *
+ * Tool definition para AgentBuilder: `list_n8n_workflows`
+ *
+ * Lista los workflows n8n registrados como Skills (type='n8n_webhook')
+ * en Prisma. Permite al AgentBuilder conocer qué workflows están
+ * disponibles para asignar a un agente via assign_skill_to_agent.
+ *
+ * Issue: #78 (F4b-03)
+ * Depende de: #76 (F4b-01)
+ */
+
+import type { PrismaClient } from '@prisma/client';
+
+// ─── JSON Schema de la tool ───────────────────────────────────────────────────
+
+export const LIST_N8N_WORKFLOWS_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'list_n8n_workflows',
+    description:
+      'Lists all n8n workflows registered as Skills (type=n8n_webhook) in the database. ' +
+      'Use this to discover available workflows before assigning one to an agent. ' +
+      'Optionally filter by connectionId to see only workflows from a specific n8n instance.',
+    parameters: {
+      type: 'object',
+      required: [],
+      additionalProperties: false,
+      properties: {
+        connectionId: {
+          type: 'string',
+          description:
+            'Optional. Filter results to only workflows from this N8nConnection. ' +
+            'Skill names follow the pattern n8n:{connectionId}:{workflowId}.',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+          default: 20,
+          description: 'Maximum number of workflows to return. Default: 20.',
+        },
+      },
+    },
+  },
+} as const;
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export interface ListN8nWorkflowsArgs {
+  connectionId?: string;
+  limit?:        number;
+}
+
+export interface N8nWorkflowSkillItem {
+  skillId:      string;
+  skillName:    string;
+  n8nWorkflowId: string;
+  connectionId: string;
+  webhookUrl:   string | null;
+}
+
+/**
+ * Ejecuta la tool list_n8n_workflows.
+ *
+ * Lee Skills de type='n8n_webhook' desde Prisma.
+ * El nombre canónico del skill es: 'n8n:{connectionId}:{n8nWorkflowId}'
+ */
+export async function handleListN8nWorkflows(
+  args: ListN8nWorkflowsArgs,
+  prisma: PrismaClient,
+): Promise<{
+  success: boolean;
+  workflows: N8nWorkflowSkillItem[];
+  total:   number;
+  error?:  string;
+}> {
+  try {
+    // Construimos el filtro de nombre si se proporciona connectionId
+    const nameFilter = args.connectionId
+      ? { startsWith: `n8n:${args.connectionId}:` }
+      : { startsWith: 'n8n:' };
+
+    const skills = await (prisma as unknown as {
+      skill: {
+        findMany: (args: {
+          where: { type: string; name: Record<string, string> };
+          take: number;
+          orderBy: { createdAt: string };
+          select: { id: true; name: true; config: true };
+        }) => Promise<Array<{ id: string; name: string; config: unknown }>>;
+      };
+    }).skill.findMany({
+      where: {
+        type: 'n8n_webhook',
+        name: nameFilter,
+      },
+      take:    args.limit ?? 20,
+      orderBy: { createdAt: 'desc' },
+      select:  { id: true, name: true, config: true },
+    });
+
+    const workflows: N8nWorkflowSkillItem[] = skills.map((skill) => {
+      // Parsear nombre canónico: 'n8n:{connectionId}:{n8nWorkflowId}'
+      const parts = skill.name.split(':');
+      const connectionId  = parts[1] ?? '';
+      const n8nWorkflowId = parts.slice(2).join(':'); // por si el id tiene ':'
+
+      const config = (skill.config ?? {}) as Record<string, unknown>;
+
+      return {
+        skillId:       skill.id,
+        skillName:     skill.name,
+        n8nWorkflowId,
+        connectionId,
+        webhookUrl:    (config['webhookUrl'] as string | null | undefined) ?? null,
+      };
+    });
+
+    return {
+      success:   true,
+      workflows,
+      total:     workflows.length,
+    };
+  } catch (err: unknown) {
+    return {
+      success:   false,
+      workflows: [],
+      total:     0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/apps/api/src/modules/n8n/n8n.service.ts
+++ b/apps/api/src/modules/n8n/n8n.service.ts
@@ -9,6 +9,7 @@
  *   N8N_API_KEY    – n8n API key (Settings → API)
  */
 
+import { Injectable } from '@nestjs/common';
 import type { FlowSpec } from '../../../../../packages/core-types/src';
 import { N8nBridgeService } from '../flows/n8n-bridge.service';
 
@@ -114,6 +115,7 @@ class N8nClient {
   }
 }
 
+@Injectable()
 export class N8nService {
   private readonly client = new N8nClient();
   private readonly bridge = new N8nBridgeService();

--- a/apps/api/src/modules/n8n/n8n.service.ts
+++ b/apps/api/src/modules/n8n/n8n.service.ts
@@ -9,7 +9,6 @@
  *   N8N_API_KEY    – n8n API key (Settings → API)
  */
 
-import { Injectable } from '@nestjs/common';
 import type { FlowSpec } from '../../../../../packages/core-types/src';
 import { N8nBridgeService } from '../flows/n8n-bridge.service';
 
@@ -115,13 +114,12 @@ class N8nClient {
   }
 }
 
-@Injectable()
 export class N8nService {
   private readonly client = new N8nClient();
   private readonly bridge = new N8nBridgeService();
 
   // ── Workflow management ─────────────────────────────────────────────────────
-  listWorkflows()       { return this.client.listWorkflows(); }
+  listWorkflows()         { return this.client.listWorkflows(); }
   getWorkflow(id: string) { return this.client.getWorkflow(id); }
 
   /** Create an n8n workflow from a FlowSpec.  Returns the created workflow. */
@@ -148,12 +146,21 @@ export class N8nService {
     return this.client.triggerWebhook(webhookPath, payload, method);
   }
 
-  getExecution(id: string)              { return this.client.getExecution(id); }
-  listExecutions(workflowId?: string)   { return this.client.listExecutions(workflowId); }
+  getExecution(id: string)            { return this.client.getExecution(id); }
+  listExecutions(workflowId?: string) { return this.client.listExecutions(workflowId); }
 
   // ── Bridge utilities ────────────────────────────────────────────────────────
   /** Returns the cross-reference map: canvas nodeId → n8n nodeId */
   getNodeIdMap(flow: FlowSpec): Map<string, string> {
     return this.bridge.buildNodeIdMap(flow);
+  }
+
+  /**
+   * Crea un workflow directamente desde un spec raw (sin FlowSpec).
+   * Usado por N8nStudioHelper para workflows generados por LLM.
+   * Refs: F4b-01 (#76)
+   */
+  createWorkflowRaw(workflow: Partial<N8nWorkflow>): Promise<N8nWorkflow> {
+    return this.client.createWorkflow(workflow);
   }
 }


### PR DESCRIPTION
## F4b-01 — N8nStudioHelper.createWorkflowFromDescription()

Closes #76

### Archivos creados

| Archivo | Descripción |
|---------|-------------|
| `apps/api/src/modules/builder-agent/n8n-studio-helper.ts` | Servicio principal — cerebro del AgentBuilder para n8n |
| `apps/api/src/modules/builder-agent/builder-agent.module.ts` | Módulo NestJS — registra providers e importa N8nModule |

### Lógica implementada (7 pasos)

1. **ModelPolicy** — `resolveModelPolicy(prisma, { agentId, workspaceId, departmentId, agencyId })` desde `policy-resolver.ts`. Cascada agent→workspace→dept→agency (D-09). Default: `openai/gpt-4o` si no hay política.
2. **buildLLMClient()** — cliente LLM con el modelo resuelto, `temperature: 0.2`, `max_tokens: 2048`, `response_format: { type: 'json_object' }`.
3. **System prompt** — instruye al LLM para devolver ÚNICAMENTE JSON válido con estructura `{ name, nodes[], connections{} }`. Incluye referencia de tipos de nodos `n8n-nodes-base.*`.
4. **Parse + validación** — JSON.parse + guardias mínimos: `name` string no vacío, `nodes` array no vacío, `connections` objeto (default `{}` si falta).
5. **N8nService.createWorkflowRaw()** — crea el workflow en n8n real via la API del módulo `apps/api/src/modules/n8n/`.
6. **webhookUrl** — extraída del nodo `n8n-nodes-base.webhook` si existe en el spec.
7. **Prisma skill.upsert()** — nombre canónico `n8n:{connectionId}:{n8nWorkflowId}`, `type: 'n8n_webhook'`, `config` con todos los metadatos.

### Manejo de errores

| Caso | Comportamiento |
|------|----------------|
| LLM devuelve JSON inválido | `Error` con primeros 200 chars |
| `spec.nodes` vacío | `Error` descriptivo |
| `N8nService.createWorkflowRaw()` falla | Re-throw con prefijo `[N8nStudioHelper]` |
| Skill upsert falla | Re-throw con contexto |
| ModelPolicy no encontrada | Default `openai/gpt-4o`, no lanza error |

### NestJS DI

```typescript
@Module({
  imports: [N8nModule],
  providers: [BuilderAgentService, N8nStudioHelper, ProfilePropagatorService],
  exports:   [BuilderAgentService, N8nStudioHelper],
})
export class BuilderAgentModule {}
```

### Checklist F4b-01

- [x] Sin imports de `workspaceStore`
- [x] ModelPolicy en cascada — no hardcodea `gpt-4o` (solo como fallback)
- [x] JSON mínimo validado antes de llamar a n8n
- [x] Skill registrado con `type='n8n_webhook'` y nombre canónico
- [x] Injectable NestJS con inyección real de dependencias
- [x] Commit incluye `Closes #76`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create n8n workflows from natural-language descriptions with optional activation.
  * Automatic detection and return of webhook URLs for workflows that expose webhooks.
  * New agent tools to create workflows, list created workflows, and assign/upsert skills to agents with structured results.

* **Chores**
  * Backend support for a builder agent and n8n integration to enable these capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->