### PR TITLE
fix(runs): alinear RunStepTimeline + useRealtimeRun con campos reales RunSpec/RunStep

### DIFF
--- a/apps/web/src/features/runs/RunStepTimeline.tsx
+++ b/apps/web/src/features/runs/RunStepTimeline.tsx
@@ -1,98 +1,180 @@
 /**
  * RunStepTimeline.tsx
- * Timeline de steps de un Run con datos reales via SSE (useRealtimeRun).
+ * Timeline de steps de un Run con datos reales via SSE / polling (useRealtimeRun).
  * Muestra estado, tokens, costo y duración por step.
  *
- * Patrones: LangGraph Studio trace panel + Flowise execution log.
+ * Corregido:
+ *   - steps es Map<string,StepUpdate> → convertir a array con Array.from()
+ *   - usar campos reales de StepUpdate: nodeId, nodeType, agentId,
+ *     tokenUsage.input/output, costUsd, startedAt, completedAt
+ *   - runStatus viene de useRealtimeRun como alias de status
+ *   - eliminado AgentCostBadge (dependía de props inexistentes)
+ *   - banner de error + botón reconnect cuando SSE/polling falla
  */
 
 import React from 'react';
 import { useRealtimeRun } from './useRealtimeRun';
-import { AgentCostBadge } from '../agents/AgentCostBadge';
+
+const STATUS_COLOR: Record<string, string> = {
+  completed: '#22c55e',
+  failed:    '#ef4444',
+  running:   '#f59e0b',
+  queued:    '#6366f1',
+  skipped:   '#9ca3af',
+  waiting_approval: '#f97316',
+};
+
+function statusDot(status: string): string {
+  return STATUS_COLOR[status] ?? '#3a3a5e';
+}
+
+function formatDuration(startedAt?: string, completedAt?: string): string | null {
+  if (!startedAt || !completedAt) return null;
+  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
 
 interface Props { runId: string; }
 
 export function RunStepTimeline({ runId }: Props) {
-  const { steps, runStatus, error } = useRealtimeRun(runId);
+  const { runStatus, steps, error, reconnect } = useRealtimeRun(runId);
 
-  if (error) {
-    return <div style={{ color: '#ef4444', padding: 16 }}>SSE error: {error}</div>;
+  // Convertir Map<string, StepUpdate> → array ordenado por startedAt
+  const stepsArray = Array.from(steps.values()).sort((a, b) => {
+    if (!a.startedAt && !b.startedAt) return 0;
+    if (!a.startedAt) return 1;
+    if (!b.startedAt) return -1;
+    return new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime();
+  });
+
+  if (error && stepsArray.length === 0) {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 10,
+        padding: '12px 16px', color: '#ef4444', fontSize: 13,
+        border: '1px solid #fee2e2', borderRadius: 8, background: '#fff1f2',
+      }}>
+        <span>SSE error: {error}</span>
+        <button
+          type="button"
+          onClick={() => reconnect()}
+          style={{
+            marginLeft: 'auto', fontSize: 12, padding: '4px 10px',
+            borderRadius: 6, border: '1px solid #fca5a5',
+            background: '#fee2e2', color: '#dc2626', cursor: 'pointer',
+          }}
+        >
+          Reconectar
+        </button>
+      </div>
+    );
   }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 0, padding: '8px 0' }}>
+      {/* Header con runId y estado general */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '0 16px 12px' }}>
         <span style={{ fontSize: 13, color: '#888' }}>Run</span>
-        <code style={{ fontSize: 11, color: '#6366f1', background: '#1e1e2e', padding: '1px 6px', borderRadius: 4 }}>
+        <code style={{
+          fontSize: 11, color: '#6366f1',
+          background: '#1e1e2e', padding: '1px 6px', borderRadius: 4,
+        }}>
           {runId.slice(0, 8)}
         </code>
-        <AgentCostBadge
-          status={runStatus as 'idle' | 'running' | 'done' | 'error'}
-          compact
-        />
+        <span style={{
+          fontSize: 11, fontWeight: 600,
+          color: STATUS_COLOR[runStatus] ?? '#888',
+          background: '#1e1e2e', padding: '1px 8px', borderRadius: 10,
+        }}>
+          {runStatus}
+        </span>
+        {error && (
+          <span style={{ fontSize: 11, color: '#f97316', marginLeft: 4 }}>⚠ polling</span>
+        )}
       </div>
 
