### PR TITLE
feat(F6b-04): Endpoint REST agency-templates con caché en memoria

### DIFF
--- a/apps/api/src/modules/agency-templates/agency-templates.controller.ts
+++ b/apps/api/src/modules/agency-templates/agency-templates.controller.ts
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+import { AgencyTemplatesService } from './agency-templates.service';
+
+export function registerAgencyTemplatesRoutes(router: Router) {
+  // Instancia única — se crea al cargar el módulo, garantizando que
+  // buildAgency() corra al arrancar el servidor, no en el primer request.
+  const service = new AgencyTemplatesService();
+
+  /**
+   * GET /api/agency-templates
+   * Retorna el objeto Agency completo con todos los departments y agents.
+   *
+   * Response 200: Agency
+   */
+  router.get('/agency-templates', (_req, res) => {
+    res.json(service.getAgency());
+  });
+
+  /**
+   * GET /api/agency-templates/departments
+   * Lista de todos los DepartmentWorkspace disponibles.
+   *
+   * Response 200: DepartmentWorkspace[]
+   */
+  router.get('/agency-templates/departments', (_req, res) => {
+    res.json(service.getDepartments());
+  });
+
+  /**
+   * GET /api/agency-templates/departments/:departmentId/agents
+   * Agents de un department específico.
+   *
+   * Response 200: AgentTemplate[]
+   * Response 404: { ok: false, error: "Department not found: xxx" }
+   */
+  router.get('/agency-templates/departments/:departmentId/agents', (req, res) => {
+    const { departmentId } = req.params;
+    const agents = service.getAgentsByDepartment(departmentId);
+
+    if (agents === null) {
+      return res.status(404).json({
+        ok: false,
+        error: `Department not found: ${departmentId}`,
+      });
+    }
+
+    return res.json(agents);
+  });
+
+  /**
+   * GET /api/agency-templates/agents/:agentId
+   * Un AgentTemplate por su slug.
+   *
+   * Response 200: AgentTemplate
+   * Response 404: { ok: false, error: "Agent not found: xxx" }
+   */
+  router.get('/agency-templates/agents/:agentId', (req, res) => {
+    const { agentId } = req.params;
+    const agent = service.getAgentById(agentId);
+
+    if (!agent) {
+      return res.status(404).json({
+        ok: false,
+        error: `Agent not found: ${agentId}`,
+      });
+    }
+
+    return res.json(agent);
+  });
+}

--- a/apps/api/src/modules/agency-templates/agency-templates.openapi.yaml
+++ b/apps/api/src/modules/agency-templates/agency-templates.openapi.yaml
@@ -1,0 +1,88 @@
+/agency-templates:
+  get:
+    summary: Get complete Agency (all departments + agents)
+    tags: [Agency Templates]
+    responses:
+      '200':
+        description: Agency object with departments and meta
+        content:
+          application/json:
+            example:
+              departments:
+                - id: engineering
+                  name: Engineering
+                  color: blue
+                  agents:
+                    - id: engineering-backend-architect
+                      slug: engineering-backend-architect
+                      department: engineering
+                      name: Backend Architect
+                      description: Senior backend architect specializing in scalable systems
+                      emoji: "🏗️"
+                      color: blue
+                      vibe: Designs the systems that hold everything up
+                      tags: []
+              meta:
+                totalDepartments: 16
+                totalAgents: 130
+                source: vendor/agency-agents
+                generatedAt: "2026-05-03T00:00:00.000Z"
+
+/agency-templates/departments:
+  get:
+    summary: List all available departments
+    tags: [Agency Templates]
+    responses:
+      '200':
+        description: Array of DepartmentWorkspace
+        content:
+          application/json:
+            example:
+              - id: engineering
+                name: Engineering
+                color: blue
+                agents: []
+
+/agency-templates/departments/{departmentId}/agents:
+  get:
+    summary: Get agents of a specific department
+    tags: [Agency Templates]
+    parameters:
+      - in: path
+        name: departmentId
+        required: true
+        schema:
+          type: string
+        example: engineering
+    responses:
+      '200':
+        description: Array of AgentTemplate for the given department
+      '404':
+        description: Department not found
+        content:
+          application/json:
+            example:
+              ok: false
+              error: "Department not found: xyz"
+
+/agency-templates/agents/{agentId}:
+  get:
+    summary: Get a single agent by slug
+    tags: [Agency Templates]
+    parameters:
+      - in: path
+        name: agentId
+        required: true
+        schema:
+          type: string
+        example: engineering-backend-architect
+    responses:
+      '200':
+        description: AgentTemplate object
+      '404':
+        description: Agent not found
+        content:
+          application/json:
+            example:
+              ok: false
+              error: "Agent not found: does-not-exist"

