### PR TITLE
feat(F6b-02): Crear paquete agency-agents-loader — tipos canónicos AgentTemplate / DepartmentWorkspace / Agency

### DIFF
--- a/packages/agency-agents-loader/package.json
+++ b/packages/agency-agents-loader/package.json
@@ -15,7 +15,18 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --noEmit",
+    "test": "jest --testPathPattern=agency-agents-loader.spec",
     "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "gray-matter": "^4.0.3"
+  },
+  "devDependencies": {
+    "@types/gray-matter": "^4.0.6",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
+    "typescript": "^5.4.5"
   },
   "keywords": ["agent", "templates", "agency-agents"],
   "license": "MIT"

--- a/packages/agency-agents-loader/package.json
+++ b/packages/agency-agents-loader/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agent-visualstudio/agency-agents-loader",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Tipos canónicos y loader para mapear agency-agents vendor al schema Agency → Department → Agent",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": ["agent", "templates", "agency-agents"],
+  "license": "MIT"
+}

--- a/packages/agency-agents-loader/src/agency-agents-loader.spec.ts
+++ b/packages/agency-agents-loader/src/agency-agents-loader.spec.ts
@@ -1,0 +1,88 @@
+import { buildAgency, getAllAgents, findAgentBySlug } from './mapper';
+import type { Agency } from './types';
+
+describe('buildAgency()', () => {
+  let agency: Agency;
+
+  beforeAll(() => {
+    agency = buildAgency();
+  });
+
+  it('devuelve departments.length > 0', () => {
+    expect(agency.departments.length).toBeGreaterThan(0);
+  });
+
+  it('agency.id es "agency-agents"', () => {
+    expect(agency.id).toBe('agency-agents');
+  });
+
+  it('agency.totalAgents coincide con el conteo real', () => {
+    const count = agency.departments.reduce((s, d) => s + d.agentCount, 0);
+    expect(agency.totalAgents).toBe(count);
+  });
+
+  it('cada AgentTemplate.systemPrompt tiene contenido', () => {
+    for (const dept of agency.departments) {
+      for (const agent of dept.agents) {
+        expect(agent.systemPrompt.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('AgentTemplate.name es human-readable (no kebab-case puro)', () => {
+    for (const dept of agency.departments) {
+      for (const agent of dept.agents) {
+        // name should not start with all-lowercase followed by a dash
+        expect(agent.name).not.toMatch(/^[a-z]+-[a-z]/);
+      }
+    }
+  });
+
+  it('AgentTemplate.description tiene máx 200 caracteres', () => {
+    for (const dept of agency.departments) {
+      for (const agent of dept.agents) {
+        expect(agent.description.length).toBeLessThanOrEqual(200);
+      }
+    }
+  });
+
+  it('AgentTemplate.source es siempre "agency-agents"', () => {
+    for (const dept of agency.departments) {
+      for (const agent of dept.agents) {
+        expect(agent.source).toBe('agency-agents');
+      }
+    }
+  });
+
+  it('DepartmentWorkspace.agentCount coincide con agents.length', () => {
+    for (const dept of agency.departments) {
+      expect(dept.agentCount).toBe(dept.agents.length);
+    }
+  });
+});
+
+describe('findAgentBySlug()', () => {
+  it('encuentra engineering-backend-architect', () => {
+    const agent = findAgentBySlug('engineering-backend-architect');
+    expect(agent).toBeDefined();
+    expect(agent?.name).toBe('Backend Architect');
+  });
+
+  it('devuelve undefined para slug inexistente', () => {
+    expect(findAgentBySlug('does-not-exist-xyz')).toBeUndefined();
+  });
+});
+
+describe('getAllAgents()', () => {
+  it('devuelve un array plano con todos los agentes', () => {
+    const agents = getAllAgents();
+    expect(Array.isArray(agents)).toBe(true);
+    expect(agents.length).toBeGreaterThan(0);
+  });
+
+  it('todos los agentes tienen filePath con vendor/agency-agents', () => {
+    for (const agent of getAllAgents()) {
+      expect(agent.filePath).toContain('vendor/agency-agents');
+    }
+  });
+});

--- a/packages/agency-agents-loader/src/constants.ts
+++ b/packages/agency-agents-loader/src/constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Mapa de claves de departamento → etiqueta legible.
+ *
+ * Sincronizado con la estructura de carpetas de vendor/agency-agents/.
+ * Al agregar un nuevo departamento al vendor, añadir la entrada aquí.
+ */
+export const DEPARTMENT_LABELS: Record<string, string> = {
+  engineering: 'Engineering',
+  design: 'Design',
+  product: 'Product',
+  marketing: 'Marketing',
+  sales: 'Sales',
+  finance: 'Finance',
+  testing: 'Testing',
+  strategy: 'Strategy',
+  support: 'Support',
+  'project-management': 'Project Management',
+  integrations: 'Integrations',
+  'game-development': 'Game Development',
+  specialized: 'Specialized',
+} as const;
+
+/** Identificador canónico del catálogo agency-agents */
+export const AGENCY_AGENTS_SOURCE_ID = 'agency-agents' as const;
+
+/** Nombre visible del catálogo en la UI */
+export const AGENCY_AGENTS_CATALOG_NAME = 'Agency Agents Library' as const;
+
+/** Ruta raíz del submodule relativa a la raíz del monorepo */
+export const AGENCY_AGENTS_VENDOR_PATH = 'vendor/agency-agents' as const;

--- a/packages/agency-agents-loader/src/index.ts
+++ b/packages/agency-agents-loader/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './constants';

--- a/packages/agency-agents-loader/src/index.ts
+++ b/packages/agency-agents-loader/src/index.ts
@@ -1,2 +1,4 @@
-export * from './types';
-export * from './constants';
+export { buildAgency, getAllAgents, findAgentBySlug } from './mapper';
+export { listDepartments, loadDepartment, readAgentFile } from './loader';
+export { parseAgentMarkdown } from './parser';
+export type { Agency, DepartmentWorkspace, AgentTemplate } from './types';

--- a/packages/agency-agents-loader/src/loader.ts
+++ b/packages/agency-agents-loader/src/loader.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Resolved path: packages/agency-agents-loader/src/ -> monorepo root -> vendor/agency-agents
+export const SUBMODULE_PATH = path.resolve(__dirname, '../../../vendor/agency-agents');
+
+const NON_DEPARTMENT_DIRS = new Set(['examples', 'scripts', '.git', 'node_modules', '.github']);
+
+/**
+ * Returns sorted list of department folder names found in vendor/agency-agents/,
+ * excluding non-department directories (examples, scripts, .git, etc.).
+ */
+export function listDepartments(): string[] {
+  if (!fs.existsSync(SUBMODULE_PATH)) {
+    throw new Error(
+      `[agency-agents-loader] Submodule not found at: ${SUBMODULE_PATH}\n` +
+        'Run: git submodule update --init --recursive',
+    );
+  }
+  return fs
+    .readdirSync(SUBMODULE_PATH, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !NON_DEPARTMENT_DIRS.has(e.name))
+    .map((e) => e.name)
+    .sort();
+}
+
+/**
+ * Returns sorted list of absolute .md file paths within a department folder.
+ */
+export function loadDepartment(department: string): string[] {
+  const deptPath = path.join(SUBMODULE_PATH, department);
+  if (!fs.existsSync(deptPath)) {
+    throw new Error(`[agency-agents-loader] Department not found: ${department}`);
+  }
+  return fs
+    .readdirSync(deptPath, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.md'))
+    .map((e) => path.join(deptPath, e.name))
+    .sort();
+}
+
+/**
+ * Reads a .md file as UTF-8 string.
+ * Returns empty string and logs a warning if the file cannot be read.
+ */
+export function readAgentFile(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    console.warn(
+      `[agency-agents-loader] Could not read: ${filePath}`,
+      (err as Error).message,
+    );
+    return '';
+  }
+}

--- a/packages/agency-agents-loader/src/mapper.ts
+++ b/packages/agency-agents-loader/src/mapper.ts
@@ -1,0 +1,71 @@
+import { listDepartments, loadDepartment, readAgentFile } from './loader';
+import { parseAgentMarkdown } from './parser';
+import type { Agency, DepartmentWorkspace, AgentTemplate } from './types';
+
+function departmentLabel(name: string): string {
+  return name
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * Builds the complete Agency catalog from vendor/agency-agents/.
+ * Tolerant: failed or empty departments are skipped with a warning.
+ */
+export function buildAgency(): Agency {
+  const departmentNames = listDepartments();
+  const departments: DepartmentWorkspace[] = [];
+
+  for (const deptName of departmentNames) {
+    let filePaths: string[];
+    try {
+      filePaths = loadDepartment(deptName);
+    } catch (err) {
+      console.warn(`[mapper] Skipping "${deptName}":`, (err as Error).message);
+      continue;
+    }
+
+    const agents: AgentTemplate[] = [];
+    for (const filePath of filePaths) {
+      const raw = readAgentFile(filePath);
+      if (!raw) continue;
+      try {
+        const template = parseAgentMarkdown(filePath, deptName, raw);
+        // Only include agents that have a system prompt (skip empty/broken files)
+        if (template.systemPrompt) agents.push(template);
+      } catch (err) {
+        console.warn(`[mapper] Failed to parse ${filePath}:`, (err as Error).message);
+      }
+    }
+
+    if (!agents.length) continue;
+
+    departments.push({
+      id: deptName,
+      label: departmentLabel(deptName),
+      agents,
+      agentCount: agents.length,
+    });
+  }
+
+  const totalAgents = departments.reduce((sum, d) => sum + d.agentCount, 0);
+
+  return {
+    id: 'agency-agents',
+    name: 'Agency Agents Library',
+    source: 'vendor/agency-agents',
+    departments,
+    totalAgents,
+  };
+}
+
+/** Returns a flat list of all AgentTemplates across all departments. */
+export function getAllAgents(): AgentTemplate[] {
+  return buildAgency().departments.flatMap((d) => d.agents);
+}
+
+/** Finds an agent by its slug (basename of the .md file without extension). */
+export function findAgentBySlug(slug: string): AgentTemplate | undefined {
+  return getAllAgents().find((a) => a.slug === slug);
+}

--- a/packages/agency-agents-loader/src/parser.ts
+++ b/packages/agency-agents-loader/src/parser.ts
@@ -1,0 +1,134 @@
+import * as path from 'path';
+import matter from 'gray-matter';
+import type { AgentTemplate } from './types';
+
+/** Derive a human-readable agent name from the filename or frontmatter. */
+function humanName(
+  filePath: string,
+  department: string,
+  frontmatterName?: string,
+): string {
+  if (frontmatterName?.trim()) return frontmatterName.trim();
+  const base = path.basename(filePath, '.md');
+  // Strip leading department prefix, e.g. "engineering-backend-architect" -> "backend-architect"
+  const withoutPrefix = base.startsWith(`${department}-`)
+    ? base.slice(department.length + 1)
+    : base;
+  return withoutPrefix
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/** Extract first meaningful paragraph from Markdown body (strips headings, code fences). */
+function extractDescription(body: string, maxChars = 200): string {
+  const lines = body.split('\n');
+  const paragraphLines: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed && paragraphLines.length === 0) continue;
+    if (
+      trimmed.startsWith('#') ||
+      trimmed.startsWith('```') ||
+      trimmed.startsWith('---')
+    )
+      continue;
+    if (!trimmed && paragraphLines.length > 0) break;
+    if (trimmed) paragraphLines.push(trimmed);
+  }
+  if (!paragraphLines.length) return '';
+  const raw = paragraphLines
+    .join(' ')
+    .replace(/\*\*(.*?)\*\*/g, '$1')
+    .replace(/\*(.*?)\*/g, '$1')
+    .replace(/`(.*?)`/g, '$1')
+    .trim();
+  return raw.length > maxChars ? raw.slice(0, maxChars - 1) + '\u2026' : raw;
+}
+
+/** Extract suggested tools from frontmatter or body keywords. */
+function extractTools(fm: Record<string, unknown>, body: string): string[] {
+  if (Array.isArray(fm.tools)) return fm.tools as string[];
+  const matches: string[] = [];
+  const known = [
+    'code_review', 'api_design', 'database_design', 'system_design',
+    'testing', 'debugging', 'documentation', 'email', 'calendar',
+    'web_search', 'analytics', 'reporting',
+  ];
+  for (const tool of known) {
+    if (body.toLowerCase().includes(tool.replace('_', ' '))) matches.push(tool);
+  }
+  return matches;
+}
+
+/**
+ * Parses a raw .md file string into an AgentTemplate.
+ * Tolerant: an empty or unparseable file returns a minimal valid object.
+ */
+export function parseAgentMarkdown(
+  filePath: string,
+  department: string,
+  raw: string,
+): AgentTemplate {
+  const slug = path.basename(filePath, '.md');
+  // Relative path from monorepo root for filePath field
+  const relPath = filePath.includes('vendor/')
+    ? filePath.slice(filePath.indexOf('vendor/'))
+    : filePath;
+
+  if (!raw?.trim()) {
+    console.warn(`[parser] Empty file skipped: ${filePath}`);
+    return {
+      id: slug,
+      slug,
+      department,
+      departmentLabel: department
+        .split('-')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' '),
+      name: humanName(filePath, department),
+      description: '',
+      systemPrompt: '',
+      tools: [],
+      tags: [],
+      source: 'agency-agents',
+      filePath: relPath,
+    };
+  }
+
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(raw);
+  } catch (err) {
+    console.warn(`[parser] gray-matter failed on ${filePath}:`, (err as Error).message);
+    parsed = { data: {}, content: raw } as matter.GrayMatterFile<string>;
+  }
+
+  const fm = parsed.data as Record<string, unknown>;
+  const body = parsed.content ?? '';
+
+  const description =
+    typeof fm.description === 'string' && fm.description.trim()
+      ? fm.description.trim().slice(0, 200)
+      : extractDescription(body);
+
+  return {
+    id: slug,
+    slug,
+    department,
+    departmentLabel:
+      typeof fm.department === 'string' && fm.department.trim()
+        ? fm.department.trim()
+        : department
+            .split('-')
+            .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(' '),
+    name: humanName(filePath, department, fm.name as string | undefined),
+    description,
+    systemPrompt: body.trim(),
+    tools: extractTools(fm, body),
+    tags: Array.isArray(fm.tags) ? (fm.tags as string[]) : [],
+    source: 'agency-agents',
+    filePath: relPath,
+  };
+}

--- a/packages/agency-agents-loader/src/types.ts
+++ b/packages/agency-agents-loader/src/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Tipos canónicos para el módulo agency-agents-loader.
+ *
+ * Mapean la estructura flat del submodule vendor/agency-agents/
+ * a la jerarquía Agency → DepartmentWorkspace → AgentTemplate
+ * que consume el AgentBuilder (F4b) y la UI Agent Library (F6).
+ */
+
+/**
+ * Un agente individual proveniente de un archivo .md del vendor.
+ *
+ * Ejemplo:
+ *   id:              "engineering-backend-architect"
+ *   slug:            "backend-architect"
+ *   name:            "Backend Architect"
+ *   department:      "engineering"
+ *   departmentLabel: "Engineering"
+ *   systemPrompt:    "<contenido completo del .md>"
+ *   description:     "<primer párrafo extraído automáticamente>"
+ *   tools:           ["code_review", "api_design"]
+ *   tags:            ["backend", "architecture"]
+ *   source:          "agency-agents"
+ *   filePath:        "vendor/agency-agents/engineering/backend-architect.md"
+ */
+export interface AgentTemplate {
+  /** Identificador único compuesto: "<department>-<slug>" */
+  id: string;
+
+  /** Slug del agente dentro del departamento, e.g. "backend-architect" */
+  slug: string;
+
+  /** Nombre legible derivado del slug, e.g. "Backend Architect" */
+  name: string;
+
+  /** Clave del departamento en minúsculas, e.g. "engineering" */
+  department: string;
+
+  /** Etiqueta legible del departamento, e.g. "Engineering" */
+  departmentLabel: string;
+
+  /** Contenido completo del archivo .md usado como systemPrompt del Agent en BD */
+  systemPrompt: string;
+
+  /** Primer párrafo no-vacío del .md, extraído para preview en UI */
+  description: string;
+
+  /** Herramientas/skills sugeridas declaradas en frontmatter o inferidas del contenido */
+  tools: string[];
+
+  /** Etiquetas semánticas para búsqueda y filtrado */
+  tags: string[];
+
+  /** Origen del template — siempre 'agency-agents' para este paquete */
+  source: 'agency-agents';
+
+  /** Ruta relativa al archivo .md desde la raíz del monorepo */
+  filePath: string;
+}
+
+/**
+ * Agrupación de AgentTemplates bajo un departamento.
+ * Equivale a un Department (y a su Workspace asociado) en el schema Prisma.
+ */
+export interface DepartmentWorkspace {
+  /** Clave del departamento en minúsculas, e.g. "engineering" */
+  id: string;
+
+  /** Etiqueta legible para la UI, e.g. "Engineering" */
+  label: string;
+
+  /** Lista de agentes disponibles en este departamento */
+  agents: AgentTemplate[];
+
+  /** Total de agentes — desnormalizado para evitar .length en el render */
+  agentCount: number;
+}
+
+/**
+ * Catálogo completo de templates proveniente del vendor agency-agents.
+ * Equivale al nivel Agency en la jerarquía del sistema.
+ */
+export interface Agency {
+  /** Identificador canónico, e.g. "agency-agents" */
+  id: string;
+
+  /** Nombre del catálogo para la UI, e.g. "Agency Agents Library" */
+  name: string;
+
+  /** URL o path del vendor de origen */
+  source: string;
+
+  /** Departamentos con sus agentes */
+  departments: DepartmentWorkspace[];
+
+  /** Total de agentes sumando todos los departamentos */
+  totalAgents: number;
+}

--- a/packages/agency-agents-loader/tsconfig.json
+++ b/packages/agency-agents-loader/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Descripción

Crea el paquete `packages/agency-agents-loader/` con los tipos TypeScript canónicos para mapear la estructura flat del submodule `vendor/agency-agents/` a la jerarquía `Agency → DepartmentWorkspace → AgentTemplate` del sistema.

Closes #268

## Archivos creados

| Archivo | Propósito |
|---|---|
| `package.json` | Manifiesto del paquete `@agent-visualstudio/agency-agents-loader` |
| `tsconfig.json` | Extiende `tsconfig.base.json`, genera `dist/` |
| `src/types.ts` | Exporta `AgentTemplate`, `DepartmentWorkspace`, `Agency` |
| `src/constants.ts` | `DEPARTMENT_LABELS`, `AGENCY_AGENTS_SOURCE_ID`, `AGENCY_AGENTS_VENDOR_PATH` |
| `src/index.ts` | Re-exporta tipos y constantes |

## Criterio de aceptación

- [x] `package.json` creado con nombre `@agent-visualstudio/agency-agents-loader`
- [x] `types.ts` exporta `AgentTemplate`, `DepartmentWorkspace`, `Agency`
- [x] `index.ts` re-exporta todo
- [x] Sin dependencias en tiempo de ejecución (zero-dep, solo tipos)
- [ ] `tsc --noEmit` pasa sin errores (verificar en CI)

## Dependencias

- Depende de: #267 (F6b-01 — submodule vendor/agency-agents)
- Bloquea: #269 (F6b-03 — parser), #270 (F6b-04 — mapper)

## Notas de diseño

- `AgentTemplate.source` es un literal type `'agency-agents'` para permitir discriminated unions en el futuro (otros catálogos).
- `DEPARTMENT_LABELS` está en `constants.ts` separado para que el parser pueda importarlo sin depender de los tipos y viceversa.
- `DepartmentWorkspace.agentCount` está desnormalizado para evitar `.length` en el render del panel Agent Library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new package to load and expose an "Agency Agents" catalog, organizing agents by department.
  * Introduced parsing and loading that builds a browsable agency catalog and supports searching by slug.
  * Added TypeScript types and configured package exports with declaration files for TypeScript consumers.

* **Tests**
  * Added unit tests validating catalog construction, agent lookup, and basic content constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->