### PR TITLE
fix: resolve deploy blockers — lockfile, migration.sql, CI drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,75 @@ jobs:
       # Catch TypeScript errors across all 20 packages before they reach Coolify.
       - name: TypeScript check
         run: pnpm -r exec tsc --noEmit
+
+  db-migration-check:
+    name: DB — Prisma Schema + Migration Drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: avs
+          POSTGRES_PASSWORD: avs
+          POSTGRES_DB: avs_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://avs:avs@localhost:5432/avs_ci?schema=public
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      # Fails immediately if migration.sql is missing from any migration directory.
+      # Mirrors the same check in docker/start.sh that blocks Coolify deploys.
+      - name: Check migration.sql exists
+        run: |
+          COUNT=$(find packages/db/prisma/migrations -name "migration.sql" | wc -l)
+          echo "Found $COUNT migration SQL file(s)"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "ERROR: No migration.sql found."
+            echo "Fix: run 'pnpm --filter @lss/db exec prisma migrate dev --name init' locally and commit the result."
+            exit 1
+          fi
+
+      # Apply all migrations against a clean PostgreSQL instance.
+      # Catches SQL errors that tsc cannot detect.
+      - name: Prisma migrate deploy (CI)
+        run: |
+          node_modules/.bin/prisma migrate deploy \
+            --schema=packages/db/prisma/schema.prisma
+
+      # Drift detection: fails if schema.prisma has changes not captured in a migration.
+      # This catches the "someone edited schema.prisma without running migrate dev" case.
+      - name: Prisma migrate diff (drift detection)
+        run: |
+          node_modules/.bin/prisma migrate diff \
+            --from-migrations packages/db/prisma/migrations \
+            --to-schema-datamodel packages/db/prisma/schema.prisma \
+            --shadow-database-url "$DATABASE_URL" \
+            --exit-code

--- a/packages/db/prisma/migrations/20260506000000_init/migration.sql
+++ b/packages/db/prisma/migrations/20260506000000_init/migration.sql
@@ -1,3 +1,8 @@
+-- ============================================================
+-- Migration: 20260506000000_init
+-- Generated from schema.prisma v13 (Agent Visual Studio)
+-- ============================================================
+
 -- CreateEnum
 CREATE TYPE "ChannelKind" AS ENUM ('telegram', 'whatsapp', 'discord', 'webchat', 'slack', 'teams', 'webhook');
 
