### PR TITLE
feat(F5-01): WhatsAppAdapter Baileys — gaps corregidos y tests añadidos

### DIFF
--- a/apps/gateway/src/channels/__tests__/discord.adapter.spec.ts
+++ b/apps/gateway/src/channels/__tests__/discord.adapter.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * discord.adapter.spec.ts — Tests F5-04
+ *
+ * Cubre:
+ *   - PING handshake (type=1) → { type: 1 }
+ *   - Slash commands (type=2) → emit IncomingMessage
+ *   - Message component (type=3) → ignorado sin crash
+ *   - send() → PATCH /webhooks/...
+ *   - Audit hooks conectados
+ */
+
+import { DiscordAdapter } from '../discord.adapter.js'
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+global.fetch = jest.fn()
+
+jest.mock('../discord.adapter.audit.js', () => ({
+  auditDiscordProvisioned:     jest.fn(),
+  auditDiscordMessageInbound:  jest.fn(),
+  auditDiscordMessageOutbound: jest.fn(),
+  auditDiscordError:           jest.fn(),
+}))
+
+import {
+  auditDiscordMessageInbound,
+  auditDiscordMessageOutbound,
+} from '../discord.adapter.audit.js'
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const makePrisma = (extra: Record<string, unknown> = {}) => ({
+  channelConfig: {
+    findUnique: jest.fn().mockResolvedValue({
+      id:               'cc-test',
+      secretsEncrypted: JSON.stringify({ publicKey: 'abc123' }),
+      config:           { applicationId: 'app-1', agentId: 'ag-1', workspaceId: 'ws-1', guildId: 'guild-1', ...extra },
+    }),
+  },
+})
+
+const makeInteraction = (overrides: Record<string, unknown> = {}) => ({
+  id:         'inter-1',
+  type:       2,
+  token:      'tok-abc',
+  channel_id: 'ch-1',
+  data:       { name: 'ask', options: [{ name: 'message', value: 'hola' }] },
+  member:     { user: { id: 'user-1', username: 'alice' } },
+  ...overrides,
+})
+
+async function buildAdapter() {
+  const prisma  = makePrisma()
+  const adapter = new DiscordAdapter(prisma)
+  // Simular emit para capturar IncomingMessage
+  const emitted: unknown[] = []
+  ;(adapter as unknown as { emit: (m: unknown) => Promise<void> }).emit =
+    jest.fn(async (m) => { emitted.push(m) })
+  await adapter.initialize('cc-test')
+  return { adapter, prisma, emitted }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('DiscordAdapter', () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok:   true,
+      text: jest.fn().mockResolvedValue(''),
+    })
+  })
+
+  // ── PING handshake ────────────────────────────────────────────────────
+
+  it('handleInteraction() con type=1 devuelve { type: 1 } (PONG)', async () => {
+    const { adapter } = await buildAdapter()
+    const result = await adapter.handleInteraction({ id: 'p-1', type: 1, token: '' })
+    expect(result).toEqual({ type: 1 })
+  })
+
+  // ── MESSAGE_COMPONENT (type=3) ────────────────────────────────────────
+
+  it('handleInteraction() con type=3 retorna null sin crash', async () => {
+    const { adapter } = await buildAdapter()
+    const result = await adapter.handleInteraction(makeInteraction({ type: 3 }) as never)
+    expect(result).toBeNull()
+  })
+
+  // ── APPLICATION_COMMAND (type=2) ─────────────────────────────────────
+
+  it('handleInteraction() con type=2 emite IncomingMessage al dispatcher', async () => {
+    const { adapter, emitted } = await buildAdapter()
+    await adapter.handleInteraction(makeInteraction())
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]).toMatchObject({
+      channelType: 'discord',
+      externalId:  'ch-1',
+      senderId:    'user-1',
+      text:        'hola',
+      type:        'text',
+    })
+  })
+
+  it('handleInteraction() sin channel_id → dropped (retorna null, no emite)', async () => {
+    const { adapter, emitted } = await buildAdapter()
+    const result = await adapter.handleInteraction(
+      makeInteraction({ channel_id: undefined }) as never,
+    )
+    expect(result).toBeNull()
+    expect(emitted).toHaveLength(0)
+  })
+
+  it('handleInteraction() extrae texto del option "message" si existe', async () => {
+    const { adapter, emitted } = await buildAdapter()
+    await adapter.handleInteraction(
+      makeInteraction({ data: { name: 'ask', options: [{ name: 'message', value: 'test message' }] } }),
+    )
+    expect((emitted[0] as { text: string }).text).toBe('test message')
+  })
+
+  it('handleInteraction() fallback al nombre del comando si no hay option "message"', async () => {
+    const { adapter, emitted } = await buildAdapter()
+    await adapter.handleInteraction(
+      makeInteraction({ data: { name: 'status', options: [] } }),
+    )
+    expect((emitted[0] as { text: string }).text).toBe('status')
+  })
+
+  // ── send() ────────────────────────────────────────────────────────────
+
+  it('send() llama PATCH /webhooks/{appId}/{token}/messages/@original', async () => {
+    const { adapter } = await buildAdapter()
+    await adapter.handleInteraction(makeInteraction())
+    await adapter.send({ text: 'respuesta', channelConfigId: 'cc-test', type: 'text' })
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://discord.com/api/v10/webhooks/app-1/tok-abc/messages/@original',
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+  })
+
+  it('send() lanza error con res.status si HTTP falla (AUDIT-13)', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok:   false,
+      status: 403,
+      text: jest.fn().mockResolvedValue('Forbidden'),
+    })
+    const { adapter } = await buildAdapter()
+    await adapter.handleInteraction(makeInteraction())
+    await expect(
+      adapter.send({ text: 'x', channelConfigId: 'cc-test', type: 'text' }),
+    ).rejects.toThrow('HTTP 403')
+  })
+
+  it('send() lanza error si llamado antes de handleInteraction()', async () => {
+    const { adapter } = await buildAdapter()
+    // No llamar handleInteraction — interactionToken queda vacío
+    await expect(
+      adapter.send({ text: 'x', channelConfigId: 'cc-test', type: 'text' }),
+    ).rejects.toThrow('send() called before handleInteraction()')
+  })
+
+  // ── Audit hooks ───────────────────────────────────────────────────────
+
+  it('handleInteraction() tipo message llama auditDiscordMessageInbound()', async () => {
+    const { adapter } = await buildAdapter()
+    await adapter.handleInteraction(makeInteraction())
+    expect(auditDiscordMessageInbound).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'inter-1' }),
+    )
+  })
+
+  it('send() exitoso llama auditDiscordMessageOutbound()', async () => {
+    const { adapter } = await buildAdapter()
+    await adapter.handleInteraction(makeInteraction())
+    await adapter.send({ text: 'ok', channelConfigId: 'cc-test', type: 'text' })
+    expect(auditDiscordMessageOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'inter-1' }),
+    )
+  })
+
+})

--- a/apps/gateway/src/channels/__tests__/slack.adapter.spec.ts
+++ b/apps/gateway/src/channels/__tests__/slack.adapter.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * slack.adapter.spec.ts
+ * [F5-03] Tests para SlackAdapter: firma HMAC, challenge, mensajes, send()
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+import { createHmac } from 'node:crypto'
+
+// ── Mock global fetch ────────────────────────────────────────────────
+
+const mockFetch = jest.fn<() => Promise<Response>>()
+global.fetch = mockFetch as unknown as typeof fetch
+
+// ── Mock de PrismaService ─────────────────────────────────────────────
+
+const BOT_TOKEN    = 'xoxb-test-token'
+const SIGNING_SECRET = 'test-signing-secret-32chars-long!'
+
+const prismaMock = {
+  channelConfig: {
+    findUnique: jest.fn().mockResolvedValue({
+      id:               'cc-slack-1',
+      secretsEncrypted: JSON.stringify({ botToken: BOT_TOKEN, signingSecret: SIGNING_SECRET }),
+    }),
+  },
+}
+
+// ── Import del adapter bajo test ───────────────────────────────────────
+
+const { SlackAdapter } = await import('../slack.adapter.js')
+
+// ── Helper: construir firma Slack válida ────────────────────────────────
+
+function makeSlackSignature(rawBody: string, timestamp: string, secret = SIGNING_SECRET): string {
+  const base = `v0:${timestamp}:${rawBody}`
+  const hmac = createHmac('sha256', secret).update(base).digest('hex')
+  return `v0=${hmac}`
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('SlackAdapter', () => {
+  let adapter: InstanceType<typeof SlackAdapter>
+  const CHANNEL_ID = 'cc-slack-1'
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    adapter = new SlackAdapter(prismaMock as never)
+    await adapter.initialize(CHANNEL_ID)
+  })
+
+  // ───────────────────────────────────────────────────────────────────
+  // Bloque 1 — Verificación de firma HMAC
+  // ───────────────────────────────────────────────────────────────────
+
+  describe('verifySlackSignature()', () => {
+    it('devuelve true con firma válida y timestamp reciente', () => {
+      const rawBody  = '{"type":"event_callback"}'
+      const timestamp = String(Math.floor(Date.now() / 1000))
+      const signature = makeSlackSignature(rawBody, timestamp)
+
+      expect(adapter.verifySlackSignature(SIGNING_SECRET, rawBody, timestamp, signature)).toBe(true)
+    })
+
+    it('devuelve false con timestamp viejo >5 min (anti-replay)', () => {
+      const rawBody   = '{"type":"event_callback"}'
+      const oldTs     = String(Math.floor(Date.now() / 1000) - 400)  // 6+ min ago
+      const signature = makeSlackSignature(rawBody, oldTs)
+
+      expect(adapter.verifySlackSignature(SIGNING_SECRET, rawBody, oldTs, signature)).toBe(false)
+    })
+
+    it('devuelve false con firma manipulada', () => {
+      const rawBody   = '{"type":"event_callback"}'
+      const timestamp = String(Math.floor(Date.now() / 1000))
+      const badSig    = 'v0=0000000000000000000000000000000000000000000000000000000000000000'
+
+      expect(adapter.verifySlackSignature(SIGNING_SECRET, rawBody, timestamp, badSig)).toBe(false)
+    })
+  })
+
+  // ───────────────────────────────────────────────────────────────────
+  // Bloque 2 — url_verification challenge
+  // ───────────────────────────────────────────────────────────────────
+
+  describe('receive() — url_verification', () => {
+    it('devuelve { challenge } para type=url_verification', async () => {
+      const rawBody  = '{"type":"url_verification","challenge":"abc123"}'
+      const timestamp = String(Math.floor(Date.now() / 1000))
+      const signature = makeSlackSignature(rawBody, timestamp)
+
+      const result = await adapter.receive(
+        { type: 'url_verification', challenge: 'abc123' },
+        { rawBody, timestamp, signature },
+      )
+
+      expect(result).toEqual({ challenge: 'abc123' })
+    })
+  })
+
+  // ───────────────────────────────────────────────────────────────────
+  // Bloque 3 — Mensajes normales
+  // ───────────────────────────────────────────────────────────────────
+
+  describe('receive() — event_callback', () => {
+    const makeEventPayload = (event: Record<string, unknown>) => ({
+      type:    'event_callback',
+      event,
+    })
+
+    const makeSecrets = (payload: unknown) => {
+      const rawBody  = JSON.stringify(payload)
+      const timestamp = String(Math.floor(Date.now() / 1000))
+      return { rawBody, timestamp, signature: makeSlackSignature(rawBody, timestamp) }
+    }
+
+    it('devuelve IncomingMessage para message con user y channel', async () => {
+      const payload = makeEventPayload({ type: 'message', user: 'U123', channel: 'C456', text: 'hola' })
+      const result  = await adapter.receive(payload, makeSecrets(payload))
+
+      expect(result).toMatchObject({
+        channelType: 'slack',
+        externalId:  'C456',
+        senderId:    'U123',
+        text:        'hola',
+        type:        'text',
+      })
+    })
+
+    it('devuelve null para mensajes sin user (bots)', async () => {
+      const payload = makeEventPayload({ type: 'message', channel: 'C456', text: 'bot msg' })
+      const result  = await adapter.receive(payload, makeSecrets(payload))
+
+      expect(result).toBeNull()
+    })
+
+    it('devuelve null para mensajes sin channel', async () => {
+      const payload = makeEventPayload({ type: 'message', user: 'U123', text: 'no channel' })
+      const result  = await adapter.receive(payload, makeSecrets(payload))
+
+      expect(result).toBeNull()
+    })
+  })
+
+  // ───────────────────────────────────────────────────────────────────
+  // Bloque 4 — send() con doble verificación AUDIT-13
+  // ───────────────────────────────────────────────────────────────────
+
+  describe('send()', () => {
+    const makeMsg = () => ({
+      channelConfigId: CHANNEL_ID,
+      channelType:     'slack' as const,
+      externalId:      'C789',
+      senderId:        'bot',
+      text:            'respuesta de prueba',
+      type:            'text' as const,
+      receivedAt:      new Date().toISOString(),
+    })
+
+    it('llama chat.postMessage con Authorization Bearer y entrega exitosa', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok:   true,
+        status: 200,
+        json: async () => ({ ok: true, ts: '1234567890.000001' }),
+      } as unknown as Response)
+
+      await expect(adapter.send(makeMsg())).resolves.toBeUndefined()
+
+      const callArgs = (mockFetch.mock.calls[0] as unknown[]) as [string, RequestInit]
+      expect(callArgs[0]).toBe('https://slack.com/api/chat.postMessage')
+      expect((callArgs[1]?.headers as Record<string, string>)?.['Authorization'])
+        .toBe(`Bearer ${BOT_TOKEN}`)
+    })
+
+    it('lanza error si data.ok === false (AUDIT-13 — Slack error en body)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok:   true,
+        status: 200,
+        json: async () => ({ ok: false, error: 'channel_not_found' }),
+      } as unknown as Response)
+
+      await expect(adapter.send(makeMsg())).rejects.toThrow('channel_not_found')
+    })
+
+    it('lanza error si res.ok === false (HTTP error)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok:     false,
+        status: 429,
+        json:   async () => ({ ok: false, error: 'ratelimited' }),
+      } as unknown as Response)
+
+      await expect(adapter.send(makeMsg())).rejects.toThrow('HTTP 429')
+    })
+  })
+})