--- a/apps/api/src/modules/agency-templates/agency-templates.service.ts
+++ b/apps/api/src/modules/agency-templates/agency-templates.service.ts
@@ -1,0 +1,53 @@
+import { buildAgency } from '../../../../../packages/agency-agents-loader/src';
+import type { Agency, DepartmentWorkspace, AgentTemplate } from '../../../../../packages/agency-agents-loader/src';
+
+/**
+ * AgencyTemplatesService
+ *
+ * Carga el objeto Agency UNA SOLA VEZ al instanciar el servicio.
+ * buildAgency() lee el filesystem una única vez; todas las queries
+ * posteriores se sirven desde this.agency en memoria.
+ */
+export class AgencyTemplatesService {
+  private readonly agency: Agency;
+
+  constructor() {
+    this.agency = buildAgency();
+    console.log(
+      `[agency-templates] Loaded ${this.agency.meta.totalAgents} agents` +
+      ` across ${this.agency.meta.totalDepartments} departments`,
+    );
+  }
+
+  /** GET /api/agency-templates — objeto Agency completo */
+  getAgency(): Agency {
+    return this.agency;
+  }
+
+  /** GET /api/agency-templates/departments — lista de departments */
+  getDepartments(): DepartmentWorkspace[] {
+    return this.agency.departments;
+  }
+
+  /**
+   * GET /api/agency-templates/departments/:departmentId/agents
+   * Retorna null si el department no existe (→ 404 en el controller).
+   */
+  getAgentsByDepartment(departmentId: string): AgentTemplate[] | null {
+    const dept = this.agency.departments.find((d) => d.id === departmentId);
+    return dept ? dept.agents : null;
+  }
+
+  /**
+   * GET /api/agency-templates/agents/:agentId
+   * Busca sobre la caché en memoria — NO relanza buildAgency().
+   * Retorna null si el agente no existe (→ 404 en el controller).
+   */
+  getAgentById(agentId: string): AgentTemplate | null {
+    for (const dept of this.agency.departments) {
+      const agent = dept.agents.find((a) => a.slug === agentId);
+      if (agent) return agent;
+    }
+    return null;
+  }
+}

--- a/apps/api/src/routes.ts
+++ b/apps/api/src/routes.ts
@@ -33,6 +33,7 @@ import { registerLlmProvidersRoutes } from './modules/llm-providers/llm-provider
 import { registerCatalogRoutes } from './modules/catalog/catalog.controller';
 import { registerSettingsRoutes } from './modules/settings/settings.controller';
 import { registerN8nConnectionRoutes } from './modules/n8n/n8n-connections.controller';
+import { registerAgencyTemplatesRoutes } from './modules/agency-templates/agency-templates.controller';
 
 export function registerRoutes(app: Express) {
   const router = Router();
@@ -77,6 +78,8 @@ export function registerRoutes(app: Express) {
   registerSettingsRoutes(router);
   // N8n Connections CRUD (F4a-02)
   registerN8nConnectionRoutes(router);
+  // Agency Templates — templates del submodule vendor/agency-agents (F6b-04)
+  registerAgencyTemplatesRoutes(router);
 
   app.use(studioConfig.apiPrefix, router);
 }


### PR DESCRIPTION
## F6b-04 — Endpoint REST agency-templates

### Archivos creados
- `apps/api/src/modules/agency-templates/agency-templates.service.ts` — `AgencyTemplatesService` con caché completa en constructor
- `apps/api/src/modules/agency-templates/agency-templates.controller.ts` — 4 rutas Express puro
- `apps/api/src/modules/agency-templates/agency-templates.openapi.yaml` — documentación OpenAPI de los 4 endpoints

### Archivos modificados
- `apps/api/src/routes.ts` — import + llamada a `registerAgencyTemplatesRoutes(router)`

### Endpoints implementados
| Método | Ruta | Respuesta |
|--------|------|-----------|
| GET | `/api/agency-templates` | Agency completo |
| GET | `/api/agency-templates/departments` | `DepartmentWorkspace[]` |
| GET | `/api/agency-templates/departments/:id/agents` | `AgentTemplate[]` / 404 |
| GET | `/api/agency-templates/agents/:agentId` | `AgentTemplate` / 404 |

### Criterios de aceptación
- [x] `buildAgency()` se llama UNA SOLA VEZ al arrancar el servidor
- [x] `getAgentById()` itera sobre `this.agency` — no relanza `buildAgency()`
- [x] 404 con `{ ok: false, error: "..." }` para department e agent inexistentes
- [x] Express puro — sin NestJS ni decoradores
- [x] OpenAPI documenta los 4 endpoints
- [x] `registerAgencyTemplatesRoutes` registrado en `routes.ts` después de `registerN8nConnectionRoutes`

Closes #270
Refs: #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four REST API endpoints for agency template retrieval: fetch complete agency information with departments and agents, list departments, retrieve agents by department ID, and get individual agent details by agent ID.
  * Includes error handling with appropriate responses for missing resources.
  * Full API documentation provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->