### PR TITLE
feat(F6b-01): integrar agency-agents como git submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Initialize submodules (fallback)
+        run: git submodule update --init --recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+        working-directory: apps/api
+
+      - name: TypeScript check (api)
+        run: npx tsc --noEmit
+        working-directory: apps/api
+
+      - name: Verify agency-agents submodule
+        run: |
+          test -d vendor/agency-agents/engineering && echo "OK: vendor/agency-agents/engineering exists"
+          find vendor/agency-agents/engineering -name "*.md" | head -5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/agency-agents"]
+	path = vendor/agency-agents
+	url = https://github.com/msitarzewski/agency-agents

--- a/README.md
+++ b/README.md
@@ -8,6 +8,41 @@ Plataforma de gestión de agentes IA, flujos, canales de mensajería y workspace
 
 ---
 
+## Clonado con Submódulos
+
+Este repositorio usa **git submodules**. Si clonas sin inicializarlos, `vendor/agency-agents/` quedará vacía.
+
+### Clonar desde cero (recomendado)
+
+```bash
+git clone --recurse-submodules https://github.com/lssmanager/agent-visualstudio
+```
+
+### Si ya clonaste sin submódulos
+
+```bash
+git submodule update --init --recursive
+```
+
+### Qué contiene `vendor/agency-agents/`
+
+Repositorio externo [`msitarzewski/agency-agents`](https://github.com/msitarzewski/agency-agents) con templates de agentes por departamento:
+
+```
+vendor/agency-agents/
+  engineering/           ← departamento de ingeniería
+    engineering-code-reviewer.md
+    ...
+  marketing/
+  ...
+```
+
+- Cada **carpeta** = un departamento
+- Cada **archivo `.md`** = un template de agente
+- Estos templates se usarán como presets del canvas en fases posteriores (F6b)
+
+---
+
 ## Arquitectura
 
 ```
@@ -280,7 +315,10 @@ La selección del backend se hace en el módulo de bootstrap del API. Para produ
 ├── templates/
 │   ├── profiles/                          ← .md + .json sidecar files
 │   └── workspaces/                        ← Plantillas de rutinas
+├── vendor/
+│   └── agency-agents/                     ← git submodule (msitarzewski/agency-agents)
 ├── .env.example
+├── .gitmodules
 ├── package.json
 ├── tsconfig.json
 └── nixpacks.toml


### PR DESCRIPTION
## Descripción

Integra [`msitarzewski/agency-agents`](https://github.com/msitarzewski/agency-agents) como git submodule bajo `vendor/agency-agents/`.

Este es el primer entregable de la subfase **F6b — Agency Agents Templates**, que prepara la base de infra/DX para que fases posteriores puedan leer departamentos y templates `.md` desde `vendor/agency-agents/` y exponerlos como presets del canvas.

## Cambios

### `.gitmodules`
- Registra `vendor/agency-agents` apuntando a `https://github.com/msitarzewski/agency-agents`

### `.github/workflows/ci.yml` (nuevo)
- Checkout con `submodules: recursive` via `actions/checkout@v4`
- Paso adicional `git submodule update --init --recursive` como fallback
- Step de verificación: confirma que `vendor/agency-agents/engineering/` existe y contiene `.md`

### `README.md`
- Nueva sección **"Clonado con Submódulos"** con instrucciones operativas:
  - `git clone --recurse-submodules` para clonar desde cero
  - `git submodule update --init --recursive` para repos ya clonados
  - Descripción de qué contiene `vendor/agency-agents/`
- `vendor/agency-agents/` añadido al árbol de estructura de archivos

## Criterio de aceptación

- [x] `.gitmodules` registrado correctamente
- [x] CI inicializa submodules con `submodules: recursive`
- [x] README documenta clonado con submodules
- [x] Commit en rama de fase + push

## Notas

- Esta tarea **no** incluye UI, parsers ni loaders de templates.
- La lectura de `.md` para el canvas pertenece a la siguiente tarea F6b.

Closes #276