--- a/apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.spec.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * whatsapp-baileys.adapter.spec.ts — F5-01
+ *
+ * Tests unitarios de WhatsAppBaileysAdapter.
+ * Jest puro — sin TestingModule NestJS.
+ * Cubre los 6 casos del criterio de aceptación F5-01.
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockEvHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+const mockSock = {
+  ev: {
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!mockEvHandlers[event]) mockEvHandlers[event] = [];
+      mockEvHandlers[event].push(handler);
+    }),
+    off:                jest.fn(),
+    removeAllListeners: jest.fn(),
+  },
+  sendMessage: jest.fn().mockResolvedValue({}),
+  logout:      jest.fn().mockResolvedValue(undefined),
+  end:         jest.fn(),
+  user:        { id: '5491155000000@s.whatsapp.net', name: 'Test' },
+};
+
+const mockSaveCreds = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@whiskeysockets/baileys', () => ({
+  makeWASocket: jest.fn(() => mockSock),
+  useMultiFileAuthState: jest.fn().mockResolvedValue({
+    state:     { creds: {}, keys: {} },
+    saveCreds: mockSaveCreds,
+  }),
+  fetchLatestBaileysVersion: jest.fn().mockResolvedValue({ version: [2, 3000, 1] }),
+  DisconnectReason: { loggedOut: 401, connectionLost: 408, restartRequired: 515, badSession: 500, connectionReplaced: 440, timedOut: 408 },
+}));
+
+// Mock PrismaService — credenciales en BD
+const prismaMock = {
+  gatewaySession: {
+    findUnique: jest.fn().mockResolvedValue(null),
+    upsert:     jest.fn().mockResolvedValue({ id: 'sess-1', channelConfigId: 'ch-1' }),
+    update:     jest.fn().mockResolvedValue({}),
+  },
+};
+
+jest.mock('../../../prisma/prisma.service.js', () => ({
+  PrismaService: jest.fn().mockImplementation(() => prismaMock),
+}));
+
+// Mock fs para que setup() no falle en el entorno de CI
+jest.mock('node:fs', () => ({
+  mkdirSync: jest.fn(),
+  rmSync:    jest.fn(),
+}));
+
+// ── Helper: emitir evento Baileys ──────────────────────────────────────────
+function emitBaileysEvent(event: string, payload: unknown): void {
+  const handlers = mockEvHandlers[event] ?? [];
+  handlers.forEach(h => h(payload));
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('WhatsAppBaileysAdapter', () => {
+  let adapter: import('../whatsapp-baileys.adapter.js').WhatsAppBaileysAdapter;
+  let dispatchMock: jest.Mock;
+
+  beforeEach(async () => {
+    // Limpiar handlers entre tests
+    Object.keys(mockEvHandlers).forEach(k => delete mockEvHandlers[k]);
+    jest.clearAllMocks();
+
+    const mod = await import('../whatsapp-baileys.adapter.js');
+    adapter = new mod.WhatsAppBaileysAdapter();
+    await adapter.setup({ sessionsDir: '/tmp/wa-test' }, {});
+    await adapter.initialize('ch-test-1');
+
+    dispatchMock = jest.fn().mockResolvedValue(undefined);
+    adapter.onMessage(dispatchMock);
+  });
+
+  // ── Caso 1: connect() arranca socket Baileys ──────────────────────────────
+  it('connect() arranca socket Baileys y registra handlers de eventos', async () => {
+    const baileys = await import('@whiskeysockets/baileys');
+    await adapter.connect();
+
+    expect(baileys.makeWASocket).toHaveBeenCalledTimes(1);
+    // Al menos connection.update, creds.update y messages.upsert deben estar registrados
+    expect(Object.keys(mockEvHandlers)).toEqual(
+      expect.arrayContaining(['connection.update', 'creds.update', 'messages.upsert']),
+    );
+  });
+
+  // ── Caso 2: mensaje entrante fromMe=false → dispatcher llamado ────────────
+  it('mensaje entrante fromMe=false → onMessage handler llamado', async () => {
+    await adapter.connect();
+
+    emitBaileysEvent('messages.upsert', {
+      type:     'notify',
+      messages: [{
+        key:     { remoteJid: '5491155000000@s.whatsapp.net', fromMe: false, id: 'MSG-001' },
+        message: { conversation: 'Hola mundo' },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+        pushName: 'Test User',
+      }],
+    });
+
+    // Esperar micro-tarea del .catch()
+    await Promise.resolve();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Caso 3: mensaje fromMe=true → dispatcher NO llamado ──────────────────
+  it('mensaje fromMe=true → onMessage handler NO llamado', async () => {
+    await adapter.connect();
+
+    emitBaileysEvent('messages.upsert', {
+      type:     'notify',
+      messages: [{
+        key:     { remoteJid: '5491155000000@s.whatsapp.net', fromMe: true, id: 'MSG-002' },
+        message: { conversation: 'Mensaje propio' },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      }],
+    });
+
+    await Promise.resolve();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  // ── Caso 4: status@broadcast → dispatcher NO llamado ─────────────────────
+  it('status@broadcast → onMessage handler NO llamado', async () => {
+    await adapter.connect();
+
+    emitBaileysEvent('messages.upsert', {
+      type:     'notify',
+      messages: [{
+        key:     { remoteJid: 'status@broadcast', fromMe: false, id: 'MSG-003' },
+        message: { conversation: 'Status update' },
+        messageTimestamp: Math.floor(Date.now() / 1000),
+      }],
+    });
+
+    await Promise.resolve();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  // ── Caso 5: disconnect() limpio ───────────────────────────────────────────
+  it('logout() llama sock.logout() y deja estado closed', async () => {
+    await adapter.connect();
+    expect(adapter.state).toBe('connecting'); // socket abierto, aún no 'open' sin evento
+
+    await adapter.logout();
+
+    expect(mockSock.logout).toHaveBeenCalledTimes(1);
+    expect(mockSock.ev.removeAllListeners).toHaveBeenCalled();
+    expect(adapter.state).toBe('closed');
+  });
+
+  // ── Caso 6: QR emitido como evento 'qr' antes del primer login ───────────
+  it('QR emitido via onQr() callback como string antes del primer login', async () => {
+    const qrHandler = jest.fn();
+    adapter.onQr(qrHandler);
+
+    await adapter.connect();
+
+    // Simular evento QR de Baileys
+    emitBaileysEvent('connection.update', { qr: 'data:image/png;base64,QRCODE==' });
+
+    expect(qrHandler).toHaveBeenCalledWith('data:image/png;base64,QRCODE==');
+    expect(adapter.state).toBe('qr');
+  });
+});

--- a/apps/gateway/src/channels/__tests__/whatsapp-prisma-auth.spec.ts
+++ b/apps/gateway/src/channels/__tests__/whatsapp-prisma-auth.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * whatsapp-prisma-auth.spec.ts
+ * [F5-02] Tests para usePrismaAuthState() y clearSessionInDb()
+ */
+
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+// ── Mock de @whiskeysockets/baileys ─────────────────────────────────────
+
+const mockInitAuthCreds = jest.fn().mockReturnValue({
+  noiseKey:                    { type: 'Buffer', data: [1, 2, 3] },
+  pairingEphemeralKeyPair:     { type: 'Buffer', data: [4, 5, 6] },
+  signedIdentityKey:           { type: 'Buffer', data: [7, 8, 9] },
+  signedPreKey:                { type: 'Buffer', data: [10, 11, 12] },
+  registrationId:              42,
+  advSecretKey:                'test-adv-secret',
+  nextPreKeyId:                1,
+  firstUnappendedPreKeyId:     1,
+  serverHasPreKeys:            false,
+  account:                     null,
+})
+
+const BufferJSON = {
+  replacer: (_key: string, value: unknown) => value,
+  reviver:  (_key: string, value: unknown) => value,
+}
+
+jest.mock('@whiskeysockets/baileys', () => ({
+  initAuthCreds: mockInitAuthCreds,
+  BufferJSON,
+}))
+
+// ── Import del módulo bajo test ─────────────────────────────────────────
+// Importamos DESPUÉS de configurar el mock
+const { usePrismaAuthState, clearSessionInDb } = await import('../whatsapp-prisma-auth.js')
+
+// ── Mock de PrismaClient ────────────────────────────────────────────────
+
+const makePrismaMock = () => ({
+  gatewaySession: {
+    findFirst:  jest.fn<() => Promise<{ metadata: unknown } | null>>(),
+    upsert:     jest.fn<() => Promise<{ id: string }>>().mockResolvedValue({ id: 'gs-test-1' }),
+    updateMany: jest.fn<() => Promise<{ count: number }>>().mockResolvedValue({ count: 1 }),
+  },
+})
+
+type PrismaMock = ReturnType<typeof makePrismaMock>
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('usePrismaAuthState', () => {
+  const CHANNEL_ID = 'test-channel-config-id'
+  let prismaMock: PrismaMock
+
+  beforeEach(() => {
+    prismaMock = makePrismaMock()
+    jest.clearAllMocks()
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  it('primera vez: devuelve initAuthCreds() cuando no hay registro en BD', async () => {
+    prismaMock.gatewaySession.findFirst.mockResolvedValue(null)
+
+    const { state, saveCreds } = await usePrismaAuthState(
+      prismaMock as unknown as import('@prisma/client').PrismaClient,
+      CHANNEL_ID,
+    )
+
+    expect(mockInitAuthCreds).toHaveBeenCalledTimes(1)
+    expect(state.creds).toBeDefined()
+    expect(state.creds.registrationId).toBe(42)
+    expect(typeof saveCreds).toBe('function')
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  it('segunda vez: carga creds desde BD con BufferJSON.reviver', async () => {
+    const savedCreds = {
+      noiseKey:                { type: 'Buffer', data: [99, 100] },
+      pairingEphemeralKeyPair: { type: 'Buffer', data: [101] },
+      signedIdentityKey:       { type: 'Buffer', data: [102] },
+      signedPreKey:            { type: 'Buffer', data: [103] },
+      registrationId:          99,
+      advSecretKey:            'loaded-from-db',
+      nextPreKeyId:            10,
+      firstUnappendedPreKeyId: 10,
+      serverHasPreKeys:        true,
+      account:                 null,
+    }
+
+    prismaMock.gatewaySession.findFirst.mockResolvedValue({ metadata: savedCreds })
+
+    const { state } = await usePrismaAuthState(
+      prismaMock as unknown as import('@prisma/client').PrismaClient,
+      CHANNEL_ID,
+    )
+
+    // initAuthCreds NO debe ser llamado cuando hay datos en BD
+    expect(mockInitAuthCreds).not.toHaveBeenCalled()
+    expect(state.creds.registrationId).toBe(99)
+    expect(state.creds.advSecretKey).toBe('loaded-from-db')
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  it('saveCreds() hace upsert en BD con el channelConfigId correcto', async () => {
+    prismaMock.gatewaySession.findFirst.mockResolvedValue(null)
+
+    const { saveCreds } = await usePrismaAuthState(
+      prismaMock as unknown as import('@prisma/client').PrismaClient,
+      CHANNEL_ID,
+    )
+
+    await saveCreds()
+
+    expect(prismaMock.gatewaySession.upsert).toHaveBeenCalledTimes(1)
+
+    const upsertCall = prismaMock.gatewaySession.upsert.mock.calls[0]?.[0] as {
+      where: { channelConfigId_externalUserId: { channelConfigId: string; externalUserId: string } }
+      create: { channelConfigId: string; externalUserId: string; status: string }
+      update: { status: string }
+    }
+
+    expect(upsertCall.where.channelConfigId_externalUserId.channelConfigId).toBe(CHANNEL_ID)
+    expect(upsertCall.where.channelConfigId_externalUserId.externalUserId).toBe('__baileys_creds__')
+    expect(upsertCall.create.channelConfigId).toBe(CHANNEL_ID)
+    expect(upsertCall.create.status).toBe('connected')
+    expect(upsertCall.update.status).toBe('connected')
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  it('clearSessionInDb() llama updateMany con metadata=null y status=logged_out', async () => {
+    await clearSessionInDb(
+      prismaMock as unknown as import('@prisma/client').PrismaClient,
+      CHANNEL_ID,
+    )
+
+    expect(prismaMock.gatewaySession.updateMany).toHaveBeenCalledTimes(1)
+
+    const updateCall = prismaMock.gatewaySession.updateMany.mock.calls[0]?.[0] as {
+      where: { channelConfigId: string; externalUserId: string }
+      data:  { status: string; metadata: null }
+    }
+
+    expect(updateCall.where.channelConfigId).toBe(CHANNEL_ID)
+    expect(updateCall.where.externalUserId).toBe('__baileys_creds__')
+    expect(updateCall.data.status).toBe('logged_out')
+    expect(updateCall.data.metadata).toBeNull()
+  })
+
+  // ────────────────────────────────────────────────────────────────────
+  it('creds corruptos en BD → fallback a initAuthCreds() sin lanzar error', async () => {
+    // metadata inválida que falla al deserializar
+    prismaMock.gatewaySession.findFirst.mockResolvedValue({
+      metadata: 'string-invalida-no-es-objeto',
+    })
+
+    // No debe lanzar — debe usar initAuthCreds() como fallback
+    await expect(
+      usePrismaAuthState(
+        prismaMock as unknown as import('@prisma/client').PrismaClient,
+        CHANNEL_ID,
+      )
+    ).resolves.toBeDefined()
+  })
+})

--- a/apps/gateway/src/channels/discord.adapter.ts
+++ b/apps/gateway/src/channels/discord.adapter.ts
@@ -4,17 +4,30 @@
  * Maneja slash commands e interacciones de Discord.
  * Flujo: Discord → POST /gateway/discord → handleInteraction() → emit()
  *        Router → agent → send() → PATCH followup endpoint
+ *
+ * Fixes F5-04:
+ *   - PING handshake (type=1) → responde { type: 1 } para registro de webhook
+ *   - type=3 (components) manejado sin crash
+ *   - Audit hooks conectados desde discord.adapter.audit.ts
+ *   - loadConfig() usa PrismaService por DI (no más new PrismaService())
+ *   - decryptSecrets() dev mode hasta F3b-05
  */
 
 import type { IncomingMessage, OutgoingMessage } from './channel-adapter.interface.js'
 import { BaseChannelAdapter } from './channel-adapter.interface.js'
+import {
+  auditDiscordProvisioned,
+  auditDiscordMessageInbound,
+  auditDiscordMessageOutbound,
+  auditDiscordError,
+} from './discord.adapter.audit.js'
 
 // ── Tipos Discord ───────────────────────────────────────────────────────
 
 interface DiscordInteraction {
-  id:         string
-  type:       number
-  token:      string
+  id:          string
+  type:        number   // 1=PING, 2=APPLICATION_COMMAND, 3=MESSAGE_COMPONENT
+  token:       string
   channel_id?: string
   data?: {
     name:    string
@@ -24,11 +37,12 @@ interface DiscordInteraction {
   user?:   { id?: string; username?: string }
 }
 
-interface DiscordWebhookBody {
-  application_id: string
-  interaction_id:    string
-  interaction_token: string
-}
+/**
+ * Resultado devuelto por handleInteraction().
+ * null  → mensaje procesado normalmente (emit al dispatcher)
+ * { type: 1 } → PONG — el controller debe responder res.json({ type: 1 })
+ */
+export type DiscordInteractionResult = { type: 1 } | null
 
 // ── Adapter ─────────────────────────────────────────────────────────────
 
@@ -41,10 +55,24 @@ export class DiscordAdapter extends BaseChannelAdapter {
   private interactionId     = ''
   private replied           = false
 
+  /**
+   * @param prisma  PrismaService inyectado por DI (NestJS o manual)
+   */
+  constructor(private readonly prisma: {
+    channelConfig: {
+      findUnique(args: { where: { id: string } }): Promise<{
+        id: string
+        secretsEncrypted?: string | null
+        config: unknown
+      } | null>
+    }
+  }) {
+    super()
+  }
+
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
 
-    // AUDIT-24: leer secretsEncrypted, NO credentials
     const config = await this.loadConfig(channelConfigId)
     const secrets = config.secretsEncrypted
       ? JSON.parse(this.decryptSecrets(config.secretsEncrypted))
@@ -53,6 +81,15 @@ export class DiscordAdapter extends BaseChannelAdapter {
     const cfg = config.config as Record<string, unknown>
     this.applicationId = (cfg.applicationId as string) ?? ''
     this.publicKey     = (secrets.publicKey  as string) ?? ''
+
+    // Audit: canal provisionado exitosamente
+    auditDiscordProvisioned({
+      channelId:   this.channelConfigId,
+      channelName: 'discord',
+      agentId:     String((cfg.agentId     as string | undefined) ?? ''),
+      workspaceId: String((cfg.workspaceId as string | undefined) ?? ''),
+      guildId:     String((cfg.guildId     as string | undefined) ?? ''),
+    })
   }
 
   async dispose(): Promise<void> {
@@ -62,9 +99,32 @@ export class DiscordAdapter extends BaseChannelAdapter {
   /**
    * Procesa una interacción de Discord recibida vía webhook HTTP.
    * Llamado desde discord.controller.ts tras verificar la firma Ed25519.
+   *
+   * @returns { type: 1 } si es PING — el controller DEBE hacer res.json({ type: 1 })
+   * @returns null        para cualquier interacción procesada normalmente
    */
-  async handleInteraction(interaction: DiscordInteraction): Promise<void> {
-    // Reset state per interaction
+  async handleInteraction(
+    interaction: DiscordInteraction,
+  ): Promise<DiscordInteractionResult> {
+    // ── PASO 1: PING handshake (type=1) ─────────────────────────────────
+    // Discord envía un PING al registrar el webhook URL.
+    // Sin esta respuesta, Discord rechaza el endpoint.
+    if (interaction.type === 1) {
+      return { type: 1 }  // PONG
+    }
+
+    // ── PASO 2: MESSAGE_COMPONENT (type=3) ──────────────────────────────
+    // Botones, select menus, etc. No los procesamos aún — solo log.
+    if (interaction.type === 3) {
+      console.info(
+        `[discord] MESSAGE_COMPONENT interaction received — not handled yet`,
+        { interactionId: interaction.id },
+      )
+      return null
+    }
+
+    // ── PASO 3: APPLICATION_COMMAND (type=2) ────────────────────────────
+    // Reset state por interacción
     this.replied           = false
     this.interactionToken  = interaction.token
     this.interactionId     = interaction.id
@@ -76,12 +136,12 @@ export class DiscordAdapter extends BaseChannelAdapter {
         `[discord] interaction without channel_id — dropped`,
         { interactionId: interaction.id },
       )
-      return
+      return null
     }
 
-    const user      = interaction.member?.user ?? interaction.user
-    const senderId  = user?.id ?? externalId
-    const text      = interaction.data?.options?.find((o) => o.name === 'message')?.value
+    const user     = interaction.member?.user ?? interaction.user
+    const senderId = user?.id ?? externalId
+    const text     = interaction.data?.options?.find((o) => o.name === 'message')?.value
       ?? interaction.data?.name
       ?? ''
 
@@ -91,11 +151,31 @@ export class DiscordAdapter extends BaseChannelAdapter {
       externalId,
       senderId,
       text,
-      type:        'text',
-      receivedAt:  this.makeTimestamp(),
+      type:       'text',
+      receivedAt: this.makeTimestamp(),
     }
 
-    await this.emit(msg)
+    // Audit inbound ANTES de emitir al dispatcher
+    auditDiscordMessageInbound({
+      channelId: this.channelConfigId,
+      messageId: interaction.id,
+    })
+
+    try {
+      await this.emit(msg)
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      auditDiscordError({
+        channelId:    this.channelConfigId,
+        errorCode:    String((e as NodeJS.ErrnoException).code ?? 'UNKNOWN'),
+        errorMessage: e.message,
+        recoverable:  false,
+        stack:        e.stack,
+      })
+      throw e
+    }
+
+    return null
   }
 
   /**
@@ -109,34 +189,59 @@ export class DiscordAdapter extends BaseChannelAdapter {
 
     const url = `https://discord.com/api/v10/webhooks/${this.applicationId}/${this.interactionToken}/messages/@original`
 
-    const res = await fetch(url, {
-      method:  'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body:    JSON.stringify({ content: message.text }),
-    })
+    try {
+      const res = await fetch(url, {
+        method:  'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ content: message.text }),
+      })
 
-    // AUDIT-13: verificar res.ok ANTES de marcar replied=true
-    if (!res.ok) {
-      const body = await res.text().catch(() => '')
-      throw new Error(
-        `[discord] send() failed: HTTP ${res.status} — ${body.slice(0, 200)}`,
-      )
+      // AUDIT-13: verificar res.ok ANTES de marcar replied=true
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        throw new Error(
+          `[discord] send() failed: HTTP ${res.status} — ${body.slice(0, 200)}`,
+        )
+      }
+
+      this.replied = true  // ← AUDIT-13: solo aquí, tras confirmar entrega
+
+      // Audit outbound
+      auditDiscordMessageOutbound({
+        channelId: this.channelConfigId,
+        messageId: this.interactionId,
+      })
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      auditDiscordError({
+        channelId:    this.channelConfigId,
+        errorCode:    String((e as NodeJS.ErrnoException).code ?? 'UNKNOWN'),
+        errorMessage: e.message,
+        recoverable:  false,
+        stack:        e.stack,
+      })
+      throw e
     }
-
-    this.replied = true  // ← AUDIT-13: solo aquí, tras confirmar entrega
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────
 
-  private decryptSecrets(_enc: string): string {
-    // F3b-05: decrypt AES-256-GCM — placeholder hasta implementación completa
-    return '{}'
+  /**
+   * TODO F3b-05: reemplazar con CryptoService.decrypt(AES-256-GCM).
+   * Dev mode: secretsEncrypted contiene JSON en plaintext hasta que
+   * F3b-05 implemente el cifrado real.
+   */
+  private decryptSecrets(enc: string): string {
+    return enc
   }
 
+  /**
+   * Carga la configuración del canal desde Prisma (DI — no new PrismaService()).
+   */
   private async loadConfig(channelConfigId: string) {
-    const { PrismaService } = await import('../prisma/prisma.service.js')
-    const db = new PrismaService()
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } })
+    const config = await this.prisma.channelConfig.findUnique({
+      where: { id: channelConfigId },
+    })
     if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`)
     return config
   }

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -10,6 +10,7 @@
  * F5-03: Gaps corregidos
  *   - receive(): url_verification challenge + verificación de firma HMAC
  *   - verifySlackSignature(): HMAC-SHA256, timingSafeEqual, anti-replay 5 min
+ *   - verifySignature(): método estático para routes/slack.ts (sin instancia)
  *   - loadConfig(): PrismaService por DI (no más new PrismaService())
  *   - decryptSecrets(): TODO F3b-05 documentado, no más return '{}' silencioso
  */
@@ -81,7 +82,6 @@ export class SlackAdapter extends BaseChannelAdapter {
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
 
-    // AUDIT-24: leer secretsEncrypted, NO credentials/tokenEnc
     const config = await this.loadConfig(channelConfigId)
     const secrets = config.secretsEncrypted
       ? JSON.parse(this.decryptSecrets(config.secretsEncrypted)) as Record<string, unknown>
@@ -116,12 +116,10 @@ export class SlackAdapter extends BaseChannelAdapter {
     rawPayload: Record<string, unknown>,
     secrets: Record<string, unknown>,
   ): Promise<IncomingMessage | { challenge: string } | null> {
-    // ── Verificar firma HMAC (F5-03 Gap B) ─────────────────────────────
     const rawBody   = (secrets['rawBody']   as string | undefined) ?? ''
     const timestamp = (secrets['timestamp'] as string | undefined) ?? ''
     const signature = (secrets['signature'] as string | undefined) ?? ''
 
-    // Si hay signingSecret cargado, la verificación es obligatoria
     if (this.signingSecret) {
       const valid = this.verifySlackSignature(
         this.signingSecret,
@@ -140,13 +138,10 @@ export class SlackAdapter extends BaseChannelAdapter {
     const payload = rawPayload as SlackWebhookPayload
 
     // ── url_verification challenge (F5-03 Gap A) ────────────────────────
-    // Slack envía este handshake al configurar el webhook.
-    // El controller debe detectar { challenge } y responder res.json({ challenge }).
     if (payload.type === 'url_verification') {
       return { challenge: payload.challenge ?? '' }
     }
 
-    // ── Evento normal ──────────────────────────────────────────────────
     if (payload.type !== 'event_callback' || !payload.event) return null
 
     return this.parseEvent(payload.event)
@@ -154,11 +149,6 @@ export class SlackAdapter extends BaseChannelAdapter {
 
   // ── handleEvent() (compatibilidad con llamadas directas) ─────────────────
 
-  /**
-   * Procesa un evento de Slack (Events API).
-   * Llamado desde slack.controller.ts tras verificar la firma HMAC.
-   * @deprecated Usar receive() en su lugar para el flujo completo.
-   */
   async handleEvent(payload: SlackWebhookPayload): Promise<void> {
     if (!payload.event) return
     const msg = this.parseEvent(payload.event)
@@ -169,9 +159,6 @@ export class SlackAdapter extends BaseChannelAdapter {
 
   /**
    * AUDIT-13: replied=true SOLO después de verificar res.ok && data.ok.
-   *
-   * Slack usa HTTP 200 para todo — el error real es data.ok === false.
-   * Ambas condiciones deben pasar antes de marcar la entrega como exitosa.
    */
   async send(message: OutgoingMessage): Promise<void> {
     if (!this.botToken) {
@@ -190,7 +177,6 @@ export class SlackAdapter extends BaseChannelAdapter {
       }),
     })
 
-    // AUDIT-13: doble verificación (HTTP layer + Slack protocol layer)
     const data = await res.json() as SlackApiResponse
     if (!res.ok || data.ok === false) {
       throw new Error(
@@ -198,29 +184,45 @@ export class SlackAdapter extends BaseChannelAdapter {
       )
     }
 
-    this.replied = true  // ← AUDIT-13: solo aquí, tras confirmar entrega exitosa
+    this.replied = true
     console.info(
       `[slack:${this.channelConfigId}] Message sent to ${message.externalId} ts=${data.ts ?? 'unknown'}`,
     )
   }
 
-  // ── verifySlackSignature (F5-03 Gap B) ───────────────────────────────
+  // ── verifySlackSignature (instancia) ──────────────────────────────────────
 
   /**
-   * Verifica la firma HMAC-SHA256 de Slack.
-   *
-   * @param signingSecret - Slack App Signing Secret
-   * @param rawBody       - body como string exacto (antes de JSON.parse)
-   * @param timestamp     - valor del header X-Slack-Request-Timestamp
-   * @param signature     - valor del header X-Slack-Signature (v0=<hex>)
-   *
-   * @see https://api.slack.com/authentication/verifying-requests-from-slack
+   * Verifica la firma HMAC-SHA256 de Slack (método de instancia).
+   * Usado internamente desde receive() con el signingSecret ya cargado.
    */
   verifySlackSignature(
     signingSecret: string,
     rawBody:       string,
     timestamp:     string,
     signature:     string,
+  ): boolean {
+    return SlackAdapter.verifySignature(signingSecret, timestamp, signature, rawBody)
+  }
+
+  // ── verifySignature (estático) ─────────────────────────────────────────────
+
+  /**
+   * Verifica la firma HMAC-SHA256 de Slack (método estático).
+   * Usado desde routes/slack.ts sin necesidad de una instancia del adapter.
+   *
+   * @param signingSecret - Slack App Signing Secret
+   * @param timestamp     - valor del header X-Slack-Request-Timestamp
+   * @param signature     - valor del header X-Slack-Signature (v0=<hex>)
+   * @param rawBody       - body como string exacto (antes de JSON.parse)
+   *
+   * @see https://api.slack.com/authentication/verifying-requests-from-slack
+   */
+  static verifySignature(
+    signingSecret: string,
+    timestamp:     string,
+    signature:     string,
+    rawBody:       string,
   ): boolean {
     if (!signingSecret || !rawBody || !timestamp || !signature) return false
 
@@ -247,19 +249,16 @@ export class SlackAdapter extends BaseChannelAdapter {
   private parseEvent(event: SlackEvent): IncomingMessage | null {
     if (event.type !== 'message') return null
 
-    // AUDIT-21: validar channel antes de construir IncomingMessage
     if (!event.channel) {
       console.warn('[slack] event without channel — dropped', { event })
       return null
     }
 
-    // Ignorar mensajes del propio bot (sin user = bot/system message)
     if (!event.user) {
       console.warn('[slack] event without user (posible bot message) — dropped', { event })
       return null
     }
 
-    // Ignorar subtypes (message_changed, message_deleted, bot_message, etc.)
     if (event.subtype) {
       console.debug('[slack] event with subtype ignored', { subtype: event.subtype })
       return null
@@ -290,8 +289,6 @@ export class SlackAdapter extends BaseChannelAdapter {
    */
   private decryptSecrets(enc: string): string {
     // TODO F3b-05: this.cryptoService.decrypt(enc)
-    // Mientras F3b-05 no esté implementado, se asume plaintext JSON.
-    // NO devolver '{}' — eso rompe silenciosamente toda la autenticación.
     return enc
   }
 

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -89,6 +89,18 @@ export class SlackAdapter extends BaseChannelAdapter {
 
     this.botToken     = (secrets['botToken']     as string) ?? ''
     this.signingSecret = (secrets['signingSecret'] as string) ?? ''
+
+    // Validate that both secrets are non-empty (fail closed)
+    if (!this.botToken) {
+      throw new Error(
+        `[slack:${channelConfigId}] Missing required secret 'botToken' — adapter cannot start without valid credentials`,
+      )
+    }
+    if (!this.signingSecret) {
+      throw new Error(
+        `[slack:${channelConfigId}] Missing required secret 'signingSecret' — adapter cannot start without valid credentials`,
+      )
+    }
   }
 
   async dispose(): Promise<void> {
@@ -250,12 +262,22 @@ export class SlackAdapter extends BaseChannelAdapter {
     if (event.type !== 'message') return null
 
     if (!event.channel) {
-      console.warn('[slack] event without channel — dropped', { event })
+      console.warn('[slack] dropped event — missing channel', {
+        type: event.type,
+        channel: event.channel,
+        user: event.user,
+        ts: event.ts,
+      })
       return null
     }
 
     if (!event.user) {
-      console.warn('[slack] event without user (posible bot message) — dropped', { event })
+      console.warn('[slack] dropped event — missing user (possible bot message)', {
+        type: event.type,
+        channel: event.channel,
+        user: event.user,
+        ts: event.ts,
+      })
       return null
     }
 

--- a/apps/gateway/src/channels/slack.adapter.ts
+++ b/apps/gateway/src/channels/slack.adapter.ts
@@ -1,28 +1,52 @@
 /**
  * slack.adapter.ts — Slack Events API Adapter
+ * [F5-03]
  *
  * Nota Slack-específica (AUDIT-13):
  *   Slack SIEMPRE devuelve HTTP 200, incluso cuando falla.
  *   El error real viene en el body: { ok: false, error: 'channel_not_found' }
  *   Por eso se verifica TANTO res.ok (red) COMO data.ok (protocolo Slack).
+ *
+ * F5-03: Gaps corregidos
+ *   - receive(): url_verification challenge + verificación de firma HMAC
+ *   - verifySlackSignature(): HMAC-SHA256, timingSafeEqual, anti-replay 5 min
+ *   - loadConfig(): PrismaService por DI (no más new PrismaService())
+ *   - decryptSecrets(): TODO F3b-05 documentado, no más return '{}' silencioso
  */
 
+import { createHmac, timingSafeEqual } from 'node:crypto'
 import type { IncomingMessage, OutgoingMessage } from './channel-adapter.interface.js'
-import { BaseChannelAdapter } from './channel-adapter.interface.js'
+import { BaseChannelAdapter }                    from './channel-adapter.interface.js'
 
-// ── Tipos Slack ─────────────────────────────────────────────────────────
+// ── PrismaService type (importado como tipo para evitar import circular) ──
 
-interface SlackEvent {
+type PrismaServiceLike = {
+  channelConfig: {
+    findUnique: (args: { where: { id: string } }) => Promise<{
+      id: string
+      secretsEncrypted: string | null
+    } | null>
+  }
+}
+
+// ── Tipos Slack ─────────────────────────────────────────────────────────────────
+
+export interface SlackEvent {
   type:     string
   text?:    string
   user?:    string
   channel?: string
   ts?:      string
+  subtype?: string
 }
 
-interface SlackWebhookPayload {
-  type:  string
-  event: SlackEvent
+export interface SlackWebhookPayload {
+  type:      string
+  event?:    SlackEvent
+  challenge?: string
+  token?:    string
+  team_id?:  string
+  api_app_id?: string
 }
 
 interface SlackApiResponse {
@@ -31,13 +55,28 @@ interface SlackApiResponse {
   ts?:    string
 }
 
-// ── Adapter ─────────────────────────────────────────────────────────────
+export interface SlackVerifyOptions {
+  rawBody:   string   // body como string sin parsear
+  timestamp: string   // header X-Slack-Request-Timestamp
+  signature: string   // header X-Slack-Signature (v0=<hash>)
+}
+
+// ── Adapter ───────────────────────────────────────────────────────────────────
 
 export class SlackAdapter extends BaseChannelAdapter {
   readonly channel = 'slack'
 
-  private botToken  = ''
-  private replied   = false
+  private botToken:     string = ''
+  private signingSecret: string = ''
+  private replied:      boolean = false
+
+  /**
+   * PrismaService inyectado por constructor (DI).
+   * Reemplaza el anti-patrón new PrismaService() en loadConfig().
+   */
+  constructor(private readonly prisma: PrismaServiceLike) {
+    super()
+  }
 
   async initialize(channelConfigId: string): Promise<void> {
     this.channelConfigId = channelConfigId
@@ -45,50 +84,88 @@ export class SlackAdapter extends BaseChannelAdapter {
     // AUDIT-24: leer secretsEncrypted, NO credentials/tokenEnc
     const config = await this.loadConfig(channelConfigId)
     const secrets = config.secretsEncrypted
-      ? JSON.parse(this.decryptSecrets(config.secretsEncrypted))
+      ? JSON.parse(this.decryptSecrets(config.secretsEncrypted)) as Record<string, unknown>
       : {}
 
-    this.botToken = (secrets.botToken as string) ?? ''
+    this.botToken     = (secrets['botToken']     as string) ?? ''
+    this.signingSecret = (secrets['signingSecret'] as string) ?? ''
   }
 
   async dispose(): Promise<void> {
-    this.botToken = ''
-    this.replied  = false
+    this.botToken      = ''
+    this.signingSecret = ''
+    this.replied       = false
   }
+
+  // ── receive() — punto de entrada del webhook ──────────────────────────
+
+  /**
+   * Procesa el payload crudo de Slack Events API.
+   *
+   * secrets debe contener:
+   *   - rawBody:   string  (body antes de JSON.parse para verificar HMAC)
+   *   - timestamp: string  (header X-Slack-Request-Timestamp)
+   *   - signature: string  (header X-Slack-Signature)
+   *
+   * Retorna:
+   *   - { challenge: string }  para url_verification (el controller responde directo)
+   *   - IncomingMessage        para mensajes reales
+   *   - null                   para eventos ignorados
+   */
+  async receive(
+    rawPayload: Record<string, unknown>,
+    secrets: Record<string, unknown>,
+  ): Promise<IncomingMessage | { challenge: string } | null> {
+    // ── Verificar firma HMAC (F5-03 Gap B) ─────────────────────────────
+    const rawBody   = (secrets['rawBody']   as string | undefined) ?? ''
+    const timestamp = (secrets['timestamp'] as string | undefined) ?? ''
+    const signature = (secrets['signature'] as string | undefined) ?? ''
+
+    // Si hay signingSecret cargado, la verificación es obligatoria
+    if (this.signingSecret) {
+      const valid = this.verifySlackSignature(
+        this.signingSecret,
+        rawBody,
+        timestamp,
+        signature,
+      )
+      if (!valid) {
+        console.warn(
+          `[slack:${this.channelConfigId}] Invalid HMAC signature — request dropped`,
+        )
+        return null
+      }
+    }
+
+    const payload = rawPayload as SlackWebhookPayload
+
+    // ── url_verification challenge (F5-03 Gap A) ────────────────────────
+    // Slack envía este handshake al configurar el webhook.
+    // El controller debe detectar { challenge } y responder res.json({ challenge }).
+    if (payload.type === 'url_verification') {
+      return { challenge: payload.challenge ?? '' }
+    }
+
+    // ── Evento normal ──────────────────────────────────────────────────
+    if (payload.type !== 'event_callback' || !payload.event) return null
+
+    return this.parseEvent(payload.event)
+  }
+
+  // ── handleEvent() (compatibilidad con llamadas directas) ─────────────────
 
   /**
    * Procesa un evento de Slack (Events API).
    * Llamado desde slack.controller.ts tras verificar la firma HMAC.
+   * @deprecated Usar receive() en su lugar para el flujo completo.
    */
   async handleEvent(payload: SlackWebhookPayload): Promise<void> {
-    const event = payload.event
-    if (event.type !== 'message') return
-
-    // AUDIT-21: validar channel antes de construir IncomingMessage
-    const externalId = event.channel
-    if (!externalId) {
-      console.warn('[slack] event without channel — dropped', { event })
-      return
-    }
-
-    // Ignorar mensajes del propio bot
-    if (!event.user) {
-      console.warn('[slack] event without user (posible bot message) — dropped', { event })
-      return
-    }
-
-    const msg: IncomingMessage = {
-      channelConfigId: this.channelConfigId,
-      channelType:     'slack',
-      externalId,
-      senderId:        event.user,
-      text:            event.text ?? '',
-      type:            'text',
-      receivedAt:      this.makeTimestamp(),
-    }
-
-    await this.emit(msg)
+    if (!payload.event) return
+    const msg = this.parseEvent(payload.event)
+    if (msg) await this.emit(msg)
   }
+
+  // ── send() ───────────────────────────────────────────────────────────────────
 
   /**
    * AUDIT-13: replied=true SOLO después de verificar res.ok && data.ok.
@@ -122,20 +199,111 @@ export class SlackAdapter extends BaseChannelAdapter {
     }
 
     this.replied = true  // ← AUDIT-13: solo aquí, tras confirmar entrega exitosa
+    console.info(
+      `[slack:${this.channelConfigId}] Message sent to ${message.externalId} ts=${data.ts ?? 'unknown'}`,
+    )
   }
 
-  // ── Helpers ───────────────────────────────────────────────────────────
+  // ── verifySlackSignature (F5-03 Gap B) ───────────────────────────────
 
-  private decryptSecrets(_enc: string): string {
-    // F3b-05: decrypt AES-256-GCM — placeholder hasta implementación completa
-    return '{}'
+  /**
+   * Verifica la firma HMAC-SHA256 de Slack.
+   *
+   * @param signingSecret - Slack App Signing Secret
+   * @param rawBody       - body como string exacto (antes de JSON.parse)
+   * @param timestamp     - valor del header X-Slack-Request-Timestamp
+   * @param signature     - valor del header X-Slack-Signature (v0=<hex>)
+   *
+   * @see https://api.slack.com/authentication/verifying-requests-from-slack
+   */
+  verifySlackSignature(
+    signingSecret: string,
+    rawBody:       string,
+    timestamp:     string,
+    signature:     string,
+  ): boolean {
+    if (!signingSecret || !rawBody || !timestamp || !signature) return false
+
+    // Anti-replay: rechazar timestamps de más de 5 minutos
+    const tsNum = parseInt(timestamp, 10)
+    if (isNaN(tsNum)) return false
+    if (Math.abs(Date.now() / 1000 - tsNum) > 300) return false
+
+    // HMAC-SHA256 sobre 'v0:{timestamp}:{rawBody}'
+    const baseString = `v0:${timestamp}:${rawBody}`
+    const hmac = createHmac('sha256', signingSecret)
+      .update(baseString)
+      .digest('hex')
+    const expected = Buffer.from(`v0=${hmac}`)
+    const received = Buffer.from(signature)
+
+    // timingSafeEqual previene timing attacks
+    if (expected.length !== received.length) return false
+    return timingSafeEqual(expected, received)
   }
 
+  // ── parseEvent (helper privado) ──────────────────────────────────────
+
+  private parseEvent(event: SlackEvent): IncomingMessage | null {
+    if (event.type !== 'message') return null
+
+    // AUDIT-21: validar channel antes de construir IncomingMessage
+    if (!event.channel) {
+      console.warn('[slack] event without channel — dropped', { event })
+      return null
+    }
+
+    // Ignorar mensajes del propio bot (sin user = bot/system message)
+    if (!event.user) {
+      console.warn('[slack] event without user (posible bot message) — dropped', { event })
+      return null
+    }
+
+    // Ignorar subtypes (message_changed, message_deleted, bot_message, etc.)
+    if (event.subtype) {
+      console.debug('[slack] event with subtype ignored', { subtype: event.subtype })
+      return null
+    }
+
+    return {
+      channelConfigId: this.channelConfigId,
+      channelType:     'slack',
+      externalId:      event.channel,
+      senderId:        event.user,
+      text:            event.text ?? '',
+      type:            'text',
+      receivedAt:      this.makeTimestamp(),
+    }
+  }
+
+  // ── Helpers privados ────────────────────────────────────────────────────────
+
+  /**
+   * Desencripta los secrets del ChannelConfig.
+   *
+   * TODO F3b-05: Reemplazar esta implementación con CryptoService.decrypt()
+   * cuando el servicio AES-256-GCM esté disponible en el contenedor DI.
+   * Ver: apps/api/src/modules/secrets/ (fase F3b)
+   *
+   * Por ahora los secrets se leen como JSON plaintext (desarrollo local).
+   * En producción DEBEN estar cifrados con AES-256-GCM antes de guardarse.
+   */
+  private decryptSecrets(enc: string): string {
+    // TODO F3b-05: this.cryptoService.decrypt(enc)
+    // Mientras F3b-05 no esté implementado, se asume plaintext JSON.
+    // NO devolver '{}' — eso rompe silenciosamente toda la autenticación.
+    return enc
+  }
+
+  /**
+   * Carga la configuración del canal desde Prisma.
+   * F5-03: usa PrismaService por DI (no más new PrismaService()).
+   */
   private async loadConfig(channelConfigId: string) {
-    const { PrismaService } = await import('../prisma/prisma.service.js')
-    const db = new PrismaService()
-    const config = await db.channelConfig.findUnique({ where: { id: channelConfigId } })
-    if (!config) throw new Error(`ChannelConfig not found: ${channelConfigId}`)
+    const config = await this.prisma.channelConfig.findUnique({
+      where: { id: channelConfigId },
+    })
+    if (!config) throw new Error(`[slack] ChannelConfig not found: ${channelConfigId}`)
     return config
   }
 }

--- a/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
+++ b/apps/gateway/src/channels/whatsapp-baileys.adapter.ts
@@ -1,6 +1,6 @@
 /**
  * whatsapp-baileys.adapter.ts — WhatsApp via Baileys (WA Web protocol)
- * [F3a-21 / F3a-23 / F3a-24]
+ * [F3a-21 / F3a-23 / F3a-24 / F5-02]
  *
  * A diferencia de WhatsAppAdapter (Cloud API), este adapter usa el
  * protocolo WhatsApp Web via Baileys. No requiere cuenta Business ni
@@ -13,18 +13,25 @@
  * normalizeMessage(), extractText(), extractType(), extractAttachment().
  *
  * F3a-23: ExponentialBackoff integrado para reconexiones.
+ *
+ * F5-02: Session persistence en Prisma (D-22b).
+ *   - useMultiFileAuthState (filesystem) → usePrismaAuthState (Prisma)
+ *   - clearSessionFiles() → clearSessionInDb()
+ *   - Eliminados imports node:path y node:fs
+ *   - setup() ya no llama fs.mkdirSync()
+ *   - PrismaClient inyectado via constructor
  */
 
-import path         from 'node:path'
-import fs           from 'node:fs'
 import EventEmitter from 'node:events'
 import {
   BaseChannelAdapter,
   type OutgoingMessage,
 } from './channel-adapter.interface.js'
-import { baileysToIncoming }  from './whatsapp-message.mapper.js'
-import { outgoingToBaileys }  from './whatsapp-send.mapper.js'
-import { ExponentialBackoff } from './whatsapp-backoff.js'
+import { baileysToIncoming }              from './whatsapp-message.mapper.js'
+import { outgoingToBaileys }              from './whatsapp-send.mapper.js'
+import { ExponentialBackoff }             from './whatsapp-backoff.js'
+import { usePrismaAuthState, clearSessionInDb } from './whatsapp-prisma-auth.js'
+import type { PrismaClient }              from '@prisma/client'
 
 // ── Tipos de Baileys (importados dinámicamente) ─────────────────────────
 
@@ -66,7 +73,6 @@ export type WhatsAppAdapterState =
 // ── Config ─────────────────────────────────────────────────────────────────
 
 interface WhatsAppBaileysConfig {
-  sessionsDir?:          string
   maxReconnectAttempts?: number
   qrTimeoutMs?:         number
   printQrInTerminal?:   boolean
@@ -77,6 +83,9 @@ interface WhatsAppBaileysConfig {
 
 export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
   readonly channel = 'whatsapp-baileys'
+
+  // Prisma (F5-02): inyectado en el constructor para persistir credenciales
+  private readonly prisma: PrismaClient
 
   // Estado interno
   private _state:           WhatsAppAdapterState = 'idle'
@@ -93,13 +102,22 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
   })
 
   // Config
-  private sessionsDir          = process.env['WA_SESSIONS_DIR'] ?? './data/wa-sessions'
   private maxReconnectAttempts = parseInt(process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? '8')
   private qrTimeoutMs          = 120_000
   private printQrInTerminal    = false
   private browser: [string, string, string] = ['AgentVS Gateway', 'Chrome', '120.0']
 
   private readonly emitter = new EventEmitter()
+
+  /**
+   * @param prisma - PrismaClient para persistir credenciales Baileys (F5-02).
+   *   Si el gateway usa NestJS DI, pasar PrismaService (extiende PrismaClient).
+   *   Si se instancia manualmente: new WhatsAppBaileysAdapter(prismaClient)
+   */
+  constructor(prisma: PrismaClient) {
+    super()
+    this.prisma = prisma
+  }
 
   // ── Estado público ───────────────────────────────────────────────────────────
 
@@ -117,9 +135,6 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
     _secrets: Record<string, unknown>,
   ): Promise<void> {
     const cfg = config as WhatsAppBaileysConfig
-    this.sessionsDir = String(
-      process.env['WA_SESSIONS_DIR'] ?? cfg.sessionsDir ?? './data/wa-sessions',
-    )
     this.maxReconnectAttempts = Number(
       process.env['WA_MAX_RECONNECT_ATTEMPTS'] ?? cfg.maxReconnectAttempts ?? 8,
     )
@@ -127,7 +142,9 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
     this.printQrInTerminal = Boolean(cfg.printQrInTerminal ?? false)
     if (cfg.browser) this.browser = cfg.browser
 
-    fs.mkdirSync(this.getSessionPath(), { recursive: true })
+    // F5-02: No se crea ningún directorio en disco.
+    // Las credenciales se leen/escriben en Prisma vía usePrismaAuthState().
+
     console.info(
       `[whatsapp-baileys] Adapter configured (lazy) — channelId=${this.channelConfigId}`,
     )
@@ -154,17 +171,20 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
       )
     })
 
-    const { makeWASocket, useMultiFileAuthState, DisconnectReason: DR, fetchLatestBaileysVersion } =
+    const { makeWASocket, DisconnectReason: DR, fetchLatestBaileysVersion } =
       baileys as unknown as {
-        makeWASocket:          (opts: Record<string, unknown>) => BaileysSocket
-        useMultiFileAuthState: (dir: string) => Promise<{ state: unknown; saveCreds: () => Promise<void> }>
-        DisconnectReason:      DisconnectReason
+        makeWASocket:              (opts: Record<string, unknown>) => BaileysSocket
+        DisconnectReason:          DisconnectReason
         fetchLatestBaileysVersion: () => Promise<{ version: [number, number, number] }>
       }
 
-    const sessionPath       = this.getSessionPath()
-    const { state, saveCreds } = await useMultiFileAuthState(sessionPath)
-    const { version }        = await fetchLatestBaileysVersion()
+    // F5-02: Usar Prisma en lugar de filesystem para las credenciales
+    const { state, saveCreds } = await usePrismaAuthState(
+      this.prisma,
+      this.channelConfigId,
+    )
+
+    const { version } = await fetchLatestBaileysVersion()
 
     const sock = makeWASocket({
       version,
@@ -195,8 +215,9 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
           statusCode === (DR as unknown as DisconnectReason).connectionReplaced
 
         if (isPermanentClose) {
-          console.warn(`[whatsapp-baileys:${this.channelConfigId}] Permanent close (${statusCode}) — clearing session`)
-          this.clearSessionFiles()
+          console.warn(`[whatsapp-baileys:${this.channelConfigId}] Permanent close (${statusCode}) — clearing session in DB`)
+          // F5-02: clearSessionInDb() en lugar de clearSessionFiles()
+          void clearSessionInDb(this.prisma, this.channelConfigId)
           this.setState('closed')
           this.emitter.emit('closed', this.channelConfigId, 'permanent_close')
           return
@@ -258,7 +279,7 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
 
         this.emit(normalized).catch((err: unknown) =>
           console.error(
-            `[whatsapp-baileys:${this.channelConfigId}] emit error (${(waMsg as any).key?.id}):`,
+            `[whatsapp-baileys:${this.channelConfigId}] emit error (${(waMsg as Record<string, unknown> & { key?: { id?: string } })?.key?.id}):`,
             err,
           ),
         )
@@ -307,6 +328,9 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
         this.sock = null
       }
     }
+
+    // F5-02: limpiar sesión en BD en lugar de filesystem
+    await clearSessionInDb(this.prisma, this.channelConfigId)
 
     this.connectPromise = null
     this.setState('closed')
@@ -397,20 +421,6 @@ export class WhatsAppBaileysAdapter extends BaseChannelAdapter {
       this.sock?.end(new Error('QR timeout'))
       this.sock = null
     }, this.qrTimeoutMs)
-  }
-
-  private getSessionPath(): string {
-    return path.join(this.sessionsDir, this.channelConfigId || 'default')
-  }
-
-  private clearSessionFiles(): void {
-    const sessionPath = this.getSessionPath()
-    try {
-      fs.rmSync(sessionPath, { recursive: true, force: true })
-      console.info(`[whatsapp-baileys:${this.channelConfigId}] Auth state deleted: ${sessionPath}`)
-    } catch (err) {
-      console.error(`[whatsapp-baileys:${this.channelConfigId}] Error deleting auth state:`, err)
-    }
   }
 
   /**

--- a/apps/gateway/src/channels/whatsapp-prisma-auth.ts
+++ b/apps/gateway/src/channels/whatsapp-prisma-auth.ts
@@ -1,0 +1,200 @@
+/**
+ * whatsapp-prisma-auth.ts — Baileys auth state persisted in Prisma (D-22b)
+ * [F5-02]
+ *
+ * Reemplaza useMultiFileAuthState() de @whiskeysockets/baileys con una
+ * implementación que lee/escribe las credenciales Baileys en la tabla
+ * GatewaySession de Prisma, cumpliendo D-22b (nada al filesystem).
+ *
+ * Estrategia de clave:
+ *   GatewaySession es unique en (channelConfigId, externalUserId).
+ *   Para el registro de credenciales Baileys usamos:
+ *     externalUserId = '__baileys_creds__'
+ *     agentId        = 'system'
+ *   Esto permite upsert sin migración adicional al schema.
+ *
+ * Keys (Signal Protocol):
+ *   Las keys de Signal se mantienen en memoria — se regeneran automáticamente
+ *   en cada sesión sin pérdida funcional. Solo las creds determinan si se
+ *   necesita un nuevo QR. Esta es la estrategia correcta para F5-02.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+
+// ── Tipos de Baileys (compatibles — no requieren instalación del paquete
+//    para compilar este módulo; se usan en tiempo de ejecución vía dynamic import)
+
+export interface AuthenticationCreds {
+  noiseKey:            unknown
+  pairingEphemeralKeyPair: unknown
+  signedIdentityKey:   unknown
+  signedPreKey:        unknown
+  registrationId:      number
+  advSecretKey:        string
+  nextPreKeyId:        number
+  firstUnappendedPreKeyId: number
+  serverHasPreKeys:    boolean
+  account:             unknown
+  me?:                 { id: string; name?: string }
+  signalIdentities?:   unknown[]
+  myAppStateKeyId?:    string
+  firstAppStateSyncKeyId?: string
+  appStateSyncKeyId?:  string
+  accountSettings?:    unknown
+  deviceId?:           string
+  phoneId?:            string
+  identityId?:         Buffer
+  registered?:         boolean
+  backupToken?:        Buffer
+  registration?:       unknown
+  pairingCode?:        string
+  lastPropHash?:       string
+  routingInfo?:        Buffer
+}
+
+export interface AuthState {
+  creds: AuthenticationCreds
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  keys:  any
+}
+
+export interface BaileysAuthStateResult {
+  state:     AuthState
+  saveCreds: () => Promise<void>
+}
+
+// ── Constantes de clave canónica ────────────────────────────────────────────
+
+const BAILEYS_CREDS_USER_ID = '__baileys_creds__'
+const BAILEYS_SYSTEM_AGENT  = 'system'
+
+// ── usePrismaAuthState ─────────────────────────────────────────────────────
+
+/**
+ * Construye el auth state de Baileys leyendo/escribiendo en Prisma.
+ *
+ * @param prisma          - PrismaClient (o PrismaService de NestJS)
+ * @param channelConfigId - ID del ChannelConfig asociado al adapter
+ */
+export async function usePrismaAuthState(
+  prisma:          PrismaClient,
+  channelConfigId: string,
+): Promise<BaileysAuthStateResult> {
+  // ── Importar Baileys en tiempo de ejecución ─────────────────────────
+  const baileys = await import('@whiskeysockets/baileys').catch((err: unknown) => {
+    throw new Error(
+      `[usePrismaAuthState] No se pudo cargar @whiskeysockets/baileys: ${String(err)}`,
+    )
+  })
+
+  const { initAuthCreds, BufferJSON } = baileys as unknown as {
+    initAuthCreds: () => AuthenticationCreds
+    BufferJSON:    { replacer: (key: string, value: unknown) => unknown; reviver: (key: string, value: unknown) => unknown }
+  }
+
+  // ── Cargar credenciales desde BD ────────────────────────────────────
+  const record = await (prisma as unknown as {
+    gatewaySession: {
+      findFirst: (args: unknown) => Promise<{ metadata: unknown } | null>
+    }
+  }).gatewaySession.findFirst({
+    where: {
+      channelConfigId,
+      externalUserId: BAILEYS_CREDS_USER_ID,
+    },
+    select: { metadata: true },
+  })
+
+  let creds: AuthenticationCreds
+
+  if (record?.metadata) {
+    try {
+      // Deserializar con BufferJSON.reviver para restaurar los Buffer de Baileys
+      creds = JSON.parse(
+        JSON.stringify(record.metadata),
+        BufferJSON.reviver as (key: string, value: unknown) => unknown,
+      ) as AuthenticationCreds
+    } catch (err) {
+      console.warn(
+        `[usePrismaAuthState:${channelConfigId}] Creds corruptos en BD — generando nuevas:`,
+        err,
+      )
+      creds = initAuthCreds()
+    }
+  } else {
+    // Primera vez: iniciar con credenciales vacías → generará QR
+    creds = initAuthCreds()
+  }
+
+  // Keys en memoria (Signal Protocol — se regeneran automáticamente)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const keys: any = {}
+
+  // ── saveCreds ───────────────────────────────────────────────────────
+  const saveCreds = async (): Promise<void> => {
+    const serialized = JSON.parse(JSON.stringify(creds, BufferJSON.replacer as (key: string, value: unknown) => unknown))
+
+    await (prisma as unknown as {
+      gatewaySession: {
+        upsert: (args: unknown) => Promise<unknown>
+      }
+    }).gatewaySession.upsert({
+      where: {
+        channelConfigId_externalUserId: {
+          channelConfigId,
+          externalUserId: BAILEYS_CREDS_USER_ID,
+        },
+      },
+      create: {
+        channelConfigId,
+        externalUserId: BAILEYS_CREDS_USER_ID,
+        agentId:        BAILEYS_SYSTEM_AGENT,
+        metadata:       serialized,
+        status:         'connected',
+      },
+      update: {
+        metadata:  serialized,
+        status:    'connected',
+        updatedAt: new Date(),
+      },
+    })
+  }
+
+  return {
+    state: { creds, keys },
+    saveCreds,
+  }
+}
+
+// ── clearSessionInDb ────────────────────────────────────────────────────────
+
+/**
+ * Marca la sesión Baileys como logged_out en BD y elimina las credenciales.
+ * La próxima connect() generará un nuevo QR.
+ *
+ * @param prisma          - PrismaClient
+ * @param channelConfigId - ID del ChannelConfig
+ */
+export async function clearSessionInDb(
+  prisma:          PrismaClient,
+  channelConfigId: string,
+): Promise<void> {
+  await (prisma as unknown as {
+    gatewaySession: {
+      updateMany: (args: unknown) => Promise<unknown>
+    }
+  }).gatewaySession.updateMany({
+    where: {
+      channelConfigId,
+      externalUserId: BAILEYS_CREDS_USER_ID,
+    },
+    data: {
+      status:   'logged_out',
+      metadata: null,
+    },
+  })
+
+  console.info(
+    `[usePrismaAuthState:${channelConfigId}] Session cleared in DB (logged_out)`,
+  )
+}

--- a/apps/gateway/src/gateway.module.ts
+++ b/apps/gateway/src/gateway.module.ts
@@ -32,8 +32,16 @@ import { setGlobalWhatsAppSessionStorePrisma } from './whatsapp-session.store.js
   providers:   [
     GatewayService,
     AgentResolverService,
-    WhatsAppBaileysAdapter,
-    SlackAdapter,
+    {
+      provide:    WhatsAppBaileysAdapter,
+      useFactory: (prisma: PrismaService) => new WhatsAppBaileysAdapter(prisma),
+      inject:     [PrismaService],
+    },
+    {
+      provide:    SlackAdapter,
+      useFactory: (prisma: PrismaService) => new SlackAdapter(prisma),
+      inject:     [PrismaService],
+    },
   ],
   controllers: [HealthController],
   exports:     [

--- a/apps/gateway/src/gateway.module.ts
+++ b/apps/gateway/src/gateway.module.ts
@@ -1,17 +1,20 @@
 /**
- * gateway.module.ts — [F3a-01 / F5-01]
+ * gateway.module.ts — [F3a-01 / F5-01 / F5-03]
  *
  * Módulo NestJS que agrupa los servicios centrales del Gateway:
  *
  *   - GatewayService            → dispatch, session, encryption, adapter lifecycle
  *   - AgentResolverService      → resolución de agente por ChannelBinding + scope priority
  *   - WhatsAppBaileysAdapter    → adapter WhatsApp via Baileys (F5-01)
+ *   - SlackAdapter              → adapter Slack Events API con HMAC (F5-03)
  *   - HealthController          → GET /health (liveness probe)
  *   - PrismaModule              → re-exportado para que AppModule no duplique el import
  *
  * F5-01: WhatsAppBaileysAdapter registrado como provider y exportado.
  *        GatewayModule.onModuleInit() inyecta PrismaService en el singleton
  *        whatsappSessionStore para persistir credenciales en BD (D-22b).
+ * F5-03: SlackAdapter registrado como provider y exportado.
+ *        Inyecta PrismaService via DI (no más new PrismaService() directo).
  */
 
 import { Module, OnModuleInit }      from '@nestjs/common';
@@ -21,6 +24,7 @@ import { HealthController }          from './health/health.controller.js';
 import { PrismaModule }              from './prisma/prisma.module.js';
 import { PrismaService }             from './prisma/prisma.service.js';
 import { WhatsAppBaileysAdapter }    from './channels/whatsapp-baileys.adapter.js';
+import { SlackAdapter }              from './channels/slack.adapter.js';
 import { setGlobalWhatsAppSessionStorePrisma } from './whatsapp-session.store.js';
 
 @Module({
@@ -29,12 +33,14 @@ import { setGlobalWhatsAppSessionStorePrisma } from './whatsapp-session.store.js
     GatewayService,
     AgentResolverService,
     WhatsAppBaileysAdapter,
+    SlackAdapter,
   ],
   controllers: [HealthController],
   exports:     [
     GatewayService,
     AgentResolverService,
     WhatsAppBaileysAdapter,
+    SlackAdapter,
     PrismaModule,
   ],
 })

--- a/apps/gateway/src/gateway.module.ts
+++ b/apps/gateway/src/gateway.module.ts
@@ -1,52 +1,51 @@
 /**
- * gateway.module.ts — [F3a-01]
+ * gateway.module.ts — [F3a-01 / F5-01]
  *
  * Módulo NestJS que agrupa los servicios centrales del Gateway:
  *
- *   - GatewayService        → dispatch, session, encryption, adapter lifecycle
- *   - AgentResolverService  → resolución de agente por ChannelBinding + scope priority
- *   - HealthController      → GET /health (liveness probe — no inyecta GatewayService)
- *   - PrismaModule          → re-exportado para que AppModule no duplique el import
+ *   - GatewayService            → dispatch, session, encryption, adapter lifecycle
+ *   - AgentResolverService      → resolución de agente por ChannelBinding + scope priority
+ *   - WhatsAppBaileysAdapter    → adapter WhatsApp via Baileys (F5-01)
+ *   - HealthController          → GET /health (liveness probe)
+ *   - PrismaModule              → re-exportado para que AppModule no duplique el import
  *
- * ── Qué NO va aquí ──────────────────────────────────────────────────────────
- *
- *   MessageDispatcher  → clase pura (extends EventEmitter), NO @Injectable().
- *                        GatewayService la instancia internamente si la necesita.
- *
- *   loadCredentials /
- *   invalidateCredentialsCache → funciones sueltas en channel-credentials.loader.ts,
- *                                no son clases; los adapters las llaman directamente.
- *
- * ── Dependencias del grafo DI ───────────────────────────────────────────────
- *
- *   GatewayService       ← PrismaService (via PrismaModule) + AgentResolverService
- *   AgentResolverService ← PrismaService (via PrismaModule)
- *   HealthController     ← (ninguna inyección — responde ok estático)
- *
- * ── Re-export de PrismaModule ────────────────────────────────────────────────
- *
- *   AppModule importa GatewayModule. Al re-exportar PrismaModule desde aquí,
- *   AppModule obtiene PrismaService transitivamente sin necesidad de importar
- *   PrismaModule por separado, evitando la duplicación de instancias y la
- *   dependencia circular latente que aparecería en F3a-02/F3a-03.
- *
- * ── forwardRef ───────────────────────────────────────────────────────────────
- *
- *   NO se usa forwardRef. AppModule importa GatewayModule (unidireccional).
- *   Si en fases futuras aparece una dependencia circular real, añadir forwardRef
- *   solo en ese momento y documentar el motivo.
+ * F5-01: WhatsAppBaileysAdapter registrado como provider y exportado.
+ *        GatewayModule.onModuleInit() inyecta PrismaService en el singleton
+ *        whatsappSessionStore para persistir credenciales en BD (D-22b).
  */
 
-import { Module }               from '@nestjs/common';
-import { GatewayService }       from './gateway.service';
-import { AgentResolverService } from './agent-resolver.service';
-import { HealthController }     from './health/health.controller';
-import { PrismaModule }         from './prisma/prisma.module';
+import { Module, OnModuleInit }      from '@nestjs/common';
+import { GatewayService }            from './gateway.service.js';
+import { AgentResolverService }      from './agent-resolver.service.js';
+import { HealthController }          from './health/health.controller.js';
+import { PrismaModule }              from './prisma/prisma.module.js';
+import { PrismaService }             from './prisma/prisma.service.js';
+import { WhatsAppBaileysAdapter }    from './channels/whatsapp-baileys.adapter.js';
+import { setGlobalWhatsAppSessionStorePrisma } from './whatsapp-session.store.js';
 
 @Module({
   imports:     [PrismaModule],
-  providers:   [GatewayService, AgentResolverService],
+  providers:   [
+    GatewayService,
+    AgentResolverService,
+    WhatsAppBaileysAdapter,
+  ],
   controllers: [HealthController],
-  exports:     [GatewayService, AgentResolverService, PrismaModule],
+  exports:     [
+    GatewayService,
+    AgentResolverService,
+    WhatsAppBaileysAdapter,
+    PrismaModule,
+  ],
 })
-export class GatewayModule {}
+export class GatewayModule implements OnModuleInit {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Inyecta PrismaService en el singleton global de WhatsAppSessionStore
+   * para que la persistencia de credenciales Baileys use BD (D-22b).
+   */
+  onModuleInit(): void {
+    setGlobalWhatsAppSessionStorePrisma(this.prisma);
+  }
+}

--- a/apps/gateway/src/whatsapp-session.store.ts
+++ b/apps/gateway/src/whatsapp-session.store.ts
@@ -1,20 +1,17 @@
 /**
- * whatsapp-session.store.ts — F3a-30 (actualizado con JSDoc completo)
+ * whatsapp-session.store.ts — F3a-30 (F5-01: migrado a PrismaService)
  *
- * Store en memoria para sesiones WhatsApp Baileys.
- * Exporta la clase (para typing en DI) y el singleton whatsappSessionStore.
+ * Store de sesiones WhatsApp Baileys con persistencia en Prisma.
+ * Las credenciales Baileys se guardan en GatewaySession.metadata (JSON)
+ * en lugar de makeInMemoryStore o archivos en disco (regla D-22b).
  *
  * FIX #177: getOrCreate() usa Map<string, Promise<SessionEntry>> como lock
  * para prevenir la race condition TOCTOU donde dos requests simultáneos para
  * el mismo configId crean entradas duplicadas o inicializan el adapter dos veces.
- *
- * @example
- * // En WhatsAppBaileysAdapter:
- * const entry = await whatsappSessionStore.getOrCreate(channelConfigId);
- * entry.adapter = baileysAdapter;
  */
 
-import type { Response } from 'express';
+import type { Response }  from 'express';
+import type { PrismaService } from './prisma/prisma.service.js';
 
 export type WhatsAppSessionStatus =
   | 'connecting'
@@ -25,12 +22,12 @@ export type WhatsAppSessionStatus =
 
 export interface IWhatsAppAdapter {
   readonly channel: string;
-  state?:         string;
-  onQr?:          (handler: (qr: string) => void) => void;
-  onConnected?:   (handler: () => void) => void;
-  onDisconnected?:(handler: () => void) => void;
-  logout?:        () => Promise<void>;
-  dispose():      Promise<void>;
+  state?:          string;
+  onQr?:           (handler: (qr: string) => void) => void;
+  onConnected?:    (handler: () => void) => void;
+  onDisconnected?: (handler: () => void) => void;
+  logout?:         () => Promise<void>;
+  dispose():       Promise<void>;
 }
 
 export interface SessionEntry {
@@ -41,42 +38,85 @@ export interface SessionEntry {
 }
 
 /**
- * Store en memoria para sesiones WhatsApp Baileys.
- * Thread-safe para creaciones concurrentes vía Map de Promises (_creationLocks).
+ * Store de sesiones WhatsApp Baileys con persistencia en GatewaySession (Prisma).
  *
- * Ciclo de vida de una sesión:
- *   1. getOrCreate()     → crea entrada con status 'disconnected'
- *   2. setAdapter()      → asigna el adapter Baileys
- *   3. setStatus()       → transición: 'connecting' → 'qr_ready' → 'connected'
- *   4. destroy()/remove()→ limpieza y cierre de SSE clients
+ * Las credenciales Baileys se serializan como JSON y se guardan en
+ * GatewaySession.metadata para sobrevivir reinicios del proceso (D-22b).
+ *
+ * El estado en memoria (qrBuffer, sseClients) sigue siendo efímero por diseño —
+ * el QR se regenera en cada reconexión.
  */
 export class WhatsAppSessionStore {
   private readonly sessions       = new Map<string, SessionEntry>();
-  /** FIX #177: lock de creaciones en curso para prevenir race conditions */
   private readonly _creationLocks = new Map<string, Promise<SessionEntry>>();
 
+  constructor(private readonly prisma?: PrismaService) {}
+
+  // ── Persistencia Prisma (D-22b) ────────────────────────────────────────────
+
   /**
-   * Devuelve la sesión existente o crea una nueva de forma thread-safe.
-   *
-   * Si dos llamadas concurrentes llegan con el mismo configId mientras la
-   * entrada aún no existe, ambas reciben la misma Promise — la creación
-   * solo ocurre una vez (fix #177).
-   *
-   * @param configId  ID del ChannelConfig (clave de la sesión)
-   * @returns         La SessionEntry creada o existente
+   * Persiste las credenciales Baileys en GatewaySession.metadata.
+   * Llamado por saveCreds() de Baileys cada vez que las credenciales cambian.
    */
+  async saveCredentials(
+    channelConfigId: string,
+    creds: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.prisma) return;
+    await this.prisma.gatewaySession.upsert({
+      where:  { channelConfigId },
+      create: {
+        channelConfigId,
+        metadata: JSON.stringify(creds),
+        status:   'connecting',
+      },
+      update: {
+        metadata:  JSON.stringify(creds),
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  /**
+   * Carga las credenciales Baileys desde GatewaySession.metadata.
+   * Devuelve null si no existe sesión previa (primer login → generará QR).
+   */
+  async loadCredentials(
+    channelConfigId: string,
+  ): Promise<Record<string, unknown> | null> {
+    if (!this.prisma) return null;
+    const session = await this.prisma.gatewaySession.findUnique({
+      where: { channelConfigId },
+    });
+    if (!session?.metadata) return null;
+    try {
+      return JSON.parse(session.metadata as string) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Marca la sesión como closed en BD (disconnect limpio).
+   */
+  async markClosed(channelConfigId: string): Promise<void> {
+    if (!this.prisma) return;
+    await this.prisma.gatewaySession.update({
+      where:  { channelConfigId },
+      data:   { status: 'closed', updatedAt: new Date() },
+    }).catch(() => { /* no existe → ignorar */ });
+  }
+
+  // ── Store en memoria (estado efímero) ──────────────────────────────────────
+
   async getOrCreate(configId: string): Promise<SessionEntry> {
-    // Fast path: ya existe
     const existing = this.sessions.get(configId);
     if (existing) return existing;
 
-    // Lock path: si hay una creación en curso, devolver la misma Promise
     const inFlight = this._creationLocks.get(configId);
     if (inFlight) return inFlight;
 
-    // Crear la entrada y registrar el lock
     const creation = Promise.resolve().then(() => {
-      // Double-check tras await (otro contexto pudo haber completado)
       if (!this.sessions.has(configId)) {
         this.sessions.set(configId, {
           adapter:    null as unknown as IWhatsAppAdapter,
@@ -93,41 +133,19 @@ export class WhatsAppSessionStore {
     return creation;
   }
 
-  /**
-   * Devuelve la sesión si existe, sin crearla.
-   *
-   * @param configId  ID del ChannelConfig
-   */
   get(configId: string): SessionEntry | undefined {
     return this.sessions.get(configId);
   }
 
-  /**
-   * Devuelve true si la sesión existe en el store.
-   *
-   * @param configId  ID del ChannelConfig
-   */
   has(configId: string): boolean {
     return this.sessions.has(configId);
   }
 
-  /**
-   * Asigna el adapter Baileys a la sesión, creándola si no existe.
-   *
-   * @param configId  ID del ChannelConfig
-   * @param adapter   Instancia del adapter Baileys
-   */
   async setAdapter(configId: string, adapter: IWhatsAppAdapter): Promise<void> {
     const entry  = await this.getOrCreate(configId);
     entry.adapter = adapter;
   }
 
-  /**
-   * Actualiza el QR buffer y notifica a los clientes SSE.
-   *
-   * @param configId  ID del ChannelConfig
-   * @param qr        Código QR en formato base64 o string
-   */
   setQr(configId: string, qr: string): void {
     const entry = this.sessions.get(configId);
     if (!entry) return;
@@ -136,13 +154,6 @@ export class WhatsAppSessionStore {
     this.broadcastSse(entry, { event: 'qr', data: qr });
   }
 
-  /**
-   * Actualiza el status de la sesión y notifica a los clientes SSE.
-   * Si el status es 'connected', limpia el qrBuffer.
-   *
-   * @param configId  ID del ChannelConfig
-   * @param status    Nuevo estado de la sesión
-   */
   setStatus(configId: string, status: WhatsAppSessionStatus): void {
     const entry = this.sessions.get(configId);
     if (!entry) return;
@@ -151,11 +162,6 @@ export class WhatsAppSessionStore {
     this.broadcastSse(entry, { event: 'status', data: status });
   }
 
-  /**
-   * Elimina la sesión del store y cierra todos los clientes SSE.
-   *
-   * @param configId  ID del ChannelConfig
-   */
   remove(configId: string): void {
     const entry = this.sessions.get(configId);
     if (!entry) return;
@@ -167,24 +173,11 @@ export class WhatsAppSessionStore {
     this._creationLocks.delete(configId);
   }
 
-  /**
-   * Alias semántico de remove() para el flujo de deprovision.
-   * Emite un log explícito antes de eliminar.
-   *
-   * @param configId  ID del ChannelConfig
-   */
   destroy(configId: string): void {
     console.info(`[wa-session-store] Destroying session: ${configId}`);
     this.remove(configId);
   }
 
-  /**
-   * Registra un cliente SSE para recibir eventos de QR y status.
-   * Envía el estado actual inmediatamente al conectar.
-   *
-   * @param configId  ID del ChannelConfig
-   * @param res       Objeto Response de Express configurado para SSE
-   */
   async addSseClient(configId: string, res: Response): Promise<void> {
     const entry = await this.getOrCreate(configId);
     entry.sseClients.add(res);
@@ -195,23 +188,13 @@ export class WhatsAppSessionStore {
     res.on('close', () => { entry.sseClients.delete(res); });
   }
 
-  /**
-   * Devuelve los IDs de todas las sesiones activas en el store.
-   */
   activeSessions(): string[] {
     return [...this.sessions.keys()];
   }
 
-  /**
-   * Número de creaciones en curso (para diagnóstico y tests).
-   */
   get pendingCreations(): number {
     return this._creationLocks.size;
   }
-
-  // ---------------------------------------------------------------------------
-  // Privados
-  // ---------------------------------------------------------------------------
 
   private broadcastSse(
     entry:   SessionEntry,
@@ -232,8 +215,15 @@ export class WhatsAppSessionStore {
   }
 }
 
-/** Tipo exportado para inyección en WhatsAppDeprovisionService y tests */
 export type WhatsAppSessionStore_t = WhatsAppSessionStore;
 
-/** Singleton global del store de sesiones WhatsApp */
+/** Singleton global — prisma se inyecta en GatewayModule via setGlobalPrisma() */
 export const whatsappSessionStore = new WhatsAppSessionStore();
+
+/**
+ * Inyecta PrismaService en el singleton global.
+ * Llamado desde GatewayModule.onModuleInit().
+ */
+export function setGlobalWhatsAppSessionStorePrisma(prisma: PrismaService): void {
+  (whatsappSessionStore as unknown as { prisma: PrismaService }).prisma = prisma;
+}

--- a/apps/gateway/tsconfig.json
+++ b/apps/gateway/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "ignoreDeprecations":      "6.0",
     "experimentalDecorators":  true,
     "emitDecoratorMetadata":   true,
     "outDir":                  "dist",
@@ -12,5 +13,5 @@
     }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts", "**/__tests__/**"]
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,6 +30,7 @@ import SettingsPage from './features/settings/pages/SettingsPage';
 import { CommandsPage } from './features/commands/pages/CommandsPage';
 import OperationsPage from './features/operations/pages/OperationsPage';
 import { ChannelsPage } from './features/channels/ChannelsPage';
+import { ChannelDetail } from './features/channels/components/ChannelDetail';
 import { AlertTriangle } from 'lucide-react';
 
 export function App() {
@@ -173,31 +174,31 @@ export function App() {
 
             <Routes>
               <Route element={<MainLayout />}>
-                <Route path="/"                    element={<OverviewPage />} />
-                <Route path="/agency-builder"       element={<AgencyBuilderPage />} />
-                <Route path="/workspace-studio"     element={<WorkspaceStudioPage />} />
-                <Route path="/agency-topology"      element={<AgencyTopologyPage />} />
-                <Route path="/studio"               element={<Navigate to="/workspace-studio" replace />} />
-                <Route path="/observability"         element={<ObservabilityPage />} />
+                <Route path="/"            element={<OverviewPage />} />
+                <Route path="/agency-builder" element={<AgencyBuilderPage />} />
+                <Route path="/workspace-studio" element={<WorkspaceStudioPage />} />
+                <Route path="/agency-topology" element={<AgencyTopologyPage />} />
+                <Route path="/studio"      element={<Navigate to="/workspace-studio" replace />} />
+                <Route path="/observability" element={<ObservabilityPage />} />
                 <Route path="/observability/:runId" element={<ObservabilityRunPage />} />
-                <Route path="/workspaces"            element={<WorkspacesPage />} />
-                <Route path="/agents/new"            element={<AgentEditorPage />} />
-                <Route path="/agents/:id"            element={<AgentEditorPage />} />
-                <Route path="/agents"                element={<AgentListPage />} />
-                <Route path="/profiles"              element={<ProfilesPage />} />
-                <Route path="/diagnostics"           element={<DiagnosticsPage />} />
-                <Route path="/sessions"              element={<SessionsPage />} />
-                <Route path="/routing"               element={<RoutingPage />} />
-                <Route path="/runs"                  element={<RunsPage />} />
-                <Route path="/hooks"                 element={<HooksPage />} />
-                <Route path="/versions"              element={<VersionsPage />} />
-                <Route path="/settings"              element={<SettingsPage />} />
-                <Route path="/commands"              element={<CommandsPage />} />
-                <Route path="/operations"            element={<OperationsPage />} />
-                {/* F5-05 — Gestión de canales */}
-                <Route path="/channels"              element={<ChannelsPage />} />
-                <Route path="/channels/:id"          element={<ChannelsPage />} />
-                <Route path="*"                      element={<Navigate to="/" replace />} />
+                <Route path="/workspaces"  element={<WorkspacesPage />} />
+                <Route path="/agents/new"  element={<AgentEditorPage />} />
+                <Route path="/agents/:id" element={<AgentEditorPage />} />
+                <Route path="/agents"      element={<AgentListPage />} />
+                <Route path="/profiles"    element={<ProfilesPage />} />
+                <Route path="/diagnostics" element={<DiagnosticsPage />} />
+                <Route path="/sessions"    element={<SessionsPage />} />
+                <Route path="/routing"     element={<RoutingPage />} />
+                <Route path="/runs"        element={<RunsPage />} />
+                <Route path="/hooks"       element={<HooksPage />} />
+                <Route path="/versions"    element={<VersionsPage />} />
+                <Route path="/settings"    element={<SettingsPage />} />
+                <Route path="/commands"    element={<CommandsPage />} />
+                <Route path="/operations"  element={<OperationsPage />} />
+                {/* F5-05: Gestión de canales */}
+                <Route path="/channels"    element={<ChannelsPage />} />
+                <Route path="/channels/:id" element={<ChannelDetail />} />
+                <Route path="*"            element={<Navigate to="/" replace />} />
               </Route>
             </Routes>
           </BrowserRouter>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,7 @@ import VersionsPage from './features/versions/pages/VersionsPage';
 import SettingsPage from './features/settings/pages/SettingsPage';
 import { CommandsPage } from './features/commands/pages/CommandsPage';
 import OperationsPage from './features/operations/pages/OperationsPage';
+import { ChannelsPage } from './features/channels/ChannelsPage';
 import { AlertTriangle } from 'lucide-react';
 
 export function App() {
@@ -172,28 +173,31 @@ export function App() {
 
             <Routes>
               <Route element={<MainLayout />}>
-                <Route path="/"            element={<OverviewPage />} />
-                <Route path="/agency-builder" element={<AgencyBuilderPage />} />
-                <Route path="/workspace-studio" element={<WorkspaceStudioPage />} />
-                <Route path="/agency-topology" element={<AgencyTopologyPage />} />
-                <Route path="/studio"      element={<Navigate to="/workspace-studio" replace />} />
-                <Route path="/observability" element={<ObservabilityPage />} />
+                <Route path="/"                    element={<OverviewPage />} />
+                <Route path="/agency-builder"       element={<AgencyBuilderPage />} />
+                <Route path="/workspace-studio"     element={<WorkspaceStudioPage />} />
+                <Route path="/agency-topology"      element={<AgencyTopologyPage />} />
+                <Route path="/studio"               element={<Navigate to="/workspace-studio" replace />} />
+                <Route path="/observability"         element={<ObservabilityPage />} />
                 <Route path="/observability/:runId" element={<ObservabilityRunPage />} />
-                <Route path="/workspaces"  element={<WorkspacesPage />} />
-                <Route path="/agents/new"  element={<AgentEditorPage />} />
-                <Route path="/agents/:id" element={<AgentEditorPage />} />
-                <Route path="/agents"      element={<AgentListPage />} />
-                <Route path="/profiles"    element={<ProfilesPage />} />
-                <Route path="/diagnostics" element={<DiagnosticsPage />} />
-                <Route path="/sessions"    element={<SessionsPage />} />
-                <Route path="/routing"     element={<RoutingPage />} />
-                <Route path="/runs"        element={<RunsPage />} />
-                <Route path="/hooks"       element={<HooksPage />} />
-                <Route path="/versions"    element={<VersionsPage />} />
-                <Route path="/settings"    element={<SettingsPage />} />
-                <Route path="/commands"    element={<CommandsPage />} />
-                <Route path="/operations"  element={<OperationsPage />} />
-                <Route path="*"            element={<Navigate to="/" replace />} />
+                <Route path="/workspaces"            element={<WorkspacesPage />} />
+                <Route path="/agents/new"            element={<AgentEditorPage />} />
+                <Route path="/agents/:id"            element={<AgentEditorPage />} />
+                <Route path="/agents"                element={<AgentListPage />} />
+                <Route path="/profiles"              element={<ProfilesPage />} />
+                <Route path="/diagnostics"           element={<DiagnosticsPage />} />
+                <Route path="/sessions"              element={<SessionsPage />} />
+                <Route path="/routing"               element={<RoutingPage />} />
+                <Route path="/runs"                  element={<RunsPage />} />
+                <Route path="/hooks"                 element={<HooksPage />} />
+                <Route path="/versions"              element={<VersionsPage />} />
+                <Route path="/settings"              element={<SettingsPage />} />
+                <Route path="/commands"              element={<CommandsPage />} />
+                <Route path="/operations"            element={<OperationsPage />} />
+                {/* F5-05 — Gestión de canales */}
+                <Route path="/channels"              element={<ChannelsPage />} />
+                <Route path="/channels/:id"          element={<ChannelsPage />} />
+                <Route path="*"                      element={<Navigate to="/" replace />} />
               </Route>
             </Routes>
           </BrowserRouter>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,7 +30,6 @@ import SettingsPage from './features/settings/pages/SettingsPage';
 import { CommandsPage } from './features/commands/pages/CommandsPage';
 import OperationsPage from './features/operations/pages/OperationsPage';
 import { ChannelsPage } from './features/channels/ChannelsPage';
-import { ChannelDetail } from './features/channels/components/ChannelDetail';
 import { AlertTriangle } from 'lucide-react';
 
 export function App() {
@@ -197,7 +196,7 @@ export function App() {
                 <Route path="/operations"  element={<OperationsPage />} />
                 {/* F5-05: Gestión de canales */}
                 <Route path="/channels"    element={<ChannelsPage />} />
-                <Route path="/channels/:id" element={<ChannelDetail />} />
+                <Route path="/channels/:id" element={<ChannelsPage />} />
                 <Route path="*"            element={<Navigate to="/" replace />} />
               </Route>
             </Routes>

--- a/apps/web/src/features/channels/components/ChannelSettings.tsx
+++ b/apps/web/src/features/channels/components/ChannelSettings.tsx
@@ -2,9 +2,14 @@
  * ChannelSettings.tsx — [F5-05]
  *
  * Formulario de configuración de un canal existente.
- * Cubre: Telegram, WhatsApp (Meta Cloud API), WhatsApp (Baileys QR),
- *        Slack, Discord, Teams, Webchat, Webhook.
+ * Cubre: Telegram, WhatsApp (Meta), WhatsApp Baileys (QR), Slack, Discord, Teams, Webhook.
  * Montado dentro de ChannelDetail.tsx como pestaña "Configuración".
+ *
+ * Props:
+ *   channel    — ChannelConfig actual (read-only, viene del store)
+ *   onSave     — callback tras PATCH exitoso
+ *   onTest     — callback para lanzar test de conexión
+ *   gatewayUrl — URL base del gateway (para construir webhook URL)
  */
 
 import React, { useCallback, useId, useReducer, useState } from 'react';
@@ -44,11 +49,18 @@ interface FieldDef {
   key:         string;
   label:       string;
   placeholder: string;
-  type:        'text' | 'password' | 'select' | 'tags' | 'number' | 'boolean';
+  type:        'text' | 'password' | 'select' | 'tags';
   options?:    { value: string; label: string }[];
   hint?:       string;
   readOnly?:   boolean;
-  devOnly?:    boolean;
+}
+
+/**
+ * Detecta si el canal es WhatsApp Baileys (authMode='qr').
+ * Los canales de Meta tienen token API; los Baileys no tienen secrets.
+ */
+function isWhatsAppBaileys(channel: ChannelConfig): boolean {
+  return channel.type === 'whatsapp' && channel.config?.['authMode'] === 'qr';
 }
 
 const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
@@ -84,7 +96,7 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
     },
   ],
 
-  // WhatsApp Meta Cloud API
+  // WhatsApp Meta Business (token API)
   whatsapp: [
     {
       key:         'verifyToken',
@@ -116,47 +128,24 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
     },
   ],
 
-  // WhatsApp Baileys (QR pairing — sin token, sin secrets)
-  'whatsapp-baileys': [
-    {
-      key:         'maxReconnectAttempts',
-      label:       'Máximo de reconexiones',
-      placeholder: '8',
-      type:        'number',
-      hint:        'Número de veces que Baileys intenta reconectarse antes de considerar la sesión caída. Recomendado: 8.',
-    },
-    {
-      key:         'qrTimeoutMs',
-      label:       'Tiempo de espera del QR (ms)',
-      placeholder: '120000',
-      type:        'number',
-      hint:        'Tiempo en milisegundos antes de que el QR expire. Por defecto: 120000 (2 minutos).',
-    },
-    {
-      key:         'printQrInTerminal',
-      label:       'Imprimir QR en terminal',
-      placeholder: '',
-      type:        'boolean',
-      hint:        'Solo útil en entornos de desarrollo local. Deshabilitar en producción.',
-      devOnly:     true,
-    },
-  ],
+  // WhatsApp Baileys — campos de config (no secrets)
+  // Los campos de secrets no aplican (usa QR, sin token)
+  // Se detecta vía isWhatsAppBaileys() y se renderizan aparte
 
-  // Slack Bolt
   slack: [
     {
-      key:         'workspaceName',
-      label:       'Nombre del workspace (referencia)',
-      placeholder: 'Mi empresa',
+      key:         'botDisplayName',
+      label:       'Nombre del bot (display)',
+      placeholder: 'Mi Agente LSS',
       type:        'text',
-      hint:        'Texto libre para identificar el workspace de Slack. No se envía a la API.',
+      hint:        'Nombre visible en los mensajes enviados por el bot en Slack.',
     },
     {
-      key:         'botDisplayName',
-      label:       'Nombre del bot en Slack',
-      placeholder: 'Mi agente',
+      key:         'workspaceName',
+      label:       'Nombre del workspace',
+      placeholder: 'Contoso',
       type:        'text',
-      hint:        'Nombre visible del bot en los chats de Slack.',
+      hint:        'Solo informativo — facilita identificar la conexión cuando hay múltiples workspaces.',
     },
   ],
 
@@ -227,7 +216,25 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
   ],
 };
 
-const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType | 'whatsapp-baileys', FieldDef[]>> = {
+// Campos de config específicos de WhatsApp Baileys
+const WHATSAPP_BAILEYS_CONFIG_FIELDS: FieldDef[] = [
+  {
+    key:         'maxReconnectAttempts',
+    label:       'Intentos máx. de reconexión',
+    placeholder: '8',
+    type:        'text',
+    hint:        'Número de veces que el adaptador intentará reconectarse antes de marcar el canal como inactivo. Default: 8.',
+  },
+  {
+    key:         'qrTimeoutMs',
+    label:       'Timeout del QR (ms)',
+    placeholder: '120000',
+    type:        'text',
+    hint:        'Tiempo en milisegundos que el QR permanece válido antes de expirar. Default: 120000 (2 minutos).',
+  },
+];
+
+const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
   telegram: [
     {
       key:         'botToken',
@@ -237,6 +244,7 @@ const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType | 'whatsapp-baileys', Fie
       hint:        '@BotFather → /token. Rotarlo invalida el token anterior inmediatamente.',
     },
   ],
+  // WhatsApp Meta Business
   whatsapp: [
     {
       key:         'token',
@@ -246,45 +254,43 @@ const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType | 'whatsapp-baileys', Fie
       hint:        'Meta Business → System Users → Generate Token.',
     },
   ],
-  // whatsapp-baileys: no tiene secrets — usa QR
-  'whatsapp-baileys': [],
   slack: [
     {
       key:         'botToken',
       label:       'Bot Token',
       placeholder: 'Dejar vacío para no cambiar · xoxb-...',
       type:        'password',
-      hint:        'Slack API → OAuth & Permissions → Bot User OAuth Token. Empieza con xoxb-.',
+      hint:        'Slack App Dashboard → OAuth & Permissions → Bot User OAuth Token.',
     },
     {
       key:         'signingSecret',
       label:       'Signing Secret',
       placeholder: 'Dejar vacío para no cambiar',
       type:        'password',
-      hint:        'Slack API → Basic Information → App Credentials → Signing Secret.',
+      hint:        'Slack App Dashboard → Basic Information → App Credentials → Signing Secret.',
     },
     {
       key:         'appToken',
-      label:       'App-Level Token (Socket Mode, opcional)',
+      label:       'App-Level Token (opcional)',
       placeholder: 'Dejar vacío para no cambiar · xapp-...',
       type:        'password',
-      hint:        'Solo necesario si usas Socket Mode. Slack API → Basic Information → App-Level Tokens. Empieza con xapp-.',
+      hint:        'Necesario para Socket Mode. Slack App Dashboard → Basic Information → App-Level Tokens.',
     },
   ],
   discord: [
-    {
-      key:         'botToken',
-      label:       'Bot Token',
-      placeholder: 'Dejar vacío para no cambiar · MTk...',
-      type:        'password',
-      hint:        'Discord Developer Portal → Bot → Reset Token.',
-    },
     {
       key:         'publicKey',
       label:       'Public Key (verificación Ed25519)',
       placeholder: 'Dejar vacío para no cambiar · hex string',
       type:        'password',
-      hint:        'Discord Developer Portal → General Information → Public Key. Requerido para verificar interacciones entrantes.',
+      hint:        'Discord Developer Portal → General Information → Public Key. Requerido para verificar interacciones.',
+    },
+    {
+      key:         'botToken',
+      label:       'Bot Token',
+      placeholder: 'Dejar vacío para no cambiar · Bot ...',
+      type:        'password',
+      hint:        'Discord Developer Portal → Bot → Reset Token.',
     },
     {
       key:         'clientSecret',
@@ -297,7 +303,7 @@ const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType | 'whatsapp-baileys', Fie
   teams: [
     {
       key:         'clientSecret',
-      label:       'Client Secret (Azure)',
+      label:       'Client Secret',
       placeholder: 'Dejar vacío para no cambiar',
       type:        'password',
       hint:        'Azure Portal → App Registrations → Certificates & Secrets → New client secret.',
@@ -311,20 +317,6 @@ const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType | 'whatsapp-baileys', Fie
     },
   ],
 };
-
-// Determina si el tipo es whatsapp-baileys (authMode=qr en config)
-function isWhatsAppBaileys(channel: ChannelConfig): boolean {
-  return (
-    channel.type === 'whatsapp' &&
-    (channel.config?.['authMode'] === 'qr' || channel.config?.['provider'] === 'baileys')
-  );
-}
-
-// Resuelve la clave de campos según el subtipo
-function resolveFieldsKey(channel: ChannelConfig): ChannelType | 'whatsapp-baileys' {
-  if (isWhatsAppBaileys(channel)) return 'whatsapp-baileys';
-  return channel.type;
-}
 
 // ── Reducer ────────────────────────────────────────────────────────────────────
 
@@ -365,13 +357,16 @@ function initFormState(channel: ChannelConfig): FormState {
 
 function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): PatchChannelPayload {
   const payload: PatchChannelPayload = {};
-  const fieldsKey = resolveFieldsKey(originalChannel);
 
   if (state.name.trim() !== originalChannel.name) {
     payload.name = state.name.trim();
   }
 
-  const configFields = CONFIG_FIELDS[fieldsKey as ChannelType] ?? [];
+  const isBaileys = isWhatsAppBaileys(originalChannel);
+  const configFields = isBaileys
+    ? WHATSAPP_BAILEYS_CONFIG_FIELDS
+    : (CONFIG_FIELDS[originalChannel.type] ?? []);
+
   const newConfig: Record<string, unknown> = {};
   let configChanged = false;
   for (const field of configFields) {
@@ -381,14 +376,6 @@ function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): Pa
       newConfig[field.key] = arr;
       const orig = originalChannel.config[field.key];
       if (JSON.stringify(arr) !== JSON.stringify(orig)) configChanged = true;
-    } else if (field.type === 'number') {
-      const num = value === '' ? undefined : Number(value);
-      newConfig[field.key] = num;
-      if (num !== originalChannel.config[field.key]) configChanged = true;
-    } else if (field.type === 'boolean') {
-      const bool = value === 'true';
-      newConfig[field.key] = bool;
-      if (bool !== originalChannel.config[field.key]) configChanged = true;
     } else {
       newConfig[field.key] = value;
       if (value !== String(originalChannel.config[field.key] ?? '')) configChanged = true;
@@ -407,8 +394,12 @@ function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): Pa
   return payload;
 }
 
-function getWebhookUrl(gatewayUrl: string, channelId: string, channelType: ChannelType, isBaileys: boolean): string {
-  if (isBaileys) return ''; // WhatsApp Baileys no tiene webhook URL
+/**
+ * buildWebhookUrl — construye la URL de webhook/events para mostrar al usuario.
+ * Sigue los paths del plan F3a/F5.
+ */
+function buildWebhookUrl(gatewayUrl: string, channelId: string, channelType: ChannelType, isBaileys = false): string {
+  if (isBaileys) return ''; // WhatsApp Baileys no tiene webhook URL — usa QR
   const base = gatewayUrl.replace(/\/$/, '');
   const paths: Partial<Record<ChannelType, string>> = {
     telegram: `/gateway/telegram/${channelId}/webhook`,
@@ -424,7 +415,7 @@ function getWebhookUrl(gatewayUrl: string, channelId: string, channelType: Chann
 
 // ── Componentes internos ───────────────────────────────────────────────────────
 
-function WebhookUrlRow({ url, label }: { url: string; label?: string }) {
+function WebhookUrlRow({ url, label = 'Webhook URL' }: { url: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   const copy = useCallback(() => {
     void navigator.clipboard.writeText(url).then(() => {
@@ -437,14 +428,14 @@ function WebhookUrlRow({ url, label }: { url: string; label?: string }) {
 
   return (
     <div className="channel-settings__webhook-row">
-      <span className="channel-settings__webhook-label">{label ?? 'Webhook URL'}</span>
+      <span className="channel-settings__webhook-label">{label}</span>
       <div className="channel-settings__webhook-value">
         <code className="channel-settings__webhook-url">{url}</code>
         <button
           type="button"
           className="channel-settings__copy-btn"
           onClick={copy}
-          aria-label="Copiar URL"
+          aria-label={`Copiar ${label}`}
         >
           {copied ? '✓ Copiado' : 'Copiar'}
         </button>
@@ -456,16 +447,16 @@ function WebhookUrlRow({ url, label }: { url: string; label?: string }) {
   );
 }
 
-/** Badge especial para WhatsApp Baileys — indica que no usa secrets */
-function BaileysNoSecretsBadge() {
+/** Badge especial para WhatsApp Baileys — sin secrets requeridos */
+function WhatsAppBaileysBadge() {
   return (
-    <div className="channel-settings__baileys-badge" role="note">
-      <span className="channel-settings__baileys-badge-icon" aria-hidden="true">📱</span>
+    <div className="channel-settings__baileys-badge">
+      <span className="channel-settings__baileys-badge-icon" aria-hidden>📱</span>
       <div>
-        <strong className="channel-settings__baileys-badge-title">Autenticación por QR — sin credenciales</strong>
-        <p className="channel-settings__baileys-badge-desc">
-          WhatsApp Baileys usa sesiones QR persistentes almacenadas en el servidor.
-          No requiere tokens ni API keys. Usa el botón «Vincular WhatsApp» para generar un QR.
+        <strong className="channel-settings__baileys-badge-title">WhatsApp Baileys (QR)</strong>
+        <p className="channel-settings__baileys-badge-hint">
+          Este canal no usa token API — la autenticación se realiza mediante código QR.
+          No es necesario configurar credenciales en este formulario.
         </p>
       </div>
     </div>
@@ -534,56 +525,22 @@ function FieldInput({
     );
   }
 
-  if (field.type === 'boolean') {
-    return (
-      <div className="channel-settings__field channel-settings__field--boolean">
-        <label className="channel-settings__label-checkbox">
-          <input
-            id={id}
-            type="checkbox"
-            checked={value === 'true'}
-            onChange={e => onChange(e.target.checked ? 'true' : 'false')}
-            className="channel-settings__checkbox"
-            disabled={field.readOnly}
-          />
-          <span>{field.label}</span>
-          {field.devOnly && (
-            <span className="channel-settings__dev-badge" title="Solo desarrollo">DEV</span>
-          )}
-        </label>
-        {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
-      </div>
-    );
-  }
-
   return (
     <div className="channel-settings__field">
       <label htmlFor={id} className="channel-settings__label">{field.label}</label>
       <input
         id={id}
-        type={field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'}
+        type={field.type === 'password' ? 'password' : 'text'}
         value={value}
         onChange={e => onChange(e.target.value)}
         placeholder={field.placeholder}
         className="channel-settings__input"
         autoComplete={field.type === 'password' ? 'new-password' : 'off'}
         readOnly={field.readOnly}
-        min={field.type === 'number' ? 0 : undefined}
       />
       {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
     </div>
   );
-}
-
-// Etiqueta de webhook URL según tipo
-function webhookUrlLabel(channelType: ChannelType): string {
-  switch (channelType) {
-    case 'slack':    return 'Events URL (configurar en Slack API)';
-    case 'discord':  return 'Interactions Endpoint URL (configurar en Discord Dev Portal)';
-    case 'teams':    return 'Bot Messaging Endpoint (configurar en Azure Bot Service)';
-    case 'webchat':  return 'Embed URL (incrustar en tu web)';
-    default:         return 'Webhook URL';
-  }
 }
 
 // ── Componente principal ───────────────────────────────────────────────────────
@@ -595,11 +552,22 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
   const [saveErr,    setSaveErr]   = useState<string | null>(null);
   const [testResult, setTestResult] = useState<ChannelTestResult | null>(null);
 
-  const baileys      = isWhatsAppBaileys(channel);
-  const fieldsKey    = resolveFieldsKey(channel);
-  const configFields = CONFIG_FIELDS[fieldsKey as ChannelType] ?? [];
-  const secretFields = (SECRET_ROTATE_FIELDS as Record<string, FieldDef[]>)[fieldsKey] ?? [];
-  const webhookUrl   = getWebhookUrl(gatewayUrl, channel.id, channel.type, baileys);
+  const isBaileys   = isWhatsAppBaileys(channel);
+  const configFields = isBaileys
+    ? WHATSAPP_BAILEYS_CONFIG_FIELDS
+    : (CONFIG_FIELDS[channel.type] ?? []);
+  // WhatsApp Baileys no tiene secrets — nunca mostrar el fieldset de credenciales
+  const secretFields = isBaileys ? [] : (SECRET_ROTATE_FIELDS[channel.type] ?? []);
+
+  const webhookUrl = buildWebhookUrl(gatewayUrl, channel.id, channel.type, isBaileys);
+
+  // Etiqueta de la webhook URL según el tipo
+  const webhookUrlLabel: Partial<Record<ChannelType, string>> = {
+    slack:   'Events URL (Slack)',
+    discord: 'Interactions URL (Discord)',
+    teams:   'Messages URL (Teams)',
+    webchat: 'Embed URL',
+  };
 
   React.useEffect(() => {
     dispatch({ type: 'RESET', channel });
@@ -635,13 +603,100 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
     }
   }
 
-  if (configFields.length === 0 && secretFields.length === 0 && !baileys) {
+  // WhatsApp Baileys: solo badge + campos de config opcionales
+  if (isBaileys) {
+    return (
+      <section className="channel-settings" aria-label={`Configuración del canal ${channel.name}`}>
+        <div className="channel-settings__header">
+          <ChannelTypeIcon type={channel.type} size={24} />
+          <div>
+            <h3 className="channel-settings__channel-name">{channel.name}</h3>
+            <span className="channel-settings__type-badge">whatsapp · baileys</span>
+          </div>
+          <span
+            className={[
+              'channel-settings__status',
+              channel.isActive
+                ? 'channel-settings__status--active'
+                : 'channel-settings__status--inactive',
+            ].join(' ')}
+          >
+            {channel.isActive ? 'Activo' : 'Inactivo'}
+          </span>
+        </div>
+
+        <WhatsAppBaileysBadge />
+
+        {/* Test */}
+        <div className="channel-settings__test-row">
+          <button
+            type="button"
+            className="channel-settings__test-btn"
+            onClick={() => void handleTest()}
+            disabled={testing}
+            aria-busy={testing}
+          >
+            {testing ? 'Probando…' : '⚡ Test de conexión'}
+          </button>
+          <TestResultBanner result={testResult} testing={testing} />
+        </div>
+
+        {/* Campos de config opcionales de Baileys */}
+        <form
+          onSubmit={e => void handleSave(e)}
+          className="channel-settings__form"
+          aria-label="Configuración avanzada de WhatsApp Baileys"
+          noValidate
+        >
+          <fieldset className="channel-settings__fieldset">
+            <legend className="channel-settings__legend">Configuración avanzada (opcional)</legend>
+            {WHATSAPP_BAILEYS_CONFIG_FIELDS.map(field => (
+              <FieldInput
+                key={field.key}
+                field={field}
+                value={state.config[field.key] ?? ''}
+                onChange={v => dispatch({ type: 'SET_CONFIG', key: field.key, value: v })}
+              />
+            ))}
+          </fieldset>
+
+          {saveErr && (
+            <p className="channel-settings__error" role="alert">{saveErr}</p>
+          )}
+
+          <div className="channel-settings__footer">
+            <button
+              type="button"
+              className="channel-settings__btn-reset"
+              onClick={() => dispatch({ type: 'RESET', channel })}
+              disabled={!state.dirty || saving}
+            >
+              Descartar cambios
+            </button>
+            <button
+              type="submit"
+              className="channel-settings__btn-save"
+              disabled={!state.dirty || saving}
+              aria-busy={saving}
+            >
+              {saving ? 'Guardando…' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      </section>
+    );
+  }
+
+  if (configFields.length === 0 && secretFields.length === 0) {
     return (
       <div className="channel-settings channel-settings--empty">
         <p className="channel-settings__no-fields">
           Este tipo de canal no tiene configuración adicional editable.
         </p>
-        <WebhookUrlRow url={webhookUrl} label={webhookUrlLabel(channel.type)} />
+        <WebhookUrlRow
+          url={webhookUrl}
+          label={webhookUrlLabel[channel.type] ?? 'Webhook URL'}
+        />
       </div>
     );
   }
@@ -653,9 +708,7 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
         <ChannelTypeIcon type={channel.type} size={24} />
         <div>
           <h3 className="channel-settings__channel-name">{channel.name}</h3>
-          <span className="channel-settings__type-badge">
-            {baileys ? 'whatsapp-baileys' : channel.type}
-          </span>
+          <span className="channel-settings__type-badge">{channel.type}</span>
         </div>
         <span
           className={[
@@ -670,11 +723,11 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
         </span>
       </div>
 
-      {/* Badge especial WhatsApp Baileys */}
-      {baileys && <BaileysNoSecretsBadge />}
-
-      {/* Webhook URL */}
-      <WebhookUrlRow url={webhookUrl} label={webhookUrlLabel(channel.type)} />
+      {/* Webhook URL — label descriptivo según el tipo */}
+      <WebhookUrlRow
+        url={webhookUrl}
+        label={webhookUrlLabel[channel.type] ?? 'Webhook URL'}
+      />
 
       {/* Test de conexión */}
       <div className="channel-settings__test-row">
@@ -718,15 +771,15 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
               <FieldInput
                 key={field.key}
                 field={field}
-                value={state.config[field.key] ?? (field.type === 'boolean' ? 'false' : '')}
+                value={state.config[field.key] ?? ''}
                 onChange={v => dispatch({ type: 'SET_CONFIG', key: field.key, value: v })}
               />
             ))}
           </fieldset>
         )}
 
-        {/* Rotación de secrets (oculto para Baileys) */}
-        {!baileys && secretFields.length > 0 && (
+        {/* Rotación de secrets */}
+        {secretFields.length > 0 && (
           <fieldset className="channel-settings__fieldset">
             <legend className="channel-settings__legend">
               Credenciales

--- a/apps/web/src/features/channels/components/ChannelSettings.tsx
+++ b/apps/web/src/features/channels/components/ChannelSettings.tsx
@@ -1,8 +1,9 @@
 /**
- * ChannelSettings.tsx — [F3a-36]
+ * ChannelSettings.tsx — [F5-05]
  *
  * Formulario de configuración de un canal existente.
- * Cubre: Telegram, WhatsApp, Discord, Teams.
+ * Cubre: Telegram, WhatsApp (Meta Cloud API), WhatsApp Baileys (QR),
+ *        Slack, Discord, Teams, Webchat, Webhook.
  * Montado dentro de ChannelDetail.tsx como pestaña "Configuración".
  *
  * Props:
@@ -49,10 +50,11 @@ interface FieldDef {
   key:         string;
   label:       string;
   placeholder: string;
-  type:        'text' | 'password' | 'select' | 'tags';
+  type:        'text' | 'password' | 'select' | 'tags' | 'number' | 'checkbox';
   options?:    { value: string; label: string }[];
   hint?:       string;
   readOnly?:   boolean;
+  devOnly?:    boolean; // oculto en prod si NODE_ENV !== 'development'
 }
 
 const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
@@ -88,6 +90,7 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
     },
   ],
 
+  // WhatsApp META Cloud API
   whatsapp: [
     {
       key:         'verifyToken',
@@ -116,6 +119,56 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
       placeholder: '+34612345678, +1234567890 (vacío = todos)',
       type:        'tags',
       hint:        'En producción, deja vacío. En desarrollo, restringe a números de prueba.',
+    },
+  ],
+
+  // WhatsApp Baileys (QR) — authMode='qr'
+  'whatsapp-baileys': [
+    {
+      key:         'maxReconnectAttempts',
+      label:       'Máximo de reintentos de reconexión',
+      placeholder: '8',
+      type:        'number',
+      hint:        'Número de veces que Baileys intentará reconectarse antes de marcar la sesión como fallida. Default: 8.',
+    },
+    {
+      key:         'qrTimeoutMs',
+      label:       'Timeout del QR (ms)',
+      placeholder: '120000',
+      type:        'number',
+      hint:        'Tiempo en milisegundos antes de que el QR expire. Default: 120000 (2 minutos).',
+    },
+    {
+      key:         'sessionsDir',
+      label:       'Directorio de sesiones',
+      placeholder: './sessions',
+      type:        'text',
+      hint:        'Ruta donde Baileys guarda los archivos de sesión. Relativa al directorio de trabajo del gateway.',
+    },
+    {
+      key:         'printQrInTerminal',
+      label:       'Imprimir QR en terminal',
+      placeholder: '',
+      type:        'checkbox',
+      hint:        'Solo útil en desarrollo local. En producción debe estar desactivado.',
+      devOnly:     true,
+    },
+  ] as FieldDef[],
+
+  slack: [
+    {
+      key:         'workspaceName',
+      label:       'Nombre del workspace (display)',
+      placeholder: 'Mi Empresa Slack',
+      type:        'text',
+      hint:        'Solo informativo — aparece en la UI del Studio.',
+    },
+    {
+      key:         'botDisplayName',
+      label:       'Nombre del bot (display)',
+      placeholder: 'LSS Assistant',
+      type:        'text',
+      hint:        'Nombre visible del bot en Slack. Puede diferir del nombre configurado en la Slack App.',
     },
   ],
 
@@ -186,7 +239,7 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
   ],
 };
 
-const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
+const SECRET_ROTATE_FIELDS: Partial<Record<string, FieldDef[]>> = {
   telegram: [
     {
       key:         'botToken',
@@ -205,6 +258,31 @@ const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
       hint:        'Meta Business → System Users → Generate Token.',
     },
   ],
+  // whatsapp-baileys NO tiene secrets — usa QR, no tokens
+  'whatsapp-baileys': [],
+  slack: [
+    {
+      key:         'botToken',
+      label:       'Bot Token (xoxb-...)',
+      placeholder: 'Dejar vacío para no cambiar · xoxb-...',
+      type:        'password',
+      hint:        'Slack App → OAuth & Permissions → Bot User OAuth Token. Comienza con xoxb-.',
+    },
+    {
+      key:         'signingSecret',
+      label:       'Signing Secret',
+      placeholder: 'Dejar vacío para no cambiar',
+      type:        'password',
+      hint:        'Slack App → Basic Information → App Credentials → Signing Secret.',
+    },
+    {
+      key:         'appToken',
+      label:       'App-Level Token (xapp-... — opcional)',
+      placeholder: 'Dejar vacío para no cambiar · xapp-...',
+      type:        'password',
+      hint:        'Requerido solo para Socket Mode. Slack App → Basic Information → App-Level Tokens. Comienza con xapp-.',
+    },
+  ],
   discord: [
     {
       key:         'botToken',
@@ -214,23 +292,48 @@ const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
       hint:        'Discord Developer Portal → Bot → Reset Token.',
     },
     {
-      key:         'appPublicKey',
-      label:       'Public Key (verificación de interacciones)',
+      key:         'publicKey',
+      label:       'Public Key (verificación Ed25519)',
+      placeholder: 'Dejar vacío para no cambiar · hex string',
+      type:        'password',
+      hint:        'Discord Developer Portal → General Information → Public Key. Requerido para verificar interacciones.',
+    },
+    {
+      key:         'clientSecret',
+      label:       'Client Secret (opcional)',
       placeholder: 'Dejar vacío para no cambiar',
       type:        'password',
-      hint:        'Discord Developer Portal → General Information → Public Key.',
+      hint:        'Discord Developer Portal → OAuth2 → Client Secret. Solo necesario para OAuth2 flows.',
     },
   ],
   teams: [
     {
-      key:         'appPassword',
-      label:       'App Password (Client Secret)',
+      key:         'clientSecret',
+      label:       'Client Secret (Azure)',
       placeholder: 'Dejar vacío para no cambiar',
       type:        'password',
       hint:        'Azure Portal → App Registrations → Certificates & Secrets → New client secret.',
     },
+    {
+      key:         'appPassword',
+      label:       'App Password (Bot Framework)',
+      placeholder: 'Dejar vacío para no cambiar',
+      type:        'password',
+      hint:        'Azure Bot Service → Configuration → Microsoft App Password.',
+    },
   ],
 };
+
+/**
+ * Determina el "authMode" del canal para diferenciar
+ * WhatsApp Meta Cloud API de WhatsApp Baileys QR.
+ */
+function resolveChannelKey(channel: ChannelConfig): string {
+  if (channel.type === 'whatsapp' && channel.config?.['authMode'] === 'qr') {
+    return 'whatsapp-baileys';
+  }
+  return channel.type;
+}
 
 // ── Reducer ────────────────────────────────────────────────────────────────────
 
@@ -269,23 +372,37 @@ function initFormState(channel: ChannelConfig): FormState {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): PatchChannelPayload {
+function buildPatchPayload(
+  state:           FormState,
+  originalChannel: ChannelConfig,
+  channelKey:      string,
+): PatchChannelPayload {
   const payload: PatchChannelPayload = {};
 
   if (state.name.trim() !== originalChannel.name) {
     payload.name = state.name.trim();
   }
 
-  const configFields = CONFIG_FIELDS[originalChannel.type] ?? [];
+  const configFields = (CONFIG_FIELDS as Record<string, FieldDef[]>)[channelKey] ?? [];
   const newConfig: Record<string, unknown> = {};
   let configChanged = false;
   for (const field of configFields) {
+    if (field.type === 'checkbox') {
+      const value = state.config[field.key] === 'true';
+      newConfig[field.key] = value;
+      if (value !== Boolean(originalChannel.config[field.key])) configChanged = true;
+      continue;
+    }
     const value = state.config[field.key] ?? '';
     if (field.type === 'tags') {
       const arr = value.split(',').map(s => s.trim()).filter(Boolean);
       newConfig[field.key] = arr;
       const orig = originalChannel.config[field.key];
       if (JSON.stringify(arr) !== JSON.stringify(orig)) configChanged = true;
+    } else if (field.type === 'number') {
+      const num = value === '' ? undefined : Number(value);
+      newConfig[field.key] = num;
+      if (num !== Number(originalChannel.config[field.key] ?? '')) configChanged = true;
     } else {
       newConfig[field.key] = value;
       if (value !== String(originalChannel.config[field.key] ?? '')) configChanged = true;
@@ -307,17 +424,20 @@ function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): Pa
 function getWebhookUrl(gatewayUrl: string, channelId: string, channelType: ChannelType): string {
   const base = gatewayUrl.replace(/\/$/, '');
   const paths: Partial<Record<ChannelType, string>> = {
-    telegram: `/channels/telegram/${channelId}/webhook`,
+    telegram: `/gateway/telegram/${channelId}/webhook`,
     whatsapp: `/channels/whatsapp/${channelId}/webhook`,
+    slack:    `/channels/slack/${channelId}/events`,
     discord:  `/channels/discord/${channelId}/interactions`,
-    teams:    `/channels/teams/${channelId}`,
+    teams:    `/channels/teams/${channelId}/messages`,
+    webhook:  `/gateway/webhook/${channelId}`,
+    webchat:  `/embed/${channelId}`,
   };
   return paths[channelType] ? `${base}${paths[channelType]}` : '';
 }
 
 // ── Componentes internos ───────────────────────────────────────────────────────
 
-function WebhookUrlRow({ url }: { url: string }) {
+function WebhookUrlRow({ url, label }: { url: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   const copy = useCallback(() => {
     void navigator.clipboard.writeText(url).then(() => {
@@ -330,7 +450,7 @@ function WebhookUrlRow({ url }: { url: string }) {
 
   return (
     <div className="channel-settings__webhook-row">
-      <span className="channel-settings__webhook-label">Webhook URL</span>
+      <span className="channel-settings__webhook-label">{label ?? 'Webhook URL'}</span>
       <div className="channel-settings__webhook-value">
         <code className="channel-settings__webhook-url">{url}</code>
         <button
@@ -411,12 +531,34 @@ function FieldInput({
     );
   }
 
+  if (field.type === 'checkbox') {
+    return (
+      <div className="channel-settings__field channel-settings__field--checkbox">
+        <label htmlFor={id} className="channel-settings__label channel-settings__label--checkbox">
+          <input
+            id={id}
+            type="checkbox"
+            checked={value === 'true'}
+            onChange={e => onChange(e.target.checked ? 'true' : 'false')}
+            className="channel-settings__checkbox"
+            disabled={field.readOnly}
+          />
+          {field.label}
+          {field.devOnly && (
+            <span className="channel-settings__dev-badge" title="Solo entornos de desarrollo">DEV</span>
+          )}
+        </label>
+        {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
+      </div>
+    );
+  }
+
   return (
     <div className="channel-settings__field">
       <label htmlFor={id} className="channel-settings__label">{field.label}</label>
       <input
         id={id}
-        type={field.type === 'password' ? 'password' : 'text'}
+        type={field.type === 'password' ? 'password' : field.type === 'number' ? 'number' : 'text'}
         value={value}
         onChange={e => onChange(e.target.value)}
         placeholder={field.placeholder}
@@ -429,18 +571,47 @@ function FieldInput({
   );
 }
 
+/** Badge informativo para canales que usan QR (sin secrets de API) */
+function NoSecretsBadge() {
+  return (
+    <div className="channel-settings__no-secrets-badge" role="status">
+      <span className="channel-settings__no-secrets-icon" aria-hidden>📱</span>
+      <div>
+        <strong className="channel-settings__no-secrets-title">Sin credenciales de API</strong>
+        <p className="channel-settings__no-secrets-hint">
+          WhatsApp Baileys usa autenticación por QR — no requiere tokens ni secrets.
+          La sesión se mantiene en el directorio de sesiones del gateway.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 // ── Componente principal ───────────────────────────────────────────────────────
 
 export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: ChannelSettingsProps) {
+  const channelKey   = resolveChannelKey(channel);
   const [state,      dispatch]     = useReducer(formReducer, channel, initFormState);
   const [saving,     setSaving]    = useState(false);
   const [testing,    setTesting]   = useState(false);
   const [saveErr,    setSaveErr]   = useState<string | null>(null);
   const [testResult, setTestResult] = useState<ChannelTestResult | null>(null);
 
-  const configFields = CONFIG_FIELDS[channel.type]        ?? [];
-  const secretFields = SECRET_ROTATE_FIELDS[channel.type] ?? [];
+  const configFields = (CONFIG_FIELDS as Record<string, FieldDef[]>)[channelKey]  ?? [];
+  const secretFields = (SECRET_ROTATE_FIELDS)[channelKey] ?? [];
+  const isBaileys    = channelKey === 'whatsapp-baileys';
   const webhookUrl   = getWebhookUrl(gatewayUrl, channel.id, channel.type);
+
+  // Etiqueta contextual para el webhook URL según el tipo
+  const webhookLabel: Partial<Record<string, string>> = {
+    telegram: 'Webhook URL (Telegram)',
+    whatsapp: 'Webhook URL (Meta)',
+    slack:    'Events URL (Slack)',
+    discord:  'Interactions URL (Discord)',
+    teams:    'Messages URL (Teams)',
+    webhook:  'Webhook URL',
+    webchat:  'Embed URL',
+  };
 
   React.useEffect(() => {
     dispatch({ type: 'RESET', channel });
@@ -455,7 +626,7 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
     setSaving(true);
     setSaveErr(null);
     try {
-      const payload = buildPatchPayload(state, channel);
+      const payload = buildPatchPayload(state, channel, channelKey);
       await onSave(channel.id, payload);
       dispatch({ type: 'RESET', channel: { ...channel, ...payload } });
     } catch (err) {
@@ -476,13 +647,13 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
     }
   }
 
-  if (configFields.length === 0 && secretFields.length === 0) {
+  if (configFields.length === 0 && secretFields.length === 0 && !isBaileys) {
     return (
       <div className="channel-settings channel-settings--empty">
         <p className="channel-settings__no-fields">
           Este tipo de canal no tiene configuración adicional editable.
         </p>
-        <WebhookUrlRow url={webhookUrl} />
+        <WebhookUrlRow url={webhookUrl} label={webhookLabel[channelKey]} />
       </div>
     );
   }
@@ -494,7 +665,9 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
         <ChannelTypeIcon type={channel.type} size={24} />
         <div>
           <h3 className="channel-settings__channel-name">{channel.name}</h3>
-          <span className="channel-settings__type-badge">{channel.type}</span>
+          <span className="channel-settings__type-badge">
+            {isBaileys ? 'whatsapp-baileys' : channel.type}
+          </span>
         </div>
         <span
           className={[
@@ -509,8 +682,13 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
         </span>
       </div>
 
-      {/* Webhook URL */}
-      <WebhookUrlRow url={webhookUrl} />
+      {/* Webhook URL (con etiqueta contextual) */}
+      {!isBaileys && (
+        <WebhookUrlRow url={webhookUrl} label={webhookLabel[channelKey]} />
+      )}
+
+      {/* Badge especial WhatsApp Baileys — sin secrets */}
+      {isBaileys && <NoSecretsBadge />}
 
       {/* Test de conexión */}
       <div className="channel-settings__test-row">
@@ -561,8 +739,8 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
           </fieldset>
         )}
 
-        {/* Rotación de secrets */}
-        {secretFields.length > 0 && (
+        {/* Rotación de secrets (no mostrar sección si isBaileys) */}
+        {!isBaileys && secretFields.length > 0 && (
           <fieldset className="channel-settings__fieldset">
             <legend className="channel-settings__legend">
               Credenciales

--- a/apps/web/src/features/channels/components/ChannelSettings.tsx
+++ b/apps/web/src/features/channels/components/ChannelSettings.tsx
@@ -2,15 +2,9 @@
  * ChannelSettings.tsx — [F5-05]
  *
  * Formulario de configuración de un canal existente.
- * Cubre: Telegram, WhatsApp (Meta Cloud API), WhatsApp Baileys (QR),
+ * Cubre: Telegram, WhatsApp (Meta Cloud API), WhatsApp (Baileys QR),
  *        Slack, Discord, Teams, Webchat, Webhook.
  * Montado dentro de ChannelDetail.tsx como pestaña "Configuración".
- *
- * Props:
- *   channel    — ChannelConfig actual (read-only, viene del store)
- *   onSave     — callback tras PATCH exitoso
- *   onTest     — callback para lanzar test de conexión
- *   gatewayUrl — URL base del gateway (para construir webhook URL)
  */
 
 import React, { useCallback, useId, useReducer, useState } from 'react';
@@ -50,11 +44,11 @@ interface FieldDef {
   key:         string;
   label:       string;
   placeholder: string;
-  type:        'text' | 'password' | 'select' | 'tags' | 'number' | 'checkbox';
+  type:        'text' | 'password' | 'select' | 'tags' | 'number' | 'boolean';
   options?:    { value: string; label: string }[];
   hint?:       string;
   readOnly?:   boolean;
-  devOnly?:    boolean; // oculto en prod si NODE_ENV !== 'development'
+  devOnly?:    boolean;
 }
 
 const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
@@ -90,7 +84,7 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
     },
   ],
 
-  // WhatsApp META Cloud API
+  // WhatsApp Meta Cloud API
   whatsapp: [
     {
       key:         'verifyToken',
@@ -122,53 +116,47 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
     },
   ],
 
-  // WhatsApp Baileys (QR) — authMode='qr'
+  // WhatsApp Baileys (QR pairing — sin token, sin secrets)
   'whatsapp-baileys': [
     {
       key:         'maxReconnectAttempts',
-      label:       'Máximo de reintentos de reconexión',
+      label:       'Máximo de reconexiones',
       placeholder: '8',
       type:        'number',
-      hint:        'Número de veces que Baileys intentará reconectarse antes de marcar la sesión como fallida. Default: 8.',
+      hint:        'Número de veces que Baileys intenta reconectarse antes de considerar la sesión caída. Recomendado: 8.',
     },
     {
       key:         'qrTimeoutMs',
-      label:       'Timeout del QR (ms)',
+      label:       'Tiempo de espera del QR (ms)',
       placeholder: '120000',
       type:        'number',
-      hint:        'Tiempo en milisegundos antes de que el QR expire. Default: 120000 (2 minutos).',
-    },
-    {
-      key:         'sessionsDir',
-      label:       'Directorio de sesiones',
-      placeholder: './sessions',
-      type:        'text',
-      hint:        'Ruta donde Baileys guarda los archivos de sesión. Relativa al directorio de trabajo del gateway.',
+      hint:        'Tiempo en milisegundos antes de que el QR expire. Por defecto: 120000 (2 minutos).',
     },
     {
       key:         'printQrInTerminal',
       label:       'Imprimir QR en terminal',
       placeholder: '',
-      type:        'checkbox',
-      hint:        'Solo útil en desarrollo local. En producción debe estar desactivado.',
+      type:        'boolean',
+      hint:        'Solo útil en entornos de desarrollo local. Deshabilitar en producción.',
       devOnly:     true,
     },
-  ] as FieldDef[],
+  ],
 
+  // Slack Bolt
   slack: [
     {
       key:         'workspaceName',
-      label:       'Nombre del workspace (display)',
-      placeholder: 'Mi Empresa Slack',
+      label:       'Nombre del workspace (referencia)',
+      placeholder: 'Mi empresa',
       type:        'text',
-      hint:        'Solo informativo — aparece en la UI del Studio.',
+      hint:        'Texto libre para identificar el workspace de Slack. No se envía a la API.',
     },
     {
       key:         'botDisplayName',
-      label:       'Nombre del bot (display)',
-      placeholder: 'LSS Assistant',
+      label:       'Nombre del bot en Slack',
+      placeholder: 'Mi agente',
       type:        'text',
-      hint:        'Nombre visible del bot en Slack. Puede diferir del nombre configurado en la Slack App.',
+      hint:        'Nombre visible del bot en los chats de Slack.',
     },
   ],
 
@@ -239,7 +227,7 @@ const CONFIG_FIELDS: Partial<Record<ChannelType, FieldDef[]>> = {
   ],
 };
 
-const SECRET_ROTATE_FIELDS: Partial<Record<string, FieldDef[]>> = {
+const SECRET_ROTATE_FIELDS: Partial<Record<ChannelType | 'whatsapp-baileys', FieldDef[]>> = {
   telegram: [
     {
       key:         'botToken',
@@ -258,29 +246,29 @@ const SECRET_ROTATE_FIELDS: Partial<Record<string, FieldDef[]>> = {
       hint:        'Meta Business → System Users → Generate Token.',
     },
   ],
-  // whatsapp-baileys NO tiene secrets — usa QR, no tokens
+  // whatsapp-baileys: no tiene secrets — usa QR
   'whatsapp-baileys': [],
   slack: [
     {
       key:         'botToken',
-      label:       'Bot Token (xoxb-...)',
+      label:       'Bot Token',
       placeholder: 'Dejar vacío para no cambiar · xoxb-...',
       type:        'password',
-      hint:        'Slack App → OAuth & Permissions → Bot User OAuth Token. Comienza con xoxb-.',
+      hint:        'Slack API → OAuth & Permissions → Bot User OAuth Token. Empieza con xoxb-.',
     },
     {
       key:         'signingSecret',
       label:       'Signing Secret',
       placeholder: 'Dejar vacío para no cambiar',
       type:        'password',
-      hint:        'Slack App → Basic Information → App Credentials → Signing Secret.',
+      hint:        'Slack API → Basic Information → App Credentials → Signing Secret.',
     },
     {
       key:         'appToken',
-      label:       'App-Level Token (xapp-... — opcional)',
+      label:       'App-Level Token (Socket Mode, opcional)',
       placeholder: 'Dejar vacío para no cambiar · xapp-...',
       type:        'password',
-      hint:        'Requerido solo para Socket Mode. Slack App → Basic Information → App-Level Tokens. Comienza con xapp-.',
+      hint:        'Solo necesario si usas Socket Mode. Slack API → Basic Information → App-Level Tokens. Empieza con xapp-.',
     },
   ],
   discord: [
@@ -296,7 +284,7 @@ const SECRET_ROTATE_FIELDS: Partial<Record<string, FieldDef[]>> = {
       label:       'Public Key (verificación Ed25519)',
       placeholder: 'Dejar vacío para no cambiar · hex string',
       type:        'password',
-      hint:        'Discord Developer Portal → General Information → Public Key. Requerido para verificar interacciones.',
+      hint:        'Discord Developer Portal → General Information → Public Key. Requerido para verificar interacciones entrantes.',
     },
     {
       key:         'clientSecret',
@@ -324,14 +312,17 @@ const SECRET_ROTATE_FIELDS: Partial<Record<string, FieldDef[]>> = {
   ],
 };
 
-/**
- * Determina el "authMode" del canal para diferenciar
- * WhatsApp Meta Cloud API de WhatsApp Baileys QR.
- */
-function resolveChannelKey(channel: ChannelConfig): string {
-  if (channel.type === 'whatsapp' && channel.config?.['authMode'] === 'qr') {
-    return 'whatsapp-baileys';
-  }
+// Determina si el tipo es whatsapp-baileys (authMode=qr en config)
+function isWhatsAppBaileys(channel: ChannelConfig): boolean {
+  return (
+    channel.type === 'whatsapp' &&
+    (channel.config?.['authMode'] === 'qr' || channel.config?.['provider'] === 'baileys')
+  );
+}
+
+// Resuelve la clave de campos según el subtipo
+function resolveFieldsKey(channel: ChannelConfig): ChannelType | 'whatsapp-baileys' {
+  if (isWhatsAppBaileys(channel)) return 'whatsapp-baileys';
   return channel.type;
 }
 
@@ -372,27 +363,18 @@ function initFormState(channel: ChannelConfig): FormState {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function buildPatchPayload(
-  state:           FormState,
-  originalChannel: ChannelConfig,
-  channelKey:      string,
-): PatchChannelPayload {
+function buildPatchPayload(state: FormState, originalChannel: ChannelConfig): PatchChannelPayload {
   const payload: PatchChannelPayload = {};
+  const fieldsKey = resolveFieldsKey(originalChannel);
 
   if (state.name.trim() !== originalChannel.name) {
     payload.name = state.name.trim();
   }
 
-  const configFields = (CONFIG_FIELDS as Record<string, FieldDef[]>)[channelKey] ?? [];
+  const configFields = CONFIG_FIELDS[fieldsKey as ChannelType] ?? [];
   const newConfig: Record<string, unknown> = {};
   let configChanged = false;
   for (const field of configFields) {
-    if (field.type === 'checkbox') {
-      const value = state.config[field.key] === 'true';
-      newConfig[field.key] = value;
-      if (value !== Boolean(originalChannel.config[field.key])) configChanged = true;
-      continue;
-    }
     const value = state.config[field.key] ?? '';
     if (field.type === 'tags') {
       const arr = value.split(',').map(s => s.trim()).filter(Boolean);
@@ -402,7 +384,11 @@ function buildPatchPayload(
     } else if (field.type === 'number') {
       const num = value === '' ? undefined : Number(value);
       newConfig[field.key] = num;
-      if (num !== Number(originalChannel.config[field.key] ?? '')) configChanged = true;
+      if (num !== originalChannel.config[field.key]) configChanged = true;
+    } else if (field.type === 'boolean') {
+      const bool = value === 'true';
+      newConfig[field.key] = bool;
+      if (bool !== originalChannel.config[field.key]) configChanged = true;
     } else {
       newConfig[field.key] = value;
       if (value !== String(originalChannel.config[field.key] ?? '')) configChanged = true;
@@ -421,11 +407,12 @@ function buildPatchPayload(
   return payload;
 }
 
-function getWebhookUrl(gatewayUrl: string, channelId: string, channelType: ChannelType): string {
+function getWebhookUrl(gatewayUrl: string, channelId: string, channelType: ChannelType, isBaileys: boolean): string {
+  if (isBaileys) return ''; // WhatsApp Baileys no tiene webhook URL
   const base = gatewayUrl.replace(/\/$/, '');
   const paths: Partial<Record<ChannelType, string>> = {
     telegram: `/gateway/telegram/${channelId}/webhook`,
-    whatsapp: `/channels/whatsapp/${channelId}/webhook`,
+    whatsapp: `/gateway/whatsapp/${channelId}/webhook`,
     slack:    `/channels/slack/${channelId}/events`,
     discord:  `/channels/discord/${channelId}/interactions`,
     teams:    `/channels/teams/${channelId}/messages`,
@@ -457,7 +444,7 @@ function WebhookUrlRow({ url, label }: { url: string; label?: string }) {
           type="button"
           className="channel-settings__copy-btn"
           onClick={copy}
-          aria-label="Copiar webhook URL"
+          aria-label="Copiar URL"
         >
           {copied ? '✓ Copiado' : 'Copiar'}
         </button>
@@ -465,6 +452,22 @@ function WebhookUrlRow({ url, label }: { url: string; label?: string }) {
       <p className="channel-settings__webhook-hint">
         Configura esta URL en el proveedor del canal como endpoint de webhook.
       </p>
+    </div>
+  );
+}
+
+/** Badge especial para WhatsApp Baileys — indica que no usa secrets */
+function BaileysNoSecretsBadge() {
+  return (
+    <div className="channel-settings__baileys-badge" role="note">
+      <span className="channel-settings__baileys-badge-icon" aria-hidden="true">📱</span>
+      <div>
+        <strong className="channel-settings__baileys-badge-title">Autenticación por QR — sin credenciales</strong>
+        <p className="channel-settings__baileys-badge-desc">
+          WhatsApp Baileys usa sesiones QR persistentes almacenadas en el servidor.
+          No requiere tokens ni API keys. Usa el botón «Vincular WhatsApp» para generar un QR.
+        </p>
+      </div>
     </div>
   );
 }
@@ -531,10 +534,10 @@ function FieldInput({
     );
   }
 
-  if (field.type === 'checkbox') {
+  if (field.type === 'boolean') {
     return (
-      <div className="channel-settings__field channel-settings__field--checkbox">
-        <label htmlFor={id} className="channel-settings__label channel-settings__label--checkbox">
+      <div className="channel-settings__field channel-settings__field--boolean">
+        <label className="channel-settings__label-checkbox">
           <input
             id={id}
             type="checkbox"
@@ -543,9 +546,9 @@ function FieldInput({
             className="channel-settings__checkbox"
             disabled={field.readOnly}
           />
-          {field.label}
+          <span>{field.label}</span>
           {field.devOnly && (
-            <span className="channel-settings__dev-badge" title="Solo entornos de desarrollo">DEV</span>
+            <span className="channel-settings__dev-badge" title="Solo desarrollo">DEV</span>
           )}
         </label>
         {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
@@ -565,53 +568,38 @@ function FieldInput({
         className="channel-settings__input"
         autoComplete={field.type === 'password' ? 'new-password' : 'off'}
         readOnly={field.readOnly}
+        min={field.type === 'number' ? 0 : undefined}
       />
       {field.hint && <p className="channel-settings__hint">{field.hint}</p>}
     </div>
   );
 }
 
-/** Badge informativo para canales que usan QR (sin secrets de API) */
-function NoSecretsBadge() {
-  return (
-    <div className="channel-settings__no-secrets-badge" role="status">
-      <span className="channel-settings__no-secrets-icon" aria-hidden>📱</span>
-      <div>
-        <strong className="channel-settings__no-secrets-title">Sin credenciales de API</strong>
-        <p className="channel-settings__no-secrets-hint">
-          WhatsApp Baileys usa autenticación por QR — no requiere tokens ni secrets.
-          La sesión se mantiene en el directorio de sesiones del gateway.
-        </p>
-      </div>
-    </div>
-  );
+// Etiqueta de webhook URL según tipo
+function webhookUrlLabel(channelType: ChannelType): string {
+  switch (channelType) {
+    case 'slack':    return 'Events URL (configurar en Slack API)';
+    case 'discord':  return 'Interactions Endpoint URL (configurar en Discord Dev Portal)';
+    case 'teams':    return 'Bot Messaging Endpoint (configurar en Azure Bot Service)';
+    case 'webchat':  return 'Embed URL (incrustar en tu web)';
+    default:         return 'Webhook URL';
+  }
 }
 
 // ── Componente principal ───────────────────────────────────────────────────────
 
 export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: ChannelSettingsProps) {
-  const channelKey   = resolveChannelKey(channel);
   const [state,      dispatch]     = useReducer(formReducer, channel, initFormState);
   const [saving,     setSaving]    = useState(false);
   const [testing,    setTesting]   = useState(false);
   const [saveErr,    setSaveErr]   = useState<string | null>(null);
   const [testResult, setTestResult] = useState<ChannelTestResult | null>(null);
 
-  const configFields = (CONFIG_FIELDS as Record<string, FieldDef[]>)[channelKey]  ?? [];
-  const secretFields = (SECRET_ROTATE_FIELDS)[channelKey] ?? [];
-  const isBaileys    = channelKey === 'whatsapp-baileys';
-  const webhookUrl   = getWebhookUrl(gatewayUrl, channel.id, channel.type);
-
-  // Etiqueta contextual para el webhook URL según el tipo
-  const webhookLabel: Partial<Record<string, string>> = {
-    telegram: 'Webhook URL (Telegram)',
-    whatsapp: 'Webhook URL (Meta)',
-    slack:    'Events URL (Slack)',
-    discord:  'Interactions URL (Discord)',
-    teams:    'Messages URL (Teams)',
-    webhook:  'Webhook URL',
-    webchat:  'Embed URL',
-  };
+  const baileys      = isWhatsAppBaileys(channel);
+  const fieldsKey    = resolveFieldsKey(channel);
+  const configFields = CONFIG_FIELDS[fieldsKey as ChannelType] ?? [];
+  const secretFields = (SECRET_ROTATE_FIELDS as Record<string, FieldDef[]>)[fieldsKey] ?? [];
+  const webhookUrl   = getWebhookUrl(gatewayUrl, channel.id, channel.type, baileys);
 
   React.useEffect(() => {
     dispatch({ type: 'RESET', channel });
@@ -626,7 +614,7 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
     setSaving(true);
     setSaveErr(null);
     try {
-      const payload = buildPatchPayload(state, channel, channelKey);
+      const payload = buildPatchPayload(state, channel);
       await onSave(channel.id, payload);
       dispatch({ type: 'RESET', channel: { ...channel, ...payload } });
     } catch (err) {
@@ -647,13 +635,13 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
     }
   }
 
-  if (configFields.length === 0 && secretFields.length === 0 && !isBaileys) {
+  if (configFields.length === 0 && secretFields.length === 0 && !baileys) {
     return (
       <div className="channel-settings channel-settings--empty">
         <p className="channel-settings__no-fields">
           Este tipo de canal no tiene configuración adicional editable.
         </p>
-        <WebhookUrlRow url={webhookUrl} label={webhookLabel[channelKey]} />
+        <WebhookUrlRow url={webhookUrl} label={webhookUrlLabel(channel.type)} />
       </div>
     );
   }
@@ -666,7 +654,7 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
         <div>
           <h3 className="channel-settings__channel-name">{channel.name}</h3>
           <span className="channel-settings__type-badge">
-            {isBaileys ? 'whatsapp-baileys' : channel.type}
+            {baileys ? 'whatsapp-baileys' : channel.type}
           </span>
         </div>
         <span
@@ -682,13 +670,11 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
         </span>
       </div>
 
-      {/* Webhook URL (con etiqueta contextual) */}
-      {!isBaileys && (
-        <WebhookUrlRow url={webhookUrl} label={webhookLabel[channelKey]} />
-      )}
+      {/* Badge especial WhatsApp Baileys */}
+      {baileys && <BaileysNoSecretsBadge />}
 
-      {/* Badge especial WhatsApp Baileys — sin secrets */}
-      {isBaileys && <NoSecretsBadge />}
+      {/* Webhook URL */}
+      <WebhookUrlRow url={webhookUrl} label={webhookUrlLabel(channel.type)} />
 
       {/* Test de conexión */}
       <div className="channel-settings__test-row">
@@ -732,15 +718,15 @@ export function ChannelSettings({ channel, gatewayUrl, onSave, onTest }: Channel
               <FieldInput
                 key={field.key}
                 field={field}
-                value={state.config[field.key] ?? ''}
+                value={state.config[field.key] ?? (field.type === 'boolean' ? 'false' : '')}
                 onChange={v => dispatch({ type: 'SET_CONFIG', key: field.key, value: v })}
               />
             ))}
           </fieldset>
         )}
 
-        {/* Rotación de secrets (no mostrar sección si isBaileys) */}
-        {!isBaileys && secretFields.length > 0 && (
+        {/* Rotación de secrets (oculto para Baileys) */}
+        {!baileys && secretFields.length > 0 && (
           <fieldset className="channel-settings__fieldset">
             <legend className="channel-settings__legend">
               Credenciales

--- a/apps/web/src/features/channels/components/ChannelTypeIcon.tsx
+++ b/apps/web/src/features/channels/components/ChannelTypeIcon.tsx
@@ -1,64 +1,90 @@
 /**
- * ChannelTypeIcon.tsx
- * Ícono SVG por tipo de canal. Cero dependencias externas.
+ * ChannelTypeIcon.tsx — [F5-05]
+ *
+ * Icono de canal con logos de marca reales via cdn.simpleicons.org.
+ * Telegram, WhatsApp, Slack, Discord, Teams → imagen con color de marca.
+ * webchat y webhook → SVG inline con currentColor.
  */
 import React from 'react';
 import type { ChannelType } from '../types';
 
 interface Props {
-  type:      ChannelType;
-  className?: string;
+  type:       ChannelType;
   size?:      number;
+  className?: string;
 }
 
-export function ChannelTypeIcon({ type, className, size = 20 }: Props) {
-  const props = {
-    width:   size,
-    height:  size,
-    viewBox: '0 0 24 24',
-    fill:    'currentColor',
-    className,
-    'aria-hidden': true,
-  };
+/** Logos de marca con color oficial */
+const BRAND: Partial<Record<ChannelType, { url: string; color: string; label: string }>> = {
+  telegram: { url: 'https://cdn.simpleicons.org/telegram/26A5E4',          color: '#26A5E4', label: 'Telegram' },
+  whatsapp: { url: 'https://cdn.simpleicons.org/whatsapp/25D366',          color: '#25D366', label: 'WhatsApp' },
+  slack:    { url: 'https://cdn.simpleicons.org/slack/4A154B',             color: '#4A154B', label: 'Slack' },
+  discord:  { url: 'https://cdn.simpleicons.org/discord/5865F2',          color: '#5865F2', label: 'Discord' },
+  teams:    { url: 'https://cdn.simpleicons.org/microsoftteams/6264A7',    color: '#6264A7', label: 'Microsoft Teams' },
+};
 
-  switch (type) {
-    case 'webchat':
-      return (
-        <svg {...props}>
-          <path d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z" />
-        </svg>
-      );
-    case 'telegram':
-      return (
-        <svg {...props}>
-          <path d="M9.78 18.65l.28-4.23 7.68-6.92c.34-.31-.07-.46-.52-.19L7.74 13.3 3.64 12c-.88-.25-.89-.86.2-1.3l15.97-6.16c.73-.33 1.43.18 1.15 1.3l-2.72 12.81c-.19.91-.74 1.13-1.5.71L12.6 16.3l-1.99 1.93c-.23.23-.42.42-.83.42z" />
-        </svg>
-      );
-    case 'whatsapp':
-      return (
-        <svg {...props}>
-          <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413Z" />
-        </svg>
-      );
-    case 'slack':
-      return (
-        <svg {...props}>
-          <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" />
-        </svg>
-      );
-    case 'discord':
-      return (
-        <svg {...props}>
-          <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-        </svg>
-      );
-    case 'webhook':
-      return (
-        <svg {...props}>
-          <path d="M14 2a8 8 0 0 1 7.891 6.67 1.5 1.5 0 1 1-2.964.42A5.001 5.001 0 0 0 9 7a1.5 1.5 0 0 1-1.5-1.5A1.5 1.5 0 0 1 9 4a5 5 0 0 0 5-2zm-6.891 13.33a1.5 1.5 0 1 1 2.964-.42A5.001 5.001 0 0 0 19 17a1.5 1.5 0 0 1 1.5 1.5A1.5 1.5 0 0 1 19 20a8 8 0 0 1-7.891-6.67zM3 10.5a1.5 1.5 0 0 1 1.5-1.5h3a1.5 1.5 0 1 1 0 3H9a8 8 0 0 1-7.891-6.67 1.5 1.5 0 1 1 2.964.42A5.001 5.001 0 0 0 9 10.5H4.5A1.5 1.5 0 0 1 3 10.5z" />
-        </svg>
-      );
-    default:
-      return null;
+/** SVGs inline para tipos sin logo externo */
+function WebchatIcon({ size, className }: { size: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+function WebhookIcon({ size, className }: { size: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+export function ChannelTypeIcon({ type, size = 20, className }: Props) {
+  const brand = BRAND[type];
+
+  if (brand) {
+    return (
+      <img
+        src={brand.url}
+        width={size}
+        height={size}
+        alt={brand.label}
+        className={className}
+        loading="lazy"
+        aria-hidden="true"
+        style={{ display: 'inline-block', flexShrink: 0 }}
+      />
+    );
   }
+
+  if (type === 'webchat') {
+    return <WebchatIcon size={size} className={className} />;
+  }
+
+  // webhook y cualquier tipo desconocido
+  return <WebhookIcon size={size} className={className} />;
 }

--- a/apps/web/src/features/channels/components/CreateChannelPanel.tsx
+++ b/apps/web/src/features/channels/components/CreateChannelPanel.tsx
@@ -1,6 +1,8 @@
 /**
- * CreateChannelPanel.tsx
+ * CreateChannelPanel.tsx — [F5-05]
  * Panel lateral de creación de canal.
+ * Incluye los 7 tipos de canal: webchat, telegram, whatsapp, slack,
+ * discord, teams, webhook.
  * Campos dinámicos de secrets por tipo de canal.
  */
 import React, { useState } from 'react';
@@ -8,46 +10,61 @@ import type { ChannelType, CreateChannelPayload } from '../types';
 import { ChannelTypeIcon } from './ChannelTypeIcon';
 
 interface Props {
-  onClose:    () => void;
-  onCreate:   (payload: CreateChannelPayload) => Promise<void>;
+  onClose:  () => void;
+  onCreate: (payload: CreateChannelPayload) => Promise<void>;
 }
 
-const CHANNEL_TYPES: { value: ChannelType; label: string }[] = [
-  { value: 'webchat',  label: 'WebChat' },
-  { value: 'telegram', label: 'Telegram' },
-  { value: 'whatsapp', label: 'WhatsApp' },
-  { value: 'slack',    label: 'Slack' },
-  { value: 'discord',  label: 'Discord' },
-  { value: 'webhook',  label: 'Webhook genérico' },
+const CHANNEL_TYPES: { value: ChannelType; label: string; description: string }[] = [
+  { value: 'webchat',  label: 'Web Chat',   description: 'Chat embebido en tu web' },
+  { value: 'telegram', label: 'Telegram',   description: 'Bot de Telegram via grammY' },
+  { value: 'whatsapp', label: 'WhatsApp',   description: 'WhatsApp via Baileys (QR)' },
+  { value: 'slack',    label: 'Slack',      description: 'Bot Slack via Bolt SDK' },
+  { value: 'discord',  label: 'Discord',    description: 'Bot Discord via discord.js' },
+  { value: 'teams',    label: 'MS Teams',   description: 'Bot Microsoft Teams' },
+  { value: 'webhook',  label: 'Webhook',    description: 'HTTP POST genérico' },
 ];
 
-// Campos de secrets por tipo
-const SECRET_FIELDS: Record<ChannelType, { key: string; label: string; placeholder: string }[]> = {
+// Campos de secrets por tipo — se envían en la creación y nunca se devuelven
+const SECRET_FIELDS: Record<ChannelType, { key: string; label: string; placeholder: string; required?: boolean }[]> = {
   webchat:  [],
   webhook:  [],
   telegram: [
-    { key: 'botToken',  label: 'Bot Token',  placeholder: '123456:ABC...' },
+    { key: 'botToken',      label: 'Bot Token',             placeholder: '123456:ABC...',      required: true },
   ],
   whatsapp: [
-    { key: 'token',     label: 'API Token',  placeholder: 'Bearer ...' },
-    { key: 'phoneId',   label: 'Phone ID',   placeholder: '1234567890' },
+    // WhatsApp Baileys usa QR — no requiere secrets en la creación
+    // (la sesión se establece escaneando el QR tras crear el canal)
   ],
   slack: [
-    { key: 'botToken',       label: 'Bot Token',       placeholder: 'xoxb-...' },
-    { key: 'signingSecret',  label: 'Signing Secret',  placeholder: 'abc123...' },
+    { key: 'botToken',      label: 'Bot Token (xoxb-...)',  placeholder: 'xoxb-...',           required: true },
+    { key: 'signingSecret', label: 'Signing Secret',        placeholder: 'abc123def456...',    required: true },
+    { key: 'appToken',      label: 'App Token (xapp-...)',  placeholder: 'xapp-... (opcional)' },
   ],
   discord: [
-    { key: 'botToken', label: 'Bot Token', placeholder: 'MTk...' },
+    { key: 'botToken',      label: 'Bot Token',             placeholder: 'MTk...',             required: true },
+    { key: 'publicKey',     label: 'Public Key (Ed25519)',  placeholder: 'hex string...',      required: true },
+    { key: 'clientSecret',  label: 'Client Secret',         placeholder: '(opcional)' },
+  ],
+  teams: [
+    { key: 'clientSecret',  label: 'Client Secret (Azure)', placeholder: 'azure secret...',    required: true },
+    { key: 'appPassword',   label: 'App Password (Bot FW)', placeholder: 'bot password...',    required: true },
   ],
 };
 
+// Descripción de autenticación por tipo (mostrada bajo el título del fieldset)
+const AUTH_HINT: Partial<Record<ChannelType, string>> = {
+  whatsapp: '📱 WhatsApp Baileys usa autenticación por QR. Tras crear el canal, escanea el código QR para vincular tu número. No se requieren tokens ni secrets.',
+  webchat:  '🔗 El canal Webchat se activa con un snippet de código embebido — no requiere credenciales.',
+  webhook:  '🔗 El webhook genérico se activa con la URL que se genera al crear el canal.',
+};
+
 export function CreateChannelPanel({ onClose, onCreate }: Props) {
-  const [type,     setType]     = useState<ChannelType>('webchat');
-  const [name,     setName]     = useState('');
-  const [agentId,  setAgentId]  = useState('');
-  const [secrets,  setSecrets]  = useState<Record<string, string>>({});
-  const [busy,     setBusy]     = useState(false);
-  const [error,    setError]    = useState<string | null>(null);
+  const [type,    setType]    = useState<ChannelType>('webchat');
+  const [name,    setName]    = useState('');
+  const [agentId, setAgentId] = useState('');
+  const [secrets, setSecrets] = useState<Record<string, string>>({});
+  const [busy,    setBusy]    = useState(false);
+  const [error,   setError]   = useState<string | null>(null);
 
   function updateSecret(key: string, value: string) {
     setSecrets(prev => ({ ...prev, [key]: value }));
@@ -56,6 +73,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
   function handleTypeChange(t: ChannelType) {
     setType(t);
     setSecrets({});
+    setError(null);
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -65,14 +83,28 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
       return;
     }
 
+    // Validar secrets requeridos
+    const required = SECRET_FIELDS[type].filter(f => f.required);
+    for (const f of required) {
+      if (!secrets[f.key]?.trim()) {
+        setError(`El campo "${f.label}" es obligatorio para este tipo de canal.`);
+        return;
+      }
+    }
+
     setBusy(true);
     setError(null);
     try {
       const payload: CreateChannelPayload = {
         type,
-        name:     name.trim(),
-        agentId:  agentId.trim(),
-        secrets:  Object.keys(secrets).length > 0 ? secrets : undefined,
+        name:    name.trim(),
+        agentId: agentId.trim(),
+        secrets: Object.keys(secrets).filter(k => secrets[k]?.trim()).length > 0
+          ? Object.fromEntries(Object.entries(secrets).filter(([, v]) => v?.trim()))
+          : undefined,
+        // WhatsApp Baileys: indicar authMode=qr en config para que el backend
+        // sepa que debe inicializar Baileys y no el Cloud API
+        config: type === 'whatsapp' ? { authMode: 'qr' } : undefined,
       };
       await onCreate(payload);
       onClose();
@@ -84,6 +116,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
   }
 
   const secretFields = SECRET_FIELDS[type];
+  const authHint     = AUTH_HINT[type];
 
   return (
     <div className="create-panel" role="dialog" aria-modal="true" aria-label="Nuevo canal">
@@ -114,6 +147,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
                 ].join(' ')}
                 onClick={() => handleTypeChange(ct.value)}
                 aria-pressed={type === ct.value}
+                title={ct.description}
               >
                 <ChannelTypeIcon type={ct.value} size={20} />
                 <span>{ct.label}</span>
@@ -149,13 +183,21 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
           />
         </label>
 
+        {/* Hint de autenticación por tipo (QR, embed, etc.) */}
+        {authHint && (
+          <p className="create-panel__auth-hint">{authHint}</p>
+        )}
+
         {/* Secrets dinámicos por tipo */}
         {secretFields.length > 0 && (
           <fieldset className="create-panel__fieldset">
             <legend className="create-panel__legend">Credenciales</legend>
             {secretFields.map(f => (
               <label key={f.key} className="create-panel__field">
-                <span className="create-panel__label">{f.label}</span>
+                <span className="create-panel__label">
+                  {f.label}
+                  {f.required && <span aria-hidden> *</span>}
+                </span>
                 <input
                   type="password"
                   value={secrets[f.key] ?? ''}

--- a/apps/web/src/features/channels/components/CreateChannelPanel.tsx
+++ b/apps/web/src/features/channels/components/CreateChannelPanel.tsx
@@ -1,8 +1,8 @@
 /**
  * CreateChannelPanel.tsx — [F5-05]
+ *
  * Panel lateral de creación de canal.
- * Incluye los 7 tipos de canal: webchat, telegram, whatsapp, slack,
- * discord, teams, webhook.
+ * Incluye los 7 ChannelType: webchat, telegram, whatsapp, slack, discord, teams, webhook.
  * Campos dinámicos de secrets por tipo de canal.
  */
 import React, { useState } from 'react';
@@ -10,61 +10,54 @@ import type { ChannelType, CreateChannelPayload } from '../types';
 import { ChannelTypeIcon } from './ChannelTypeIcon';
 
 interface Props {
-  onClose:  () => void;
-  onCreate: (payload: CreateChannelPayload) => Promise<void>;
+  onClose:    () => void;
+  onCreate:   (payload: CreateChannelPayload) => Promise<void>;
 }
 
-const CHANNEL_TYPES: { value: ChannelType; label: string; description: string }[] = [
-  { value: 'webchat',  label: 'Web Chat',   description: 'Chat embebido en tu web' },
-  { value: 'telegram', label: 'Telegram',   description: 'Bot de Telegram via grammY' },
-  { value: 'whatsapp', label: 'WhatsApp',   description: 'WhatsApp via Baileys (QR)' },
-  { value: 'slack',    label: 'Slack',      description: 'Bot Slack via Bolt SDK' },
-  { value: 'discord',  label: 'Discord',    description: 'Bot Discord via discord.js' },
-  { value: 'teams',    label: 'MS Teams',   description: 'Bot Microsoft Teams' },
-  { value: 'webhook',  label: 'Webhook',    description: 'HTTP POST genérico' },
+const CHANNEL_TYPES: { value: ChannelType; label: string; hint: string }[] = [
+  { value: 'webchat',  label: 'Web Chat',   hint: 'Widget embebido en tu sitio web' },
+  { value: 'telegram', label: 'Telegram',   hint: 'Bot via Telegram API' },
+  { value: 'whatsapp', label: 'WhatsApp',   hint: 'WhatsApp Business Cloud API o Baileys QR' },
+  { value: 'slack',    label: 'Slack',      hint: 'App de Slack con Bolt SDK' },
+  { value: 'discord',  label: 'Discord',    hint: 'Bot de Discord con discord.js' },
+  { value: 'teams',    label: 'MS Teams',   hint: 'Bot de Microsoft Teams via Bot Framework' },
+  { value: 'webhook',  label: 'Webhook',    hint: 'HTTP POST genérico para integraciones custom' },
 ];
 
-// Campos de secrets por tipo — se envían en la creación y nunca se devuelven
-const SECRET_FIELDS: Record<ChannelType, { key: string; label: string; placeholder: string; required?: boolean }[]> = {
+// Campos de secrets por tipo
+const SECRET_FIELDS: Record<ChannelType, { key: string; label: string; placeholder: string; hint?: string; required?: boolean }[]> = {
   webchat:  [],
   webhook:  [],
   telegram: [
-    { key: 'botToken',      label: 'Bot Token',             placeholder: '123456:ABC...',      required: true },
+    { key: 'botToken',  label: 'Bot Token',  placeholder: '123456:ABC...', hint: 'Obtenlo de @BotFather con el comando /token.', required: true },
   ],
   whatsapp: [
-    // WhatsApp Baileys usa QR — no requiere secrets en la creación
-    // (la sesión se establece escaneando el QR tras crear el canal)
+    { key: 'token',   label: 'API Token (Meta Cloud API)',  placeholder: 'EAAxxxxxxx...', hint: 'Dejar vacío si usas Baileys QR (no requiere token).' },
+    { key: 'phoneId', label: 'Phone Number ID (Meta)',      placeholder: '1234567890',    hint: 'ID del número en Meta Developers. Dejar vacío si usas Baileys.' },
   ],
   slack: [
-    { key: 'botToken',      label: 'Bot Token (xoxb-...)',  placeholder: 'xoxb-...',           required: true },
-    { key: 'signingSecret', label: 'Signing Secret',        placeholder: 'abc123def456...',    required: true },
-    { key: 'appToken',      label: 'App Token (xapp-...)',  placeholder: 'xapp-... (opcional)' },
+    { key: 'botToken',      label: 'Bot Token',      placeholder: 'xoxb-...',     hint: 'OAuth & Permissions → Bot User OAuth Token.', required: true },
+    { key: 'signingSecret', label: 'Signing Secret', placeholder: 'abc123...',    hint: 'Basic Information → App Credentials → Signing Secret.', required: true },
+    { key: 'appToken',      label: 'App-Level Token (Socket Mode, opcional)', placeholder: 'xapp-...', hint: 'Basic Information → App-Level Tokens. Solo si usas Socket Mode.' },
   ],
   discord: [
-    { key: 'botToken',      label: 'Bot Token',             placeholder: 'MTk...',             required: true },
-    { key: 'publicKey',     label: 'Public Key (Ed25519)',  placeholder: 'hex string...',      required: true },
-    { key: 'clientSecret',  label: 'Client Secret',         placeholder: '(opcional)' },
+    { key: 'botToken',     label: 'Bot Token',     placeholder: 'MTk...',   hint: 'Developer Portal → Bot → Reset Token.', required: true },
+    { key: 'publicKey',    label: 'Public Key',    placeholder: 'hex...',   hint: 'Developer Portal → General Information → Public Key. Requerido para verificar interacciones.', required: true },
+    { key: 'clientSecret', label: 'Client Secret (opcional)', placeholder: '...', hint: 'Developer Portal → OAuth2. Solo para OAuth2 flows.' },
   ],
   teams: [
-    { key: 'clientSecret',  label: 'Client Secret (Azure)', placeholder: 'azure secret...',    required: true },
-    { key: 'appPassword',   label: 'App Password (Bot FW)', placeholder: 'bot password...',    required: true },
+    { key: 'clientSecret', label: 'Client Secret (Azure)', placeholder: '...',  hint: 'App Registrations → Certificates & Secrets → New client secret.', required: true },
+    { key: 'appPassword',  label: 'App Password (Bot Framework)', placeholder: '...', hint: 'Azure Bot Service → Configuration → Microsoft App Password.', required: true },
   ],
-};
-
-// Descripción de autenticación por tipo (mostrada bajo el título del fieldset)
-const AUTH_HINT: Partial<Record<ChannelType, string>> = {
-  whatsapp: '📱 WhatsApp Baileys usa autenticación por QR. Tras crear el canal, escanea el código QR para vincular tu número. No se requieren tokens ni secrets.',
-  webchat:  '🔗 El canal Webchat se activa con un snippet de código embebido — no requiere credenciales.',
-  webhook:  '🔗 El webhook genérico se activa con la URL que se genera al crear el canal.',
 };
 
 export function CreateChannelPanel({ onClose, onCreate }: Props) {
-  const [type,    setType]    = useState<ChannelType>('webchat');
-  const [name,    setName]    = useState('');
-  const [agentId, setAgentId] = useState('');
-  const [secrets, setSecrets] = useState<Record<string, string>>({});
-  const [busy,    setBusy]    = useState(false);
-  const [error,   setError]   = useState<string | null>(null);
+  const [type,     setType]     = useState<ChannelType>('webchat');
+  const [name,     setName]     = useState('');
+  const [agentId,  setAgentId]  = useState('');
+  const [secrets,  setSecrets]  = useState<Record<string, string>>({});
+  const [busy,     setBusy]     = useState(false);
+  const [error,    setError]    = useState<string | null>(null);
 
   function updateSecret(key: string, value: string) {
     setSecrets(prev => ({ ...prev, [key]: value }));
@@ -83,28 +76,27 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
       return;
     }
 
-    // Validar secrets requeridos
-    const required = SECRET_FIELDS[type].filter(f => f.required);
-    for (const f of required) {
-      if (!secrets[f.key]?.trim()) {
-        setError(`El campo "${f.label}" es obligatorio para este tipo de canal.`);
-        return;
-      }
+    // Validar campos requeridos de secrets
+    const requiredMissing = SECRET_FIELDS[type]
+      .filter(f => f.required)
+      .filter(f => !(secrets[f.key] ?? '').trim())
+      .map(f => f.label);
+    if (requiredMissing.length > 0) {
+      setError(`Campos obligatorios faltantes: ${requiredMissing.join(', ')}`);
+      return;
     }
 
     setBusy(true);
     setError(null);
     try {
+      const nonEmptySecrets = Object.fromEntries(
+        Object.entries(secrets).filter(([, v]) => v.trim() !== '')
+      );
       const payload: CreateChannelPayload = {
         type,
         name:    name.trim(),
         agentId: agentId.trim(),
-        secrets: Object.keys(secrets).filter(k => secrets[k]?.trim()).length > 0
-          ? Object.fromEntries(Object.entries(secrets).filter(([, v]) => v?.trim()))
-          : undefined,
-        // WhatsApp Baileys: indicar authMode=qr en config para que el backend
-        // sepa que debe inicializar Baileys y no el Cloud API
-        config: type === 'whatsapp' ? { authMode: 'qr' } : undefined,
+        secrets: Object.keys(nonEmptySecrets).length > 0 ? nonEmptySecrets : undefined,
       };
       await onCreate(payload);
       onClose();
@@ -116,7 +108,6 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
   }
 
   const secretFields = SECRET_FIELDS[type];
-  const authHint     = AUTH_HINT[type];
 
   return (
     <div className="create-panel" role="dialog" aria-modal="true" aria-label="Nuevo canal">
@@ -147,13 +138,17 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
                 ].join(' ')}
                 onClick={() => handleTypeChange(ct.value)}
                 aria-pressed={type === ct.value}
-                title={ct.description}
+                title={ct.hint}
               >
                 <ChannelTypeIcon type={ct.value} size={20} />
                 <span>{ct.label}</span>
               </button>
             ))}
           </div>
+          {/* Hint del tipo seleccionado */}
+          <p className="create-panel__type-hint">
+            {CHANNEL_TYPES.find(ct => ct.value === type)?.hint}
+          </p>
         </fieldset>
 
         {/* Nombre */}
@@ -163,7 +158,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
             type="text"
             value={name}
             onChange={e => setName(e.target.value)}
-            placeholder="Ej: Chat pública LSS"
+            placeholder="Ej: Soporte WhatsApp LATAM"
             className="create-panel__input"
             required
             autoFocus
@@ -183,11 +178,6 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
           />
         </label>
 
-        {/* Hint de autenticación por tipo (QR, embed, etc.) */}
-        {authHint && (
-          <p className="create-panel__auth-hint">{authHint}</p>
-        )}
-
         {/* Secrets dinámicos por tipo */}
         {secretFields.length > 0 && (
           <fieldset className="create-panel__fieldset">
@@ -206,9 +196,18 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
                   className="create-panel__input"
                   autoComplete="off"
                 />
+                {f.hint && <span className="create-panel__field-hint">{f.hint}</span>}
               </label>
             ))}
           </fieldset>
+        )}
+
+        {/* WhatsApp Baileys — aviso sin secrets */}
+        {type === 'whatsapp' && (
+          <div className="create-panel__info-note" role="note">
+            <strong>¿Usas Baileys (QR)?</strong> Deja los campos de credenciales vacíos.
+            Después de crear el canal, usa el botón «Vincular WhatsApp» para escanear el QR.
+          </div>
         )}
 
         {error && <p className="create-panel__error" role="alert">{error}</p>}
@@ -226,6 +225,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
             type="submit"
             className="create-panel__btn-create"
             disabled={busy}
+            aria-busy={busy}
           >
             {busy ? 'Creando…' : 'Crear canal'}
           </button>

--- a/apps/web/src/features/channels/components/CreateChannelPanel.tsx
+++ b/apps/web/src/features/channels/components/CreateChannelPanel.tsx
@@ -1,9 +1,8 @@
 /**
  * CreateChannelPanel.tsx — [F5-05]
- *
  * Panel lateral de creación de canal.
- * Incluye los 7 ChannelType: webchat, telegram, whatsapp, slack, discord, teams, webhook.
  * Campos dinámicos de secrets por tipo de canal.
+ * Incluye los 7 tipos: webchat, telegram, whatsapp, slack, discord, teams, webhook.
  */
 import React, { useState } from 'react';
 import type { ChannelType, CreateChannelPayload } from '../types';
@@ -14,40 +13,41 @@ interface Props {
   onCreate:   (payload: CreateChannelPayload) => Promise<void>;
 }
 
-const CHANNEL_TYPES: { value: ChannelType; label: string; hint: string }[] = [
-  { value: 'webchat',  label: 'Web Chat',   hint: 'Widget embebido en tu sitio web' },
-  { value: 'telegram', label: 'Telegram',   hint: 'Bot via Telegram API' },
-  { value: 'whatsapp', label: 'WhatsApp',   hint: 'WhatsApp Business Cloud API o Baileys QR' },
-  { value: 'slack',    label: 'Slack',      hint: 'App de Slack con Bolt SDK' },
-  { value: 'discord',  label: 'Discord',    hint: 'Bot de Discord con discord.js' },
-  { value: 'teams',    label: 'MS Teams',   hint: 'Bot de Microsoft Teams via Bot Framework' },
-  { value: 'webhook',  label: 'Webhook',    hint: 'HTTP POST genérico para integraciones custom' },
+/** Los 7 tipos de canal del plan — incluyendo teams */
+const CHANNEL_TYPES: { value: ChannelType; label: string; icon: string }[] = [
+  { value: 'webchat',  label: 'Web Chat',          icon: '💬' },
+  { value: 'telegram', label: 'Telegram',           icon: '✈️' },
+  { value: 'whatsapp', label: 'WhatsApp',           icon: '📱' },
+  { value: 'slack',    label: 'Slack',              icon: '⚡' },
+  { value: 'discord',  label: 'Discord',            icon: '🎮' },
+  { value: 'teams',    label: 'MS Teams',           icon: '👥' },
+  { value: 'webhook',  label: 'Webhook genérico',   icon: '🔗' },
 ];
 
-// Campos de secrets por tipo
-const SECRET_FIELDS: Record<ChannelType, { key: string; label: string; placeholder: string; hint?: string; required?: boolean }[]> = {
+// Campos de secrets por tipo — completos según el plan F5-05
+const SECRET_FIELDS: Record<ChannelType, { key: string; label: string; placeholder: string; required?: boolean }[]> = {
   webchat:  [],
   webhook:  [],
   telegram: [
-    { key: 'botToken',  label: 'Bot Token',  placeholder: '123456:ABC...', hint: 'Obtenlo de @BotFather con el comando /token.', required: true },
+    { key: 'botToken',       label: 'Bot Token',       placeholder: '123456:ABC-DEF...',    required: true },
   ],
   whatsapp: [
-    { key: 'token',   label: 'API Token (Meta Cloud API)',  placeholder: 'EAAxxxxxxx...', hint: 'Dejar vacío si usas Baileys QR (no requiere token).' },
-    { key: 'phoneId', label: 'Phone Number ID (Meta)',      placeholder: '1234567890',    hint: 'ID del número en Meta Developers. Dejar vacío si usas Baileys.' },
+    { key: 'token',          label: 'API Token',        placeholder: 'Bearer ...',           required: true },
+    { key: 'phoneId',        label: 'Phone Number ID',  placeholder: '1234567890',           required: true },
   ],
   slack: [
-    { key: 'botToken',      label: 'Bot Token',      placeholder: 'xoxb-...',     hint: 'OAuth & Permissions → Bot User OAuth Token.', required: true },
-    { key: 'signingSecret', label: 'Signing Secret', placeholder: 'abc123...',    hint: 'Basic Information → App Credentials → Signing Secret.', required: true },
-    { key: 'appToken',      label: 'App-Level Token (Socket Mode, opcional)', placeholder: 'xapp-...', hint: 'Basic Information → App-Level Tokens. Solo si usas Socket Mode.' },
+    { key: 'botToken',       label: 'Bot Token',        placeholder: 'xoxb-...',             required: true },
+    { key: 'signingSecret',  label: 'Signing Secret',   placeholder: 'abc123...',            required: true },
+    { key: 'appToken',       label: 'App-Level Token',  placeholder: 'xapp-... (opcional)',  required: false },
   ],
   discord: [
-    { key: 'botToken',     label: 'Bot Token',     placeholder: 'MTk...',   hint: 'Developer Portal → Bot → Reset Token.', required: true },
-    { key: 'publicKey',    label: 'Public Key',    placeholder: 'hex...',   hint: 'Developer Portal → General Information → Public Key. Requerido para verificar interacciones.', required: true },
-    { key: 'clientSecret', label: 'Client Secret (opcional)', placeholder: '...', hint: 'Developer Portal → OAuth2. Solo para OAuth2 flows.' },
+    { key: 'publicKey',      label: 'Public Key',       placeholder: 'hex string (Ed25519)', required: true },
+    { key: 'botToken',       label: 'Bot Token',        placeholder: 'Bot MTk...',           required: true },
+    { key: 'clientSecret',   label: 'Client Secret',    placeholder: 'opcional',             required: false },
   ],
   teams: [
-    { key: 'clientSecret', label: 'Client Secret (Azure)', placeholder: '...',  hint: 'App Registrations → Certificates & Secrets → New client secret.', required: true },
-    { key: 'appPassword',  label: 'App Password (Bot Framework)', placeholder: '...', hint: 'Azure Bot Service → Configuration → Microsoft App Password.', required: true },
+    { key: 'clientSecret',   label: 'Client Secret',    placeholder: 'Azure app secret',     required: true },
+    { key: 'appPassword',    label: 'App Password',     placeholder: 'Bot Framework password', required: true },
   ],
 };
 
@@ -69,6 +69,16 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
     setError(null);
   }
 
+  function validateSecrets(): string | null {
+    const fields = SECRET_FIELDS[type];
+    for (const f of fields) {
+      if (f.required && !secrets[f.key]?.trim()) {
+        return `"${f.label}" es obligatorio para canales de tipo ${type}.`;
+      }
+    }
+    return null;
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim() || !agentId.trim()) {
@@ -76,27 +86,20 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
       return;
     }
 
-    // Validar campos requeridos de secrets
-    const requiredMissing = SECRET_FIELDS[type]
-      .filter(f => f.required)
-      .filter(f => !(secrets[f.key] ?? '').trim())
-      .map(f => f.label);
-    if (requiredMissing.length > 0) {
-      setError(`Campos obligatorios faltantes: ${requiredMissing.join(', ')}`);
+    const secretsError = validateSecrets();
+    if (secretsError) {
+      setError(secretsError);
       return;
     }
 
     setBusy(true);
     setError(null);
     try {
-      const nonEmptySecrets = Object.fromEntries(
-        Object.entries(secrets).filter(([, v]) => v.trim() !== '')
-      );
       const payload: CreateChannelPayload = {
         type,
-        name:    name.trim(),
-        agentId: agentId.trim(),
-        secrets: Object.keys(nonEmptySecrets).length > 0 ? nonEmptySecrets : undefined,
+        name:     name.trim(),
+        agentId:  agentId.trim(),
+        secrets:  Object.keys(secrets).length > 0 ? secrets : undefined,
       };
       await onCreate(payload);
       onClose();
@@ -124,7 +127,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
 
       <form onSubmit={e => void handleSubmit(e)} className="create-panel__form">
 
-        {/* Tipo */}
+        {/* Tipo — los 7 tipos del plan */}
         <fieldset className="create-panel__fieldset">
           <legend className="create-panel__legend">Tipo de canal</legend>
           <div className="create-panel__type-grid">
@@ -138,17 +141,12 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
                 ].join(' ')}
                 onClick={() => handleTypeChange(ct.value)}
                 aria-pressed={type === ct.value}
-                title={ct.hint}
               >
                 <ChannelTypeIcon type={ct.value} size={20} />
                 <span>{ct.label}</span>
               </button>
             ))}
           </div>
-          {/* Hint del tipo seleccionado */}
-          <p className="create-panel__type-hint">
-            {CHANNEL_TYPES.find(ct => ct.value === type)?.hint}
-          </p>
         </fieldset>
 
         {/* Nombre */}
@@ -158,7 +156,7 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
             type="text"
             value={name}
             onChange={e => setName(e.target.value)}
-            placeholder="Ej: Soporte WhatsApp LATAM"
+            placeholder="Ej: Chat pública LSS"
             className="create-panel__input"
             required
             autoFocus
@@ -196,18 +194,17 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
                   className="create-panel__input"
                   autoComplete="off"
                 />
-                {f.hint && <span className="create-panel__field-hint">{f.hint}</span>}
               </label>
             ))}
           </fieldset>
         )}
 
-        {/* WhatsApp Baileys — aviso sin secrets */}
+        {/* WhatsApp Baileys info — no requiere secrets */}
         {type === 'whatsapp' && (
-          <div className="create-panel__info-note" role="note">
-            <strong>¿Usas Baileys (QR)?</strong> Deja los campos de credenciales vacíos.
-            Después de crear el canal, usa el botón «Vincular WhatsApp» para escanear el QR.
-          </div>
+          <p className="create-panel__hint">
+            Si usas autenticación por QR (WhatsApp Baileys), no necesitas
+            completar las credenciales. El QR se generará tras crear el canal.
+          </p>
         )}
 
         {error && <p className="create-panel__error" role="alert">{error}</p>}
@@ -225,7 +222,6 @@ export function CreateChannelPanel({ onClose, onCreate }: Props) {
             type="submit"
             className="create-panel__btn-create"
             disabled={busy}
-            aria-busy={busy}
           >
             {busy ? 'Creando…' : 'Crear canal'}
           </button>

--- a/apps/web/src/features/channels/useChannels.ts
+++ b/apps/web/src/features/channels/useChannels.ts
@@ -1,13 +1,3 @@
-/**
- * useChannels.ts — [F5-05]
- *
- * Hook de gestión de canales.
- * Endpoints corregidos para coincidir con el plan F3a/F5:
- *   - PATCH  /api/channels/:id
- *   - POST   /api/channels/:id/test
- *   - GET    /gateway/whatsapp/:id/qr          ← SSE del QR (NO /api/channels/:id/whatsapp/qr)
- *   - POST   /gateway/whatsapp/:id/logout       ← logout de sesión Baileys
- */
 import { useState, useEffect, useCallback } from 'react'
 import * as gwApi from '../../lib/gateway-api'
 import type {
@@ -38,7 +28,7 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     } finally {
       setLoading(false)
     }
-  }, [filtersKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [filtersKey])
 
   useEffect(() => { void load() }, [load])
 
@@ -120,9 +110,9 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
   }, [])
 
   /**
-   * Solicita un nuevo QR para una sesión Baileys.
-   * Endpoint corregido: POST /gateway/whatsapp/:id/qr
-   * (el SSE del QR se consume en WhatsAppQrModal via /gateway/whatsapp/:id/qr-stream)
+   * requestWhatsAppQr — solicita al gateway que genere un nuevo QR de vinculación.
+   * Endpoint: POST /gateway/whatsapp/:id/qr  (F5-01 — WhatsAppAdapter)
+   * El QR llega vía SSE en /gateway/whatsapp/:id/qr-stream → ChannelStatusCard
    */
   const requestWhatsAppQr = useCallback(async (id: string): Promise<void> => {
     const res = await fetch(`/gateway/whatsapp/${id}/qr`, { method: 'POST' })
@@ -130,19 +120,6 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
       const err = await res.json().catch(() => ({ message: 'Error al generar QR' })) as { message?: string }
       throw new Error(err.message ?? 'Error al generar QR')
     }
-  }, [])
-
-  /**
-   * Cierra la sesión Baileys del canal WhatsApp.
-   * Endpoint: POST /gateway/whatsapp/:id/logout
-   */
-  const logoutWhatsApp = useCallback(async (id: string): Promise<void> => {
-    const res = await fetch(`/gateway/whatsapp/${id}/logout`, { method: 'POST' })
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({ message: 'Error al cerrar sesión' })) as { message?: string }
-      throw new Error(err.message ?? 'Error al cerrar sesión')
-    }
-    setChannels(prev => prev.map(c => c.id === id ? { ...c, isActive: false } : c))
   }, [])
 
   const selected = channels.find(c => c.id === selectedId) ?? null
@@ -164,6 +141,5 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     patchChannel,
     testChannel,
     requestWhatsAppQr,
-    logoutWhatsApp,
   }
 }

--- a/apps/web/src/features/channels/useChannels.ts
+++ b/apps/web/src/features/channels/useChannels.ts
@@ -109,12 +109,35 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     }
   }, [])
 
+  /**
+   * requestWhatsAppQr — solicita al gateway que genere un nuevo QR para
+   * la sesión Baileys del canal. El QR se emitirá via SSE (evento 'qr')
+   * en /api/channels/:id/status/stream, que ya escucha useChannelStatus.
+   *
+   * Endpoint correcto: POST /gateway/whatsapp/:id/qr
+   * (no /api/channels/:id/whatsapp/qr — ese path no existe en el gateway)
+   */
   const requestWhatsAppQr = useCallback(async (id: string): Promise<void> => {
-    const res = await fetch(`/api/channels/${id}/whatsapp/qr`, { method: 'POST' })
+    const res = await fetch(`/gateway/whatsapp/${id}/qr`, { method: 'POST' })
     if (!res.ok) {
       const err = await res.json().catch(() => ({ message: 'Error al generar QR' })) as { message?: string }
       throw new Error(err.message ?? 'Error al generar QR')
     }
+  }, [])
+
+  /**
+   * logoutWhatsApp — cierra la sesión Baileys del canal y elimina
+   * los archivos de sesión del gateway.
+   *
+   * Endpoint: POST /gateway/whatsapp/:id/logout
+   */
+  const logoutWhatsApp = useCallback(async (id: string): Promise<void> => {
+    const res = await fetch(`/gateway/whatsapp/${id}/logout`, { method: 'POST' })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ message: 'Error al cerrar sesión' })) as { message?: string }
+      throw new Error(err.message ?? 'Error al cerrar sesión')
+    }
+    setChannels(prev => prev.map(c => (c.id === id ? { ...c, isActive: false } : c)))
   }, [])
 
   const selected = channels.find(c => c.id === selectedId) ?? null
@@ -136,5 +159,6 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     patchChannel,
     testChannel,
     requestWhatsAppQr,
+    logoutWhatsApp,
   }
 }

--- a/apps/web/src/features/channels/useChannels.ts
+++ b/apps/web/src/features/channels/useChannels.ts
@@ -1,3 +1,13 @@
+/**
+ * useChannels.ts — [F5-05]
+ *
+ * Hook de gestión de canales.
+ * Endpoints corregidos para coincidir con el plan F3a/F5:
+ *   - PATCH  /api/channels/:id
+ *   - POST   /api/channels/:id/test
+ *   - GET    /gateway/whatsapp/:id/qr          ← SSE del QR (NO /api/channels/:id/whatsapp/qr)
+ *   - POST   /gateway/whatsapp/:id/logout       ← logout de sesión Baileys
+ */
 import { useState, useEffect, useCallback } from 'react'
 import * as gwApi from '../../lib/gateway-api'
 import type {
@@ -28,7 +38,7 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
     } finally {
       setLoading(false)
     }
-  }, [filtersKey])
+  }, [filtersKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { void load() }, [load])
 
@@ -110,12 +120,9 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
   }, [])
 
   /**
-   * requestWhatsAppQr — solicita al gateway que genere un nuevo QR para
-   * la sesión Baileys del canal. El QR se emitirá via SSE (evento 'qr')
-   * en /api/channels/:id/status/stream, que ya escucha useChannelStatus.
-   *
-   * Endpoint correcto: POST /gateway/whatsapp/:id/qr
-   * (no /api/channels/:id/whatsapp/qr — ese path no existe en el gateway)
+   * Solicita un nuevo QR para una sesión Baileys.
+   * Endpoint corregido: POST /gateway/whatsapp/:id/qr
+   * (el SSE del QR se consume en WhatsAppQrModal via /gateway/whatsapp/:id/qr-stream)
    */
   const requestWhatsAppQr = useCallback(async (id: string): Promise<void> => {
     const res = await fetch(`/gateway/whatsapp/${id}/qr`, { method: 'POST' })
@@ -126,9 +133,7 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
   }, [])
 
   /**
-   * logoutWhatsApp — cierra la sesión Baileys del canal y elimina
-   * los archivos de sesión del gateway.
-   *
+   * Cierra la sesión Baileys del canal WhatsApp.
    * Endpoint: POST /gateway/whatsapp/:id/logout
    */
   const logoutWhatsApp = useCallback(async (id: string): Promise<void> => {
@@ -137,7 +142,7 @@ export function useChannels(filters?: { agentId?: string; type?: string; isActiv
       const err = await res.json().catch(() => ({ message: 'Error al cerrar sesión' })) as { message?: string }
       throw new Error(err.message ?? 'Error al cerrar sesión')
     }
-    setChannels(prev => prev.map(c => (c.id === id ? { ...c, isActive: false } : c)))
+    setChannels(prev => prev.map(c => c.id === id ? { ...c, isActive: false } : c))
   }, [])
 
   const selected = channels.find(c => c.id === selectedId) ?? null


### PR DESCRIPTION
## F5-01 — WhatsAppAdapter Baileys: gaps corregidos

### Diagnóstico previo

| Gap | Archivo | Problema | Estado |
|-----|---------|----------|--------|
| A | `whatsapp-session.store.ts` | Store 100% en memoria + credenciales en disco (`useMultiFileAuthState`) — viola D-22b | ✅ Corregido |
| B | `gateway.module.ts` | `WhatsAppBaileysAdapter` no registrado como provider NestJS | ✅ Corregido |
| C | `__tests__/` | `whatsapp-baileys.adapter.spec.ts` no existía | ✅ Creado |

---

### Cambios

#### `apps/gateway/src/whatsapp-session.store.ts` (Gap A)
- `WhatsAppSessionStore` recibe `PrismaService` por constructor
- Nuevos métodos: `saveCredentials()`, `loadCredentials()`, `markClosed()` — persisten en `GatewaySession.metadata` (D-22b)
- Estado efímero (qrBuffer, sseClients) sigue en memoria por diseño — el QR se regenera en cada reconexión
- Nuevo helper `setGlobalWhatsAppSessionStorePrisma()` para inyección en el singleton global desde el módulo NestJS

#### `apps/gateway/src/gateway.module.ts` (Gap B)
- `WhatsAppBaileysAdapter` añadido a `providers` y `exports`
- `GatewayModule` implementa `OnModuleInit` → llama a `setGlobalWhatsAppSessionStorePrisma(prisma)` en `onModuleInit()` para activar persistencia en BD

#### `apps/gateway/src/channels/__tests__/whatsapp-baileys.adapter.spec.ts` (Gap C)
6 casos Jest puros (sin TestingModule):
1. `connect()` arranca socket Baileys y registra handlers de eventos
2. Mensaje entrante `fromMe=false` → `onMessage` handler llamado
3. Mensaje `fromMe=true` → handler **NO** llamado
4. `status@broadcast` → handler **NO** llamado
5. `logout()` llama `sock.logout()` y deja estado `closed`
6. QR emitido via `onQr()` como string antes del primer login

---

### Verificación de criterios F5-01

- [x] `WhatsAppBaileysAdapter` implementa `IChannelAdapter` completo
- [x] QR generado como string y expuesto via `onQr()` callback
- [x] Credenciales Baileys persistidas en `GatewaySession` (Prisma, no archivo)
- [x] Mensajes entrantes filtran `fromMe=true` y `status@broadcast`
- [x] Registrado en `GatewayModule` como provider/export
- [x] 6 tests unitarios cubiertos con Jest puro

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for WhatsApp, Slack, and Discord adapters covering connection, message flows, QR/login/logout, signature/verification, and DB-backed session auth.

* **Improvements**
  * WhatsApp sessions now persist credentials and status to the database with corruption fallback.
  * Slack: raw-request signature verification, stricter event parsing, and send error handling.
  * Discord: standardized interaction responses, auditing, and safer send/error handling.

* **Exports**
  * Gateway now exposes additional adapter integrations for reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->