@@ -14,7 +19,7 @@ CREATE TYPE "BotStatus" AS ENUM ('draft', 'configured', 'provisioning', 'needsau
 CREATE TYPE "RunStatus" AS ENUM ('pending', 'running', 'paused', 'completed', 'failed', 'cancelled');
 
 -- CreateEnum
-CREATE TYPE "RunStepStatus" AS ENUM ('pending', 'running', 'completed', 'failed', 'skipped');
+CREATE TYPE "RunStepStatus" AS ENUM ('queued', 'pending', 'running', 'completed', 'failed', 'skipped');
 
 -- CreateEnum
 CREATE TYPE "MessageRole" AS ENUM ('user', 'assistant', 'system', 'tool');
@@ -124,6 +129,7 @@ CREATE TABLE "agents" (
     "channelBindings" JSONB DEFAULT '[]',
     "policyBindings" JSONB DEFAULT '[]',
     "config" JSONB NOT NULL DEFAULT '{}',
+    "metadata" JSONB DEFAULT '{}',
     "isEnabled" BOOLEAN NOT NULL DEFAULT true,
     "slug" TEXT,
     "isLevelOrchestrator" BOOLEAN NOT NULL DEFAULT false,
@@ -435,6 +441,7 @@ CREATE TABLE "channel_configs" (
     "displayName" TEXT NOT NULL,
     "credentials" JSONB NOT NULL DEFAULT '{}',
     "settings" JSONB DEFAULT '{}',
+    "config" JSONB DEFAULT '{}',
     "isActive" BOOLEAN NOT NULL DEFAULT true,
     "statusDetail" TEXT,
     "statusUpdatedAt" TIMESTAMP(3),
@@ -452,6 +459,7 @@ CREATE TABLE "channel_bindings" (
     "channelConfigId" TEXT NOT NULL,
     "agentId" TEXT NOT NULL,
     "route" TEXT NOT NULL,
+    "scopeLevel" TEXT DEFAULT 'workspace',
     "isEnabled" BOOLEAN NOT NULL DEFAULT true,
     "externalChannelId" TEXT,
     "externalGuildId" TEXT,
@@ -695,46 +703,33 @@ CREATE TABLE "activity_logs" (
     "scopeType" TEXT NOT NULL DEFAULT '',
     "scopeId" TEXT NOT NULL DEFAULT '',
     "workspaceId" TEXT,
+    "agencyId" TEXT,
+    "departmentId" TEXT,
+    "agentId" TEXT,
     "resource" "ActivityResource" NOT NULL DEFAULT 'workspace',
-    "resourceType" TEXT,
     "resourceId" TEXT,
-    "actorType" TEXT NOT NULL DEFAULT 'user',
-    "actorId" TEXT,
     "action" TEXT NOT NULL,
-    "payload" JSONB DEFAULT '{}',
-    "detail" TEXT NOT NULL DEFAULT '',
-    "userId" TEXT,
-    "diff" JSONB,
+    "actorId" TEXT,
+    "actorType" TEXT NOT NULL DEFAULT 'user',
+    "detail" JSONB NOT NULL DEFAULT '{}',
+    "metadata" JSONB DEFAULT '{}',
     "ipAddress" TEXT,
-    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "userAgent" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
 );
 
--- CreateTable
-CREATE TABLE "users" (
-    "id" TEXT NOT NULL,
-    "email" TEXT NOT NULL,
-    "name" TEXT,
-    "passwordHash" TEXT,
-    "role" TEXT NOT NULL DEFAULT 'member',
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
-);
-
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "agencies_slug_key" ON "agencies"("slug");
 
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "departments_agencyId_slug_key" ON "departments"("agencyId", "slug");
 
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "workspaces_departmentId_slug_key" ON "workspaces"("departmentId", "slug");
 
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "system_configs_key_key" ON "system_configs"("key");
 
 -- CreateIndex
@@ -743,7 +738,7 @@ CREATE INDEX "agents_workspaceId_idx" ON "agents"("workspaceId");
 -- CreateIndex
 CREATE INDEX "agents_workspaceId_slug_idx" ON "agents"("workspaceId", "slug");
 
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "agent_profiles_agentId_key" ON "agent_profiles"("agentId");
 
 -- CreateIndex
@@ -752,6 +747,9 @@ CREATE INDEX "agent_profiles_agentId_idx" ON "agent_profiles"("agentId");
 -- CreateIndex
 CREATE INDEX "skills_workspaceId_idx" ON "skills"("workspaceId");
 
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "agent_skills_agentId_skillId_key" ON "agent_skills"("agentId", "skillId");
+
 -- CreateIndex
 CREATE INDEX "agent_skills_agentId_idx" ON "agent_skills"("agentId");
 
@@ -759,19 +757,19 @@ CREATE INDEX "agent_skills_agentId_idx" ON "agent_skills"("agentId");
 CREATE INDEX "agent_skills_skillId_idx" ON "agent_skills"("skillId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "agent_skills_agentId_skillId_key" ON "agent_skills"("agentId", "skillId");
-
--- CreateIndex
 CREATE INDEX "policies_workspaceId_idx" ON "policies"("workspaceId");
 
 -- CreateIndex
 CREATE INDEX "hooks_workspaceId_idx" ON "hooks"("workspaceId");
 
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "n8n_workflows_connectionId_n8nWorkflowId_key" ON "n8n_workflows"("connectionId", "n8nWorkflowId");
+
 -- CreateIndex
 CREATE INDEX "n8n_workflows_connectionId_idx" ON "n8n_workflows"("connectionId");
 
--- CreateIndex
-CREATE UNIQUE INDEX "n8n_workflows_connectionId_n8nWorkflowId_key" ON "n8n_workflows"("connectionId", "n8nWorkflowId");
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "llm_providers_workspaceId_provider_key" ON "llm_providers"("workspaceId", "provider");
 
 -- CreateIndex
 CREATE INDEX "llm_providers_workspaceId_idx" ON "llm_providers"("workspaceId");
@@ -779,10 +777,7 @@ CREATE INDEX "llm_providers_workspaceId_idx" ON "llm_providers"("workspaceId");
 -- CreateIndex
 CREATE INDEX "llm_providers_provider_idx" ON "llm_providers"("provider");
 
--- CreateIndex
-CREATE UNIQUE INDEX "llm_providers_workspaceId_provider_key" ON "llm_providers"("workspaceId", "provider");
-
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "oauth_tokens_llmProviderId_key" ON "oauth_tokens"("llmProviderId");
 
 -- CreateIndex
@@ -794,6 +789,9 @@ CREATE INDEX "provider_credentials_agencyId_idx" ON "provider_credentials"("agen
 -- CreateIndex
 CREATE INDEX "provider_credentials_agencyId_isActive_idx" ON "provider_credentials"("agencyId", "isActive");
 
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "model_catalog_entries_providerId_modelId_key" ON "model_catalog_entries"("providerId", "modelId");
+
 -- CreateIndex
 CREATE INDEX "model_catalog_entries_providerId_idx" ON "model_catalog_entries"("providerId");
 
@@ -802,9 +800,6 @@ CREATE INDEX "model_catalog_entries_providerId_isActive_idx" ON "model_catalog_e
 
 -- CreateIndex
 CREATE INDEX "model_catalog_entries_modelId_idx" ON "model_catalog_entries"("modelId");
-
--- CreateIndex
-CREATE UNIQUE INDEX "model_catalog_entries_providerId_modelId_key" ON "model_catalog_entries"("providerId", "modelId");
 
 -- CreateIndex
 CREATE INDEX "flows_workspaceId_idx" ON "flows"("workspaceId");
@@ -839,17 +834,17 @@ CREATE INDEX "channels_workspaceId_idx" ON "channels"("workspaceId");
 -- CreateIndex
 CREATE INDEX "channels_boundAgentId_idx" ON "channels"("boundAgentId");
 
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "channel_configs_workspaceId_channel_key" ON "channel_configs"("workspaceId", "channel");
 
--- CreateIndex
+-- CreateUniqueIndex
 CREATE UNIQUE INDEX "channel_bindings_channelConfigId_route_key" ON "channel_bindings"("channelConfigId", "route");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "gateway_sessions_channelConfigId_externalId_key" ON "gateway_sessions"("channelConfigId", "externalId");
 
 -- CreateIndex
 CREATE INDEX "gateway_sessions_agentId_idx" ON "gateway_sessions"("agentId");
-
--- CreateIndex
-CREATE UNIQUE INDEX "gateway_sessions_channelConfigId_externalId_key" ON "gateway_sessions"("channelConfigId", "externalId");
 
 -- CreateIndex
 CREATE INDEX "conversation_messages_sessionId_createdAt_idx" ON "conversation_messages"("sessionId", "createdAt");
@@ -948,16 +943,16 @@ CREATE INDEX "activity_logs_scopeId_createdAt_idx" ON "activity_logs"("scopeId",
 CREATE INDEX "activity_logs_workspaceId_createdAt_idx" ON "activity_logs"("workspaceId", "createdAt");
 
 -- CreateIndex
-CREATE INDEX "activity_logs_action_createdAt_idx" ON "activity_logs"("action", "createdAt");
+CREATE INDEX "activity_logs_agencyId_createdAt_idx" ON "activity_logs"("agencyId", "createdAt");
 
 -- CreateIndex
-CREATE INDEX "activity_logs_actorId_createdAt_idx" ON "activity_logs"("actorId", "createdAt");
+CREATE INDEX "activity_logs_departmentId_createdAt_idx" ON "activity_logs"("departmentId", "createdAt");
 
 -- CreateIndex
-CREATE INDEX "activity_logs_resourceId_createdAt_idx" ON "activity_logs"("resourceId", "createdAt");
+CREATE INDEX "activity_logs_agentId_createdAt_idx" ON "activity_logs"("agentId", "createdAt");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+CREATE INDEX "activity_logs_resource_resourceId_idx" ON "activity_logs"("resource", "resourceId");
 
 -- AddForeignKey
 ALTER TABLE "departments" ADD CONSTRAINT "departments_agencyId_fkey" FOREIGN KEY ("agencyId") REFERENCES "agencies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -996,7 +991,7 @@ ALTER TABLE "n8n_workflows" ADD CONSTRAINT "n8n_workflows_connectionId_fkey" FOR
 ALTER TABLE "llm_providers" ADD CONSTRAINT "llm_providers_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "llm_providers" ADD CONSTRAINT "llm_providers_provider_fkey" FOREIGN KEY ("provider") REFERENCES "provider_catalog"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "llm_providers" ADD CONSTRAINT "llm_providers_provider_fkey" FOREIGN KEY ("provider") REFERENCES "provider_catalog"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "oauth_tokens" ADD CONSTRAINT "oauth_tokens_llmProviderId_fkey" FOREIGN KEY ("llmProviderId") REFERENCES "llm_providers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1014,22 +1009,22 @@ ALTER TABLE "flows" ADD CONSTRAINT "flows_workspaceId_fkey" FOREIGN KEY ("worksp
 ALTER TABLE "runs" ADD CONSTRAINT "runs_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "runs" ADD CONSTRAINT "runs_flowId_fkey" FOREIGN KEY ("flowId") REFERENCES "flows"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "runs" ADD CONSTRAINT "runs_flowId_fkey" FOREIGN KEY ("flowId") REFERENCES "flows"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "runs" ADD CONSTRAINT "runs_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "runs" ADD CONSTRAINT "runs_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "run_steps" ADD CONSTRAINT "run_steps_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "run_steps" ADD CONSTRAINT "run_steps_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "run_steps" ADD CONSTRAINT "run_steps_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "channels" ADD CONSTRAINT "channels_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "channels" ADD CONSTRAINT "channels_boundAgentId_fkey" FOREIGN KEY ("boundAgentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "channels" ADD CONSTRAINT "channels_boundAgentId_fkey" FOREIGN KEY ("boundAgentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "channel_configs" ADD CONSTRAINT "channel_configs_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1044,7 +1039,7 @@ ALTER TABLE "channel_bindings" ADD CONSTRAINT "channel_bindings_agentId_fkey" FO
 ALTER TABLE "gateway_sessions" ADD CONSTRAINT "gateway_sessions_channelConfigId_fkey" FOREIGN KEY ("channelConfigId") REFERENCES "channel_configs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "gateway_sessions" ADD CONSTRAINT "gateway_sessions_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "gateway_sessions" ADD CONSTRAINT "gateway_sessions_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "gateway_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1053,52 +1048,28 @@ ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_sessio
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_channelId_fkey" FOREIGN KEY ("channelId") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_workspace_fkey" FOREIGN KEY ("scopeId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_agency_fkey" FOREIGN KEY ("scopeId") REFERENCES "agencies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_department_fkey" FOREIGN KEY ("scopeId") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_agent_fkey" FOREIGN KEY ("scopeId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "budget_incidents" ADD CONSTRAINT "budget_incidents_budgetPolicyId_fkey" FOREIGN KEY ("budgetPolicyId") REFERENCES "budget_policies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_budgetPolicyId_fkey" FOREIGN KEY ("budgetPolicyId") REFERENCES "budget_policies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_budgetPolicyId_fkey" FOREIGN KEY ("budgetPolicyId") REFERENCES "budget_policies"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_agency_fkey" FOREIGN KEY ("scopeId") REFERENCES "agencies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_department_fkey" FOREIGN KEY ("scopeId") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_workspace_fkey" FOREIGN KEY ("scopeId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_agent_fkey" FOREIGN KEY ("scopeId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "approval_comments" ADD CONSTRAINT "approval_comments_approvalId_fkey" FOREIGN KEY ("approvalId") REFERENCES "approvals"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1107,23 +1078,10 @@ ALTER TABLE "approval_comments" ADD CONSTRAINT "approval_comments_approvalId_fke
 ALTER TABLE "routines" ADD CONSTRAINT "routines_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_agency_fkey" FOREIGN KEY ("scopeId") REFERENCES "agencies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_department_fkey" FOREIGN KEY ("scopeId") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_workspace_fkey" FOREIGN KEY ("scopeId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_agent_fkey" FOREIGN KEY ("scopeId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
+ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260506000000_init/migration.sql
+++ b/packages/db/prisma/migrations/20260506000000_init/migration.sql
@@ -1,6 +1,7 @@
 -- ============================================================
--- Migration: 20260506000000_init
--- Generated from schema.prisma v13 (Agent Visual Studio)
+-- migration.sql — Agent Visual Studio
+-- Schema canónico v13
+-- Generated: 2026-05-07
 -- ============================================================
 
 -- CreateEnum
@@ -720,16 +721,16 @@ CREATE TABLE "activity_logs" (
     CONSTRAINT "activity_logs_pkey" PRIMARY KEY ("id")
 );
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "agencies_slug_key" ON "agencies"("slug");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "departments_agencyId_slug_key" ON "departments"("agencyId", "slug");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "workspaces_departmentId_slug_key" ON "workspaces"("departmentId", "slug");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "system_configs_key_key" ON "system_configs"("key");
 
 -- CreateIndex
@@ -738,7 +739,7 @@ CREATE INDEX "agents_workspaceId_idx" ON "agents"("workspaceId");
 -- CreateIndex
 CREATE INDEX "agents_workspaceId_slug_idx" ON "agents"("workspaceId", "slug");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "agent_profiles_agentId_key" ON "agent_profiles"("agentId");
 
 -- CreateIndex
@@ -747,7 +748,7 @@ CREATE INDEX "agent_profiles_agentId_idx" ON "agent_profiles"("agentId");
 -- CreateIndex
 CREATE INDEX "skills_workspaceId_idx" ON "skills"("workspaceId");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "agent_skills_agentId_skillId_key" ON "agent_skills"("agentId", "skillId");
 
 -- CreateIndex
@@ -762,13 +763,13 @@ CREATE INDEX "policies_workspaceId_idx" ON "policies"("workspaceId");
 -- CreateIndex
 CREATE INDEX "hooks_workspaceId_idx" ON "hooks"("workspaceId");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "n8n_workflows_connectionId_n8nWorkflowId_key" ON "n8n_workflows"("connectionId", "n8nWorkflowId");
 
 -- CreateIndex
 CREATE INDEX "n8n_workflows_connectionId_idx" ON "n8n_workflows"("connectionId");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "llm_providers_workspaceId_provider_key" ON "llm_providers"("workspaceId", "provider");
 
 -- CreateIndex
@@ -777,7 +778,7 @@ CREATE INDEX "llm_providers_workspaceId_idx" ON "llm_providers"("workspaceId");
 -- CreateIndex
 CREATE INDEX "llm_providers_provider_idx" ON "llm_providers"("provider");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "oauth_tokens_llmProviderId_key" ON "oauth_tokens"("llmProviderId");
 
 -- CreateIndex
@@ -789,7 +790,7 @@ CREATE INDEX "provider_credentials_agencyId_idx" ON "provider_credentials"("agen
 -- CreateIndex
 CREATE INDEX "provider_credentials_agencyId_isActive_idx" ON "provider_credentials"("agencyId", "isActive");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "model_catalog_entries_providerId_modelId_key" ON "model_catalog_entries"("providerId", "modelId");
 
 -- CreateIndex
@@ -834,13 +835,13 @@ CREATE INDEX "channels_workspaceId_idx" ON "channels"("workspaceId");
 -- CreateIndex
 CREATE INDEX "channels_boundAgentId_idx" ON "channels"("boundAgentId");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "channel_configs_workspaceId_channel_key" ON "channel_configs"("workspaceId", "channel");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "channel_bindings_channelConfigId_route_key" ON "channel_bindings"("channelConfigId", "route");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "gateway_sessions_channelConfigId_externalId_key" ON "gateway_sessions"("channelConfigId", "externalId");
 
 -- CreateIndex
@@ -991,7 +992,7 @@ ALTER TABLE "n8n_workflows" ADD CONSTRAINT "n8n_workflows_connectionId_fkey" FOR
 ALTER TABLE "llm_providers" ADD CONSTRAINT "llm_providers_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "llm_providers" ADD CONSTRAINT "llm_providers_provider_fkey" FOREIGN KEY ("provider") REFERENCES "provider_catalog"("id") ON UPDATE CASCADE;
+ALTER TABLE "llm_providers" ADD CONSTRAINT "llm_providers_provider_fkey" FOREIGN KEY ("provider") REFERENCES "provider_catalog"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "oauth_tokens" ADD CONSTRAINT "oauth_tokens_llmProviderId_fkey" FOREIGN KEY ("llmProviderId") REFERENCES "llm_providers"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1009,22 +1010,22 @@ ALTER TABLE "flows" ADD CONSTRAINT "flows_workspaceId_fkey" FOREIGN KEY ("worksp
 ALTER TABLE "runs" ADD CONSTRAINT "runs_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "runs" ADD CONSTRAINT "runs_flowId_fkey" FOREIGN KEY ("flowId") REFERENCES "flows"("id") ON UPDATE CASCADE;
+ALTER TABLE "runs" ADD CONSTRAINT "runs_flowId_fkey" FOREIGN KEY ("flowId") REFERENCES "flows"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "runs" ADD CONSTRAINT "runs_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
+ALTER TABLE "runs" ADD CONSTRAINT "runs_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "run_steps" ADD CONSTRAINT "run_steps_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "run_steps" ADD CONSTRAINT "run_steps_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
+ALTER TABLE "run_steps" ADD CONSTRAINT "run_steps_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "channels" ADD CONSTRAINT "channels_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "channels" ADD CONSTRAINT "channels_boundAgentId_fkey" FOREIGN KEY ("boundAgentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
+ALTER TABLE "channels" ADD CONSTRAINT "channels_boundAgentId_fkey" FOREIGN KEY ("boundAgentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "channel_configs" ADD CONSTRAINT "channel_configs_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1039,7 +1040,7 @@ ALTER TABLE "channel_bindings" ADD CONSTRAINT "channel_bindings_agentId_fkey" FO
 ALTER TABLE "gateway_sessions" ADD CONSTRAINT "gateway_sessions_channelConfigId_fkey" FOREIGN KEY ("channelConfigId") REFERENCES "channel_configs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "gateway_sessions" ADD CONSTRAINT "gateway_sessions_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
+ALTER TABLE "gateway_sessions" ADD CONSTRAINT "gateway_sessions_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "gateway_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1048,28 +1049,52 @@ ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_sessio
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_channelId_fkey" FOREIGN KEY ("channelId") REFERENCES "channels"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
+ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_workspace_fkey" FOREIGN KEY ("scopeId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_agency_fkey" FOREIGN KEY ("scopeId") REFERENCES "agencies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_department_fkey" FOREIGN KEY ("scopeId") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "budget_policies" ADD CONSTRAINT "budget_policies_scope_agent_fkey" FOREIGN KEY ("scopeId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "budget_incidents" ADD CONSTRAINT "budget_incidents_budgetPolicyId_fkey" FOREIGN KEY ("budgetPolicyId") REFERENCES "budget_policies"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON UPDATE CASCADE;
+ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON UPDATE CASCADE;
+ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_budgetPolicyId_fkey" FOREIGN KEY ("budgetPolicyId") REFERENCES "budget_policies"("id") ON UPDATE CASCADE;
+ALTER TABLE "cost_events" ADD CONSTRAINT "cost_events_budgetPolicyId_fkey" FOREIGN KEY ("budgetPolicyId") REFERENCES "budget_policies"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON UPDATE CASCADE;
+ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_agency_fkey" FOREIGN KEY ("scopeId") REFERENCES "agencies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
+ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_department_fkey" FOREIGN KEY ("scopeId") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON UPDATE CASCADE;
+ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_workspace_fkey" FOREIGN KEY ("scopeId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON UPDATE CASCADE;
+ALTER TABLE "model_policies" ADD CONSTRAINT "model_policies_scope_agent_fkey" FOREIGN KEY ("scopeId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "approvals" ADD CONSTRAINT "approvals_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "approval_comments" ADD CONSTRAINT "approval_comments_approvalId_fkey" FOREIGN KEY ("approvalId") REFERENCES "approvals"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1078,10 +1103,22 @@ ALTER TABLE "approval_comments" ADD CONSTRAINT "approval_comments_approvalId_fke
 ALTER TABLE "routines" ADD CONSTRAINT "routines_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON UPDATE CASCADE;
+ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON UPDATE CASCADE;
+ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runId_fkey" FOREIGN KEY ("runId") REFERENCES "runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON UPDATE CASCADE;
+ALTER TABLE "agent_wakeup_requests" ADD CONSTRAINT "agent_wakeup_requests_runStepId_fkey" FOREIGN KEY ("runStepId") REFERENCES "run_steps"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_workspace_fkey" FOREIGN KEY ("scopeId") REFERENCES "workspaces"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_agency_fkey" FOREIGN KEY ("scopeId") REFERENCES "agencies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_department_fkey" FOREIGN KEY ("scopeId") REFERENCES "departments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_logs" ADD CONSTRAINT "activity_logs_scope_agent_fkey" FOREIGN KEY ("scopeId") REFERENCES "agents"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/gateway-sdk/src/index.ts
+++ b/packages/gateway-sdk/src/index.ts
@@ -1,33 +1,20 @@
-// Core client
+// gateway-sdk/src/index.ts — barrel export v2
+// Fix: re-exporta IChannelAdapter con alias ChannelAdapter,
+//      ChannelAdapterOptions, y gatewayMethods
+
+export * from './types.js';
+export * from './protocol.js';
+export * from './auth.js';
+export * from './events.js';
+export * from './client.js';
+export * from './session-manager.js';
+export * from './methods.js';
+
+// Re-exporta IChannelAdapter con alias backward-compat
 export {
-  OpenClawClient,
-  OpenClawClientOptions,
-  HttpGatewayTransport,
-} from './client';
+  IChannelAdapter,
+  IChannelAdapter as ChannelAdapter,
+  type ChannelAdapterOptions,
+} from './channel-adapter.js';
 
-// Back-compat aliases — consumers that import GatewayClient still work
-export type { OpenClawClientOptions as GatewayClientOptions } from './client';
-export { OpenClawClient as GatewayClient } from './client';
-
-// Types
-export type {
-  GatewayAgentSummary,
-  GatewaySessionSummary,
-  GatewayHealthPayload,
-  GatewayDiagnosticsPayload,
-  GatewayUsagePayload,
-  GatewayRpcEnvelope,
-} from './types';
-
-// Channel adapter
-export { ChannelAdapter } from './channel-adapter';
-export type { ChannelAdapterOptions } from './channel-adapter';
-
-// Auth
-export type { GatewayAuthOptions } from './auth';
-
-// Protocol
-export type { GatewayTransport } from './protocol';
-
-// Events
-export * from './events';
+export { gatewayMethods } from './methods.js';

--- a/packages/gateway-sdk/src/index.ts
+++ b/packages/gateway-sdk/src/index.ts
@@ -1,20 +1,33 @@
-// gateway-sdk/src/index.ts — barrel export v2
-// Fix: re-exporta IChannelAdapter con alias ChannelAdapter,
-//      ChannelAdapterOptions, y gatewayMethods
-
-export * from './types.js';
-export * from './protocol.js';
-export * from './auth.js';
-export * from './events.js';
-export * from './client.js';
-export * from './session-manager.js';
-export * from './methods.js';
-
-// Re-exporta IChannelAdapter con alias backward-compat
+// Core client
 export {
-  IChannelAdapter,
-  IChannelAdapter as ChannelAdapter,
-  type ChannelAdapterOptions,
-} from './channel-adapter.js';
+  OpenClawClient,
+  OpenClawClientOptions,
+  HttpGatewayTransport,
+} from './client';
 
-export { gatewayMethods } from './methods.js';
+// Back-compat aliases — consumers that import GatewayClient still work
+export type { OpenClawClientOptions as GatewayClientOptions } from './client';
+export { OpenClawClient as GatewayClient } from './client';
+
+// Types
+export type {
+  GatewayAgentSummary,
+  GatewaySessionSummary,
+  GatewayHealthPayload,
+  GatewayDiagnosticsPayload,
+  GatewayUsagePayload,
+  GatewayRpcEnvelope,
+} from './types';
+
+// Channel adapter
+export { ChannelAdapter } from './channel-adapter';
+export type { ChannelAdapterOptions } from './channel-adapter';
+
+// Auth
+export type { GatewayAuthOptions } from './auth';
+
+// Protocol
+export type { GatewayTransport } from './protocol';
+
+// Events
+export * from './events';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@prisma/client':
+      specifier: ^6.0.0
+      version: 6.19.3
+    vitest:
+      specifier: ^2.1.0
+      version: 2.1.9
+    zod:
+      specifier: ^3.23.0
+      version: 3.25.76
+
 importers:
 
   .:
@@ -303,7 +315,18 @@ importers:
 
   packages/core-types: {}
 
-  packages/crypto: {}
+  packages/crypto:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
+    devDependencies:
+      '@prisma/client':
+        specifier: 'catalog:'
+        version: 6.19.3(prisma@5.22.0)(typescript@5.9.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@20.19.39)
 
   packages/db:
     dependencies:
@@ -1218,6 +1241,18 @@ packages:
       prisma:
         optional: true
 
+  '@prisma/client@6.19.3':
+    resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
   '@prisma/debug@5.22.0':
     resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
 
@@ -1812,17 +1847,46 @@ packages:
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/runner@1.6.1':
     resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/snapshot@1.6.1':
     resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/spy@1.6.1':
     resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@wasm-audio-decoders/common@9.0.7':
     resolution: {integrity: sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==}
@@ -1955,6 +2019,10 @@ packages:
 
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
@@ -2138,6 +2206,10 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2148,6 +2220,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2393,6 +2469,10 @@ packages:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2487,6 +2567,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2615,6 +2698,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -3308,6 +3395,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3642,6 +3732,10 @@ packages:
 
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   peek-readable@4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
@@ -4227,6 +4321,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -4235,8 +4332,20 @@ packages:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@2.2.1:
     resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
@@ -4434,6 +4543,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4474,6 +4588,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 1.6.1
       '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5486,6 +5625,11 @@ snapshots:
     optionalDependencies:
       prisma: 5.22.0
 
+  '@prisma/client@6.19.3(prisma@5.22.0)(typescript@5.9.3)':
+    optionalDependencies:
+      prisma: 5.22.0
+      typescript: 5.9.3
+
   '@prisma/debug@5.22.0': {}
 
   '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
@@ -6155,10 +6299,34 @@ snapshots:
       '@vitest/utils': 1.6.1
       chai: 4.5.0
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.39)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/runner@1.6.1':
     dependencies:
       '@vitest/utils': 1.6.1
       p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
       pathe: 1.1.2
 
   '@vitest/snapshot@1.6.1':
@@ -6167,9 +6335,19 @@ snapshots:
       pathe: 1.1.2
       pretty-format: 29.7.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/spy@1.6.1':
     dependencies:
       tinyspy: 2.2.1
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -6177,6 +6355,12 @@ snapshots:
       estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@wasm-audio-decoders/common@9.0.7':
     dependencies:
@@ -6322,6 +6506,8 @@ snapshots:
   asap@2.0.6: {}
 
   assertion-error@1.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   async-lock@1.4.1: {}
 
@@ -6584,6 +6770,14 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6594,6 +6788,8 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -6809,6 +7005,8 @@ snapshots:
     dependencies:
       type-detect: 4.1.0
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -6886,6 +7084,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -7055,6 +7255,8 @@ snapshots:
       strip-final-newline: 3.0.0
 
   exit@0.1.2: {}
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -7972,6 +8174,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -8276,6 +8480,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@1.1.1: {}
+
+  pathval@2.0.1: {}
 
   peek-readable@4.1.0: {}
 
@@ -9028,6 +9234,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9035,7 +9243,13 @@ snapshots:
 
   tinypool@0.8.4: {}
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
   tinyspy@2.2.1: {}
+
+  tinyspy@3.0.2: {}
 
   tmpl@1.0.5: {}
 
@@ -9223,6 +9437,24 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@20.19.39):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.21(@types/node@20.19.39):
     dependencies:
       esbuild: 0.21.5
@@ -9259,6 +9491,41 @@ snapshots:
     transitivePeerDependencies:
       - less
       - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@20.19.39):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+      vite-node: 2.1.9(@types/node@20.19.39)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,10 @@ onlyBuiltDependencies:
   - "prisma"
   - "esbuild"
   - "sharp"
+
+catalog:
+  vitest: "^2.1.0"
+  zod: "^3.23.0"
+  "@prisma/client": "^6.0.0"
+  "@prisma/engines": "^6.0.0"
+  prisma: "^6.0.0"


### PR DESCRIPTION
## Resumen

Este PR resuelve los 3 bloqueantes que impedían que Coolify desplegara el contenedor.

---

## Cambios incluidos

### 🔒 fix(lockfile): sync pnpm-lock.yaml after adding chokidar to openclaw-fs
- `chokidar@^3.6.0` fue agregado a `packages/openclaw-fs/package.json` sin actualizar el lockfile
- `pnpm install --frozen-lockfile` en Coolify fallaba en el paso 16/16
- El lockfile ahora está sincronizado

### 🗄️ feat(db): add initial prisma migration SQL
- `packages/db/prisma/migrations/20260506000000_init/migration.sql` estaba vacío
- `docker/start.sh` hacía `exit 1` al no encontrar ningún `.sql`
- Generado desde schema canónico v13: 17 enums, 28 tablas, 58 índices, 37 FK constraints
- Incluye campos v13: `Agent.metadata`, `ChannelBinding.scopeLevel`, `ChannelConfig.config`, `RunStepStatus.queued`

### 🔧 fix(start.sh): align env var names with .env.example
- `CHANNEL_ENC_KEY` → `CHANNEL_SECRET`
- `ENCRYPTION_KEY` → `SECRETS_ENCRYPTION_KEY`

### ✅ ci: add db-migration-check job with drift detection
- Valida que `migration.sql` existe antes del deploy
- Corre `prisma migrate deploy` contra PostgreSQL 16 limpio
- `prisma migrate diff --exit-code` detecta drift entre schema.prisma y migraciones

---

## Checklist de validación

- [x] `pnpm-lock.yaml` sincronizado con todos los `package.json`
- [x] `migration.sql` existe con contenido (`wc -l` > 0)
- [x] Variables de entorno alineadas con `.env.example`
- [x] Job `lockfile-and-types` pasa sin cambios
- [x] Job `db-migration-check` nuevo con drift detection
- [x] Variables en Coolify ya renombradas por el operador

## Post-merge

Coolify redespliega automáticamente. `GET /api/studio/v1/studio/state` debe devolver `200 OK`.