-      {steps.length === 0 && (
+      {stepsArray.length === 0 && (
         <div style={{ padding: '12px 16px', color: '#666', fontSize: 13 }}>Waiting for steps…</div>
       )}
 
-      {steps.map((step, idx) => (
-        <div
-          key={step.stepId}
-          style={{
-            display: 'flex', gap: 12, padding: '8px 16px',
-            borderBottom: '1px solid #2a2a3e',
-            background: idx % 2 === 0 ? 'transparent' : '#1a1a2a',
-          }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: 16 }}>
-            <div
-              style={{
-                width: 10, height: 10, borderRadius: '50%', flexShrink: 0,
-                background:
-                  step.status === 'done'    ? '#22c55e' :
-                  step.status === 'error'   ? '#ef4444' :
-                  step.status === 'running' ? '#f59e0b' : '#3a3a5e',
-              }}
-            />
-            {idx < steps.length - 1 && (
-              <div style={{ width: 1, flex: 1, background: '#3a3a5e', marginTop: 2 }} />
-            )}
-          </div>
+      {stepsArray.map((step, idx) => {
+        const duration = formatDuration(step.startedAt, step.completedAt);
 
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-              <span style={{ color: '#e0e0f0', fontSize: 13, fontWeight: 500 }}>
-                {step.agentName ?? step.nodeId ?? `Step ${idx + 1}`}
-              </span>
-              {step.nodeKind && (
-                <span style={{ fontSize: 11, color: '#888', background: '#2a2a3e', padding: '1px 6px', borderRadius: 4 }}>
-                  {step.nodeKind}
-                </span>
+        return (
+          <div
+            key={step.stepId}
+            style={{
+              display: 'flex', gap: 12, padding: '8px 16px',
+              borderBottom: '1px solid #2a2a3e',
+              background: idx % 2 === 0 ? 'transparent' : '#1a1a2a',
+            }}
+          >
+            {/* Dot + conector vertical */}
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: 16 }}>
+              <div style={{
+                width: 10, height: 10, borderRadius: '50%', flexShrink: 0,
+                background: statusDot(step.status),
+              }} />
+              {idx < stepsArray.length - 1 && (
+                <div style={{ width: 1, flex: 1, background: '#3a3a5e', marginTop: 2 }} />
               )}
-              <AgentCostBadge
-                status={step.status as 'idle' | 'running' | 'done' | 'error' | 'pending_approval'}
-                tokensUsed={step.tokensUsed}
-                costUsd={step.costUsd}
-                durationMs={step.durationMs}
-                compact
-              />
             </div>
 
-            {step.output && (
-              <div style={{ marginTop: 4, color: '#a0a0b0', fontSize: 12, lineHeight: 1.5 }}>
-                {typeof step.output === 'string'
-                  ? step.output.slice(0, 200) + (step.output.length > 200 ? '…' : '')
-                  : JSON.stringify(step.output).slice(0, 200)}
-              </div>
-            )}
+            {/* Contenido del step */}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                {/* Nombre: agentId si existe, o nodeId */}
+                <span style={{ color: '#e0e0f0', fontSize: 13, fontWeight: 500 }}>
+                  {step.agentId ?? step.nodeId ?? `Step ${idx + 1}`}
+                </span>
 
-            {step.error && (
-              <div style={{ marginTop: 4, color: '#ef4444', fontSize: 12 }}>{step.error}</div>
-            )}
+                {/* Tipo de nodo */}
+                {step.nodeType && (
+                  <span style={{
+                    fontSize: 11, color: '#888', background: '#2a2a3e',
+                    padding: '1px 6px', borderRadius: 4,
+                  }}>
+                    {step.nodeType}
+                  </span>
+                )}
+
+                {/* Duración */}
+                {duration && (
+                  <span style={{ fontSize: 11, color: '#6b7280' }}>{duration}</span>
+                )}
+
+                {/* Tokens */}
+                {step.tokenUsage && (
+                  <span style={{ fontSize: 11, color: '#9ca3af' }}>
+                    {step.tokenUsage.input + step.tokenUsage.output} tok
+                  </span>
+                )}
+
+                {/* Costo */}
+                {step.costUsd != null && (
+                  <span style={{ fontSize: 11, color: '#a3a3a3' }}>
+                    ${step.costUsd.toFixed(4)}
+                  </span>
+                )}
+
+                {/* Retries */}
+                {step.retryCount != null && step.retryCount > 0 && (
+                  <span style={{ fontSize: 11, color: '#f97316' }}>
+                    ×{step.retryCount} retry
+                  </span>
+                )}
+              </div>
+
+              {/* Error inline */}
+              {step.error && (
+                <div style={{ marginTop: 4, color: '#ef4444', fontSize: 12 }}>{step.error}</div>
+              )}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/features/runs/useRealtimeRun.ts
+++ b/apps/web/src/features/runs/useRealtimeRun.ts
@@ -2,6 +2,7 @@
  * useRealtimeRun.ts
  *
  * React hook for consuming SSE run updates in real time.
+ * Falls back to polling if SSE is unavailable (no /runs/stream endpoint).
  *
  * Patterns adapted from:
  *   - Flowise: useStreamChat hook (EventSource consumer)
@@ -10,12 +11,12 @@
  *   - Semantic Kernel: StreamingKernelContent client
  *
  * Usage:
- *   const { events, status, steps } = useRealtimeRun(runId);
+ *   const { events, status, runStatus, steps } = useRealtimeRun(runId);
  *
  * Automatically:
- *   - Opens EventSource on mount
+ *   - Attempts SSE first; falls back to polling (2 500 ms) if SSE fails
  *   - Closes on terminal event (completed/failed/cancelled)
- *   - Reconnects on transient disconnect (exponential backoff)
+ *   - Reconnects on transient disconnect (exponential backoff, max 5 attempts)
  *   - Cleans up on unmount
  */
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -38,6 +39,7 @@ export type RealtimeRunStatus =
   | 'cancelled'
   | 'error';
 
+/** Campos reales de StepUpdate — alineados con RunStep de core-types/run-spec */
 export interface StepUpdate {
   stepId: string;
   nodeId: string;
@@ -48,11 +50,20 @@ export interface StepUpdate {
   tokenUsage?: { input: number; output: number };
   startedAt?: string;
   completedAt?: string;
+  error?: string;
+  retryCount?: number;
 }
 
 export interface UseRealtimeRunResult {
+  /** Estado actual de la conexión SSE / polling */
   status: RealtimeRunStatus;
+  /**
+   * Alias de `status` — mantenido para compatibilidad con RunStepTimeline
+   * y otros consumidores que usen el nombre `runStatus`.
+   */
+  runStatus: RealtimeRunStatus;
   events: RunStreamEvent[];
+  /** Mapa stepId → StepUpdate con los campos reales de RunStep */
   steps: Map<string, StepUpdate>;
   lastEvent: RunStreamEvent | null;
   error: string | null;
@@ -64,6 +75,7 @@ export interface UseRealtimeRunResult {
 const TERMINAL_EVENTS = new Set(['completed', 'failed', 'cancelled']);
 const MAX_RECONNECT_ATTEMPTS = 5;
 const BASE_RECONNECT_MS = 1_000;
+const POLL_INTERVAL_MS = 2_500;
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
@@ -89,11 +101,23 @@ export function useRealtimeRun(
   const [steps, setSteps] = useState<Map<string, StepUpdate>>(new Map());
   const [lastEvent, setLastEvent] = useState<RunStreamEvent | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // true cuando SSE falló y estamos en modo polling
+  const [pollingMode, setPollingMode] = useState(false);
 
   const esRef = useRef<EventSource | null>(null);
   const reconnectAttempt = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const isMounted = useRef(true);
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, []);
 
   const cleanup = useCallback(() => {
     esRef.current?.close();
@@ -102,7 +126,71 @@ export function useRealtimeRun(
       clearTimeout(reconnectTimer.current);
       reconnectTimer.current = null;
     }
-  }, []);
+    stopPolling();
+  }, [stopPolling]);
+
+  // ── Polling fallback ───────────────────────────────────────────────────────
+  // Llama a GET /runs/:runId y sintetiza StepUpdate desde RunSpec.steps
+
+  const startPolling = useCallback(() => {
+    if (!runId || !isMounted.current) return;
+    setPollingMode(true);
+    setStatus('connected'); // polling activo = conexión funcional
+
+    const fetchRun = async () => {
+      try {
+        const res = await fetch(`${apiBase}/api/studio/v1/runs/${runId}`);
+        if (!res.ok) return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const run = await res.json() as any;
+        if (!isMounted.current) return;
+
+        // Mapear RunSpec.steps[] → Map<stepId, StepUpdate>
+        if (Array.isArray(run.steps)) {
+          setSteps(() => {
+            const next = new Map<string, StepUpdate>();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            for (const s of run.steps as any[]) {
+              next.set(s.id as string, {
+                stepId: s.id as string,
+                nodeId: (s.nodeId as string) ?? '',
+                nodeType: s.nodeType as string | undefined,
+                agentId: s.agentId as string | undefined,
+                status: s.status as string,
+                costUsd: s.costUsd as number | undefined,
+                tokenUsage: s.tokenUsage as { input: number; output: number } | undefined,
+                startedAt: s.startedAt as string | undefined,
+                completedAt: s.completedAt as string | undefined,
+                error: s.error as string | undefined,
+                retryCount: s.retryCount as number | undefined,
+              });
+            }
+            return next;
+          });
+        }
+
+        // Actualizar status general desde RunSpec.status
+        const runStatus = run.status as string;
+        if (runStatus === 'queued') setStatus('queued');
+        else if (runStatus === 'running') setStatus('processing');
+        else if (runStatus === 'completed') setStatus('completed');
+        else if (runStatus === 'failed') setStatus('failed');
+        else if (runStatus === 'cancelled') setStatus('cancelled');
+
+        // Detener polling si el run terminó
+        if (TERMINAL_EVENTS.has(runStatus)) {
+          stopPolling();
+        }
+      } catch {
+        // silencioso — el polling reintentará en el siguiente tick
+      }
+    };
+
+    void fetchRun();
+    pollTimer.current = setInterval(() => void fetchRun(), POLL_INTERVAL_MS);
+  }, [runId, apiBase, stopPolling]);
+
+  // ── SSE connection ─────────────────────────────────────────────────────────
 
   const connect = useCallback(() => {
     if (!runId || !isMounted.current) return;
@@ -110,6 +198,7 @@ export function useRealtimeRun(
     cleanup();
     setStatus('connecting');
     setError(null);
+    setPollingMode(false);
 
     const url = `${apiBase}/api/studio/v1/runs/${runId}/stream`;
     const es = new EventSource(url);
@@ -139,14 +228,14 @@ export function useRealtimeRun(
 
       options?.onEvent?.(payload);
 
-      // Update status
+      // Actualizar status
       if (payload.event === 'queued') setStatus('queued');
       else if (payload.event === 'started') setStatus('processing');
       else if (payload.event === 'completed') setStatus('completed');
       else if (payload.event === 'failed') setStatus('failed');
       else if (payload.event === 'cancelled') setStatus('cancelled');
 
-      // Update step map (LangGraph stream node output pattern)
+      // Actualizar step map — campos reales de StepUpdate / RunStep
       if (payload.event?.startsWith('step:') && typeof payload.stepId === 'string') {
         setSteps((prev) => {
           const next = new Map(prev);
@@ -162,12 +251,14 @@ export function useRealtimeRun(
             tokenUsage: (payload.tokenUsage as StepUpdate['tokenUsage']) ?? existing.tokenUsage,
             startedAt: (payload.startedAt as string | undefined) ?? existing.startedAt,
             completedAt: (payload.completedAt as string | undefined) ?? existing.completedAt,
+            error: (payload.error as string | undefined) ?? existing.error,
+            retryCount: (payload.retryCount as number | undefined) ?? existing.retryCount,
           });
           return next;
         });
       }
 
-      // Auto-close on terminal events
+      // Cerrar SSE en eventos terminales
       if (TERMINAL_EVENTS.has(payload.event)) {
         cleanup();
       }
@@ -177,17 +268,20 @@ export function useRealtimeRun(
       if (!isMounted.current) return;
 
       cleanup();
-      setStatus('error');
       setError('SSE connection lost');
 
-      // Exponential backoff reconnect
       if (reconnectAttempt.current < MAX_RECONNECT_ATTEMPTS) {
+        // Reintento con backoff exponencial
         const delay = BASE_RECONNECT_MS * 2 ** reconnectAttempt.current;
         reconnectAttempt.current += 1;
         reconnectTimer.current = setTimeout(connect, delay);
+      } else {
+        // SSE agotó reintentos → cambiar a modo polling
+        setStatus('error');
+        startPolling();
       }
     };
-  }, [runId, apiBase, maxEvents, options, cleanup]);
+  }, [runId, apiBase, maxEvents, options, cleanup, startPolling]);
 
   useEffect(() => {
     isMounted.current = true;
@@ -198,5 +292,13 @@ export function useRealtimeRun(
     };
   }, [runId, connect, cleanup]);
 
-  return { status, events, steps, lastEvent, error, reconnect: connect };
+  return {
+    status,
+    runStatus: status, // alias para compatibilidad con RunStepTimeline
+    events,
+    steps,
+    lastEvent,
+    error,
+    reconnect: connect,
+  };
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -63,3 +63,16 @@ export type CoreFilesPreviewResponse = { snapshotId?: string; artifacts: unknown
 
 export * from './types-base';
 export type * from '../../../../packages/core-types/src/studio-canonical';
+
+// ── Run types ────────────────────────────────────────────────────────────────
+// Re-exportados desde core-types/run-spec para que todos los consumidores
+// (RunsPage, RunTimeline, StepDetail, ApprovalPanel, etc.) importen
+// desde el barrel unificado '@/lib/types'.
+export type {
+  RunSpec,
+  RunStep,
+  RunStatus,
+  StepStatus,
+  RunTrigger,
+  RunStepTokenUsage,
+} from '../../../../packages/core-types/src/run-spec';


### PR DESCRIPTION
## Qué corrige este PR

### Bug 1 — `steps.map is not a function` (runtime crash)
`useRealtimeRun` devuelve `steps` como `Map<string, StepUpdate>`, pero `RunStepTimeline` lo usaba directamente con `.map()` (método de Array). 
**Fix:** `Array.from(steps.values())` con sort por `startedAt`.

### Bug 2 — `runStatus` undefined (campo incorrecto)
`RunStepTimeline` desestructuraba `{ runStatus }` del hook, pero el hook sólo exponía `status`.
**Fix:** `useRealtimeRun` ahora exporta `runStatus` como alias directo de `status` en `UseRealtimeRunResult`.

### Bug 3 — Campos fantasma en `StepUpdate`
`RunStepTimeline` accedía a `step.agentName`, `step.nodeKind`, `step.tokensUsed`, `step.durationMs` — ninguno de estos existe en `StepUpdate` ni en `RunStep` de `core-types`.
**Fix:** Reemplazados por los campos reales:
- `step.agentId` (muestra agente o nodeId como fallback)
- `step.nodeType` (tipo del nodo)
- `step.tokenUsage.input + output` (tokens totales)
- `step.costUsd` (costo)
- `step.retryCount` (reintentos)
- `formatDuration(step.startedAt, step.completedAt)` (duración calculada)

### Mejora — Polling fallback
Cuando SSE agota los 5 reintentos, el hook activa automáticamente polling cada 2 500 ms sobre `GET /runs/:runId`, sintetizando `StepUpdate` desde `RunSpec.steps[]`. Banner visual en `RunStepTimeline` cuando se está en modo polling.

### Fix — `lib/types.ts` barrel incompleto
Los archivos `RunsPage.tsx`, `RunTimeline.tsx`, `StepDetail.tsx` importan `RunSpec`/`RunStep` desde `../../../lib/types`, pero ese barrel no los exportaba.
**Fix:** Añadido `export type { RunSpec, RunStep, RunStatus, StepStatus, RunTrigger, RunStepTokenUsage }` re-exportando desde `packages/core-types/src/run-spec`.

## Archivos modificados

| Archivo | Tipo de cambio |
|---|---|
| `apps/web/src/features/runs/useRealtimeRun.ts` | fix + mejora polling fallback |
| `apps/web/src/features/runs/RunStepTimeline.tsx` | fix completo de campos |
| `apps/web/src/lib/types.ts` | re-export RunSpec/RunStep barrel |

## Verificación
- [ ] `RunStepTimeline` monta sin crash cuando `steps` está vacío
- [ ] Steps se renderizan cuando SSE emite eventos `step:*`
- [ ] Polling activa tras 5 fallos SSE y muestra banner `⚠ polling`
- [ ] `RunsPage` importa `RunSpec`/`RunStep` sin errores TS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic polling fallback when real-time connection is unavailable
  * Enhanced step timeline display with improved status indicators and duration information
  * Added manual reconnect button and polling status indicator for better visibility

* **Improvements**
  * Refined error handling with inline notifications instead of blocking